### PR TITLE
Allow a static build on Windows/MSVC, use MSYS2 as build infrastrucure

### DIFF
--- a/recipe/0001-x86-MSVC-does-not-support-Complex-type.patch
+++ b/recipe/0001-x86-MSVC-does-not-support-Complex-type.patch
@@ -1,0 +1,26 @@
+From 96c216173b3b03f42b29b4ec1b02037be4061d9a Mon Sep 17 00:00:00 2001
+From: Nobuyoshi Nakada <nobu@ruby-lang.org>
+Date: Mon, 22 Dec 2014 17:14:40 +0900
+Subject: [PATCH 1/3] x86: MSVC does not support Complex type
+
+---
+ src/x86/ffitarget.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/x86/ffitarget.h b/src/x86/ffitarget.h
+index a236677..ff0f718 100644
+--- a/src/x86/ffitarget.h
++++ b/src/x86/ffitarget.h
+@@ -50,7 +50,9 @@
+ #endif
+ 
+ #define FFI_TARGET_SPECIFIC_STACK_SPACE_ALLOCATION
++#ifndef _MSC_VER
+ #define FFI_TARGET_HAS_COMPLEX_TYPE
++#endif
+ 
+ /* ---- Generic type definitions ----------------------------------------- */
+ 
+-- 
+2.8.2
+

--- a/recipe/0002-Don-t-define-FFI_COMPLEX_TYPEDEF-ifndef-FFI_TARGET_H.patch
+++ b/recipe/0002-Don-t-define-FFI_COMPLEX_TYPEDEF-ifndef-FFI_TARGET_H.patch
@@ -1,0 +1,33 @@
+From 77a2d361b38c957700a79b79dd4002eb9b638877 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Fri, 3 Jun 2016 14:26:07 +0100
+Subject: [PATCH 2/3] Don't define FFI_COMPLEX_TYPEDEF ifndef
+ FFI_TARGET_HAS_COMPLEX_TYPE
+
+---
+ src/types.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/types.c b/src/types.c
+index 7e80aec..e4b024c 100644
+--- a/src/types.c
++++ b/src/types.c
+@@ -44,6 +44,7 @@ maybe_const ffi_type ffi_type_##name = {	\
+   id, NULL					\
+ }
+ 
++#ifdef FFI_TARGET_HAS_COMPLEX_TYPE
+ #define FFI_COMPLEX_TYPEDEF(name, type, maybe_const)	\
+ static ffi_type *ffi_elements_complex_##name [2] = {	\
+ 	(ffi_type *)(&ffi_type_##name), NULL		\
+@@ -58,6 +59,7 @@ maybe_const ffi_type ffi_type_complex_##name = {	\
+   FFI_TYPE_COMPLEX,					\
+   (ffi_type **)ffi_elements_complex_##name		\
+ }
++#endif
+ 
+ /* Size and alignment are fake here. They must not be 0. */
+ const ffi_type ffi_type_void = {
+-- 
+2.8.2
+

--- a/recipe/0003-Win64-Remove-two-SHORT-annotations.patch
+++ b/recipe/0003-Win64-Remove-two-SHORT-annotations.patch
@@ -1,0 +1,34 @@
+From 71595bbd3b14d5936004035f0814726946b0c998 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Mon, 6 Jun 2016 17:08:18 +0100
+Subject: [PATCH 3/3] Win64: Remove two SHORT annotations
+
+---
+ src/x86/win64.S | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/x86/win64.S b/src/x86/win64.S
+index 687f97c..c47fbfc 100644
+--- a/src/x86/win64.S
++++ b/src/x86/win64.S
+@@ -170,7 +170,7 @@ ret_uint16$:
+ 	mov	rcx, QWORD PTR RVALUE[rbp]
+ 	movzx   rax, ax
+ 	mov	QWORD PTR [rcx], rax
+-	jmp	SHORT ret_void$
++	jmp	ret_void$
+ 
+ ret_sint16$:
+  	cmp	DWORD PTR CIF_FLAGS[rbp], FFI_TYPE_SINT16
+@@ -179,7 +179,7 @@ ret_sint16$:
+ 	mov	rcx, QWORD PTR RVALUE[rbp]
+ 	movsx   rax, ax
+ 	mov	QWORD PTR [rcx], rax
+-	jmp	SHORT ret_void$
++	jmp	ret_void$
+ 
+ ret_uint32$:
+  	cmp	DWORD PTR CIF_FLAGS[rbp], FFI_TYPE_UINT32
+-- 
+2.8.2
+

--- a/recipe/0004-Update-to-libtool-2.4.6.34.patch
+++ b/recipe/0004-Update-to-libtool-2.4.6.34.patch
@@ -1,0 +1,23378 @@
+From 65443918443673d57a82a13e52c386dbc9aa4c3d Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Tue, 7 Jun 2016 19:18:24 +0100
+Subject: [PATCH 4/4] Update to libtool 2.4.6.34
+
+---
+ Makefile.in           |    1 +
+ aclocal.m4            |  250 ++-
+ compile               |    4 +-
+ config.guess          |    3 +
+ config.sub            |    2 +-
+ configure             | 3237 +++++++++++++++------------
+ fficonfig.h.in        |    3 +-
+ include/Makefile.in   |    1 +
+ ltmain.sh             | 5840 ++++++++++++++++++++++++++++++++-----------------
+ m4/libtool.m4         | 2628 ++++++++++++----------
+ m4/ltoptions.m4       |  127 +-
+ m4/ltsugar.m4         |    7 +-
+ m4/ltversion.m4       |   12 +-
+ m4/lt~obsolete.m4     |    7 +-
+ man/Makefile.in       |    1 +
+ testsuite/Makefile.in |    1 +
+ 16 files changed, 7476 insertions(+), 4648 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index dcc5f47..a473914 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -516,6 +516,7 @@ LIBTOOL = @LIBTOOL@
+ LIPO = @LIPO@
+ LN_S = @LN_S@
+ LTLIBOBJS = @LTLIBOBJS@
++LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
+ MAINT = @MAINT@
+ MAKEINFO = @MAKEINFO@
+ MANIFEST_TOOL = @MANIFEST_TOOL@
+diff --git a/aclocal.m4 b/aclocal.m4
+index 6292fba..ff5b92e 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -22,14 +22,14 @@ To do so, use the procedure documented by the package, typically 'autoreconf'.])
+ 
+ # ltdl.m4 - Configure ltdl for the target system. -*-Autoconf-*-
+ #
+-#   Copyright (C) 1999-2006, 2007, 2008, 2011 Free Software Foundation, Inc.
++#   Copyright (C) 1999-2008, 2011-2015 Free Software Foundation, Inc.
+ #   Written by Thomas Tanner, 1999
+ #
+ # This file is free software; the Free Software Foundation gives
+ # unlimited permission to copy and/or distribute it, with or without
+ # modifications, as long as this notice is preserved.
+ 
+-# serial 18 LTDL_INIT
++# serial 20 LTDL_INIT
+ 
+ # LT_CONFIG_LTDL_DIR(DIRECTORY, [LTDL-MODE])
+ # ------------------------------------------
+@@ -46,14 +46,14 @@ m4_defun([_LT_CONFIG_LTDL_DIR],
+ [dnl remove trailing slashes
+ m4_pushdef([_ARG_DIR], m4_bpatsubst([$1], [/*$]))
+ m4_case(_LTDL_DIR,
+-	[], [dnl only set lt_ltdl_dir if _ARG_DIR is not simply `.'
++	[], [dnl only set lt_ltdl_dir if _ARG_DIR is not simply '.'
+ 	     m4_if(_ARG_DIR, [.],
+ 	             [],
+ 		 [m4_define([_LTDL_DIR], _ARG_DIR)
+ 	          _LT_SHELL_INIT([lt_ltdl_dir=']_ARG_DIR['])])],
+     [m4_if(_ARG_DIR, _LTDL_DIR,
+ 	    [],
+-	[m4_fatal([multiple libltdl directories: `]_LTDL_DIR[', `]_ARG_DIR['])])])
++	[m4_fatal([multiple libltdl directories: ']_LTDL_DIR[', ']_ARG_DIR['])])])
+ m4_popdef([_ARG_DIR])
+ ])# _LT_CONFIG_LTDL_DIR
+ 
+@@ -63,16 +63,16 @@ m4_define([_LTDL_DIR], [])
+ 
+ # _LT_BUILD_PREFIX
+ # ----------------
+-# If Autoconf is new enough, expand to `${top_build_prefix}', otherwise
+-# to `${top_builddir}/'.
++# If Autoconf is new enough, expand to '$(top_build_prefix)', otherwise
++# to '$(top_builddir)/'.
+ m4_define([_LT_BUILD_PREFIX],
+ [m4_ifdef([AC_AUTOCONF_VERSION],
+    [m4_if(m4_version_compare(m4_defn([AC_AUTOCONF_VERSION]), [2.62]),
+ 	  [-1], [m4_ifdef([_AC_HAVE_TOP_BUILD_PREFIX],
+-			  [${top_build_prefix}],
+-			  [${top_builddir}/])],
+-	  [${top_build_prefix}])],
+-   [${top_builddir}/])[]dnl
++			  [$(top_build_prefix)],
++			  [$(top_builddir)/])],
++	  [$(top_build_prefix)])],
++   [$(top_builddir)/])[]dnl
+ ])
+ 
+ 
+@@ -82,8 +82,8 @@ m4_define([_LT_BUILD_PREFIX],
+ # LTDLINCL to the include flags for the libltdl header and adds
+ # --enable-ltdl-convenience to the configure arguments.  Note that
+ # AC_CONFIG_SUBDIRS is not called here.  LIBLTDL will be prefixed with
+-# '${top_build_prefix}' if available, otherwise with '${top_builddir}/',
+-# and LTDLINCL will be prefixed with '${top_srcdir}/' (note the single
++# '$(top_build_prefix)' if available, otherwise with '$(top_builddir)/',
++# and LTDLINCL will be prefixed with '$(top_srcdir)/' (note the single
+ # quotes!).  If your package is not flat and you're not using automake,
+ # define top_build_prefix, top_builddir, and top_srcdir appropriately
+ # in your Makefiles.
+@@ -119,14 +119,14 @@ m4_defun([_LTDL_CONVENIENCE],
+ esac
+ LIBLTDL='_LT_BUILD_PREFIX'"${lt_ltdl_dir+$lt_ltdl_dir/}libltdlc.la"
+ LTDLDEPS=$LIBLTDL
+-LTDLINCL='-I${top_srcdir}'"${lt_ltdl_dir+/$lt_ltdl_dir}"
++LTDLINCL='-I$(top_srcdir)'"${lt_ltdl_dir+/$lt_ltdl_dir}"
+ 
+ AC_SUBST([LIBLTDL])
+ AC_SUBST([LTDLDEPS])
+ AC_SUBST([LTDLINCL])
+ 
+ # For backwards non-gettext consistent compatibility...
+-INCLTDL="$LTDLINCL"
++INCLTDL=$LTDLINCL
+ AC_SUBST([INCLTDL])
+ ])# _LTDL_CONVENIENCE
+ 
+@@ -137,9 +137,9 @@ AC_SUBST([INCLTDL])
+ # and LTDLINCL to the include flags for the libltdl header and adds
+ # --enable-ltdl-install to the configure arguments.  Note that
+ # AC_CONFIG_SUBDIRS is not called from here.  If an installed libltdl
+-# is not found, LIBLTDL will be prefixed with '${top_build_prefix}' if
+-# available, otherwise with '${top_builddir}/', and LTDLINCL will be
+-# prefixed with '${top_srcdir}/' (note the single quotes!).  If your
++# is not found, LIBLTDL will be prefixed with '$(top_build_prefix)' if
++# available, otherwise with '$(top_builddir)/', and LTDLINCL will be
++# prefixed with '$(top_srcdir)/' (note the single quotes!).  If your
+ # package is not flat and you're not using automake, define top_build_prefix,
+ # top_builddir, and top_srcdir appropriately in your Makefiles.
+ # In the future, this macro may have to be called after LT_INIT.
+@@ -168,18 +168,18 @@ dnl AC_DEFUN([AC_LIBLTDL_INSTALLABLE], [])
+ # -----------------
+ # Code shared by LTDL_INSTALLABLE and LTDL_INIT([installable]).
+ m4_defun([_LTDL_INSTALLABLE],
+-[if test -f $prefix/lib/libltdl.la; then
+-  lt_save_LDFLAGS="$LDFLAGS"
++[if test -f "$prefix/lib/libltdl.la"; then
++  lt_save_LDFLAGS=$LDFLAGS
+   LDFLAGS="-L$prefix/lib $LDFLAGS"
+   AC_CHECK_LIB([ltdl], [lt_dlinit], [lt_lib_ltdl=yes])
+-  LDFLAGS="$lt_save_LDFLAGS"
+-  if test x"${lt_lib_ltdl-no}" = xyes; then
+-    if test x"$enable_ltdl_install" != xyes; then
++  LDFLAGS=$lt_save_LDFLAGS
++  if test yes = "${lt_lib_ltdl-no}"; then
++    if test yes != "$enable_ltdl_install"; then
+       # Don't overwrite $prefix/lib/libltdl.la without --enable-ltdl-install
+-      AC_MSG_WARN([not overwriting libltdl at $prefix, force with `--enable-ltdl-install'])
++      AC_MSG_WARN([not overwriting libltdl at $prefix, force with '--enable-ltdl-install'])
+       enable_ltdl_install=no
+     fi
+-  elif test x"$enable_ltdl_install" = xno; then
++  elif test no = "$enable_ltdl_install"; then
+     AC_MSG_WARN([libltdl not installed, but installation disabled])
+   fi
+ fi
+@@ -188,7 +188,7 @@ fi
+ # with --disable-ltdl-install, we will install the shipped libltdl.
+ case $enable_ltdl_install in
+   no) ac_configure_args="$ac_configure_args --enable-ltdl-install=no"
+-      LIBLTDL="-lltdl"
++      LIBLTDL=-lltdl
+       LTDLDEPS=
+       LTDLINCL=
+       ;;
+@@ -196,7 +196,7 @@ case $enable_ltdl_install in
+       ac_configure_args="$ac_configure_args --enable-ltdl-install"
+       LIBLTDL='_LT_BUILD_PREFIX'"${lt_ltdl_dir+$lt_ltdl_dir/}libltdl.la"
+       LTDLDEPS=$LIBLTDL
+-      LTDLINCL='-I${top_srcdir}'"${lt_ltdl_dir+/$lt_ltdl_dir}"
++      LTDLINCL='-I$(top_srcdir)'"${lt_ltdl_dir+/$lt_ltdl_dir}"
+       ;;
+ esac
+ 
+@@ -205,7 +205,7 @@ AC_SUBST([LTDLDEPS])
+ AC_SUBST([LTDLINCL])
+ 
+ # For backwards non-gettext consistent compatibility...
+-INCLTDL="$LTDLINCL"
++INCLTDL=$LTDLINCL
+ AC_SUBST([INCLTDL])
+ ])# LTDL_INSTALLABLE
+ 
+@@ -213,14 +213,14 @@ AC_SUBST([INCLTDL])
+ # _LTDL_MODE_DISPATCH
+ # -------------------
+ m4_define([_LTDL_MODE_DISPATCH],
+-[dnl If _LTDL_DIR is `.', then we are configuring libltdl itself:
++[dnl If _LTDL_DIR is '.', then we are configuring libltdl itself:
+ m4_if(_LTDL_DIR, [],
+ 	[],
+-    dnl if _LTDL_MODE was not set already, the default value is `subproject':
++    dnl if _LTDL_MODE was not set already, the default value is 'subproject':
+     [m4_case(m4_default(_LTDL_MODE, [subproject]),
+ 	  [subproject], [AC_CONFIG_SUBDIRS(_LTDL_DIR)
+-			  _LT_SHELL_INIT([lt_dlopen_dir="$lt_ltdl_dir"])],
+-	  [nonrecursive], [_LT_SHELL_INIT([lt_dlopen_dir="$lt_ltdl_dir"; lt_libobj_prefix="$lt_ltdl_dir/"])],
++			  _LT_SHELL_INIT([lt_dlopen_dir=$lt_ltdl_dir])],
++	  [nonrecursive], [_LT_SHELL_INIT([lt_dlopen_dir=$lt_ltdl_dir; lt_libobj_prefix=$lt_ltdl_dir/])],
+ 	  [recursive], [],
+ 	[m4_fatal([unknown libltdl mode: ]_LTDL_MODE)])])dnl
+ dnl Be careful not to expand twice:
+@@ -265,7 +265,7 @@ AC_ARG_WITH([included_ltdl],
+     [AS_HELP_STRING([--with-included-ltdl],
+                     [use the GNU ltdl sources included here])])
+ 
+-if test "x$with_included_ltdl" != xyes; then
++if test yes != "$with_included_ltdl"; then
+   # We are not being forced to use the included libltdl sources, so
+   # decide whether there is a useful installed version we can use.
+   AC_CHECK_HEADER([ltdl.h],
+@@ -293,7 +293,7 @@ AC_ARG_WITH([ltdl_include],
+ if test -n "$with_ltdl_include"; then
+   if test -f "$with_ltdl_include/ltdl.h"; then :
+   else
+-    AC_MSG_ERROR([invalid ltdl include directory: `$with_ltdl_include'])
++    AC_MSG_ERROR([invalid ltdl include directory: '$with_ltdl_include'])
+   fi
+ else
+   with_ltdl_include=no
+@@ -306,7 +306,7 @@ AC_ARG_WITH([ltdl_lib],
+ if test -n "$with_ltdl_lib"; then
+   if test -f "$with_ltdl_lib/libltdl.la"; then :
+   else
+-    AC_MSG_ERROR([invalid ltdl library directory: `$with_ltdl_lib'])
++    AC_MSG_ERROR([invalid ltdl library directory: '$with_ltdl_lib'])
+   fi
+ else
+   with_ltdl_lib=no
+@@ -329,15 +329,15 @@ case ,$with_included_ltdl,$with_ltdl_include,$with_ltdl_lib, in
+ 	LTDLINCL=
+ 	;;
+   ,no*,no,*)
+-	AC_MSG_ERROR([`--with-ltdl-include' and `--with-ltdl-lib' options must be used together])
++	AC_MSG_ERROR(['--with-ltdl-include' and '--with-ltdl-lib' options must be used together])
+ 	;;
+   *)	with_included_ltdl=no
+ 	LIBLTDL="-L$with_ltdl_lib -lltdl"
+ 	LTDLDEPS=
+-	LTDLINCL="-I$with_ltdl_include"
++	LTDLINCL=-I$with_ltdl_include
+ 	;;
+ esac
+-INCLTDL="$LTDLINCL"
++INCLTDL=$LTDLINCL
+ 
+ # Report our decision...
+ AC_MSG_CHECKING([where to find libltdl headers])
+@@ -395,7 +395,7 @@ AC_REQUIRE([LT_LIB_DLLOAD])dnl
+ AC_REQUIRE([LT_SYS_SYMBOL_USCORE])dnl
+ AC_REQUIRE([LT_FUNC_DLSYM_USCORE])dnl
+ AC_REQUIRE([LT_SYS_DLOPEN_DEPLIBS])dnl
+-AC_REQUIRE([gl_FUNC_ARGZ])dnl
++AC_REQUIRE([LT_FUNC_ARGZ])dnl
+ 
+ m4_require([_LT_CHECK_OBJDIR])dnl
+ m4_require([_LT_HEADER_DLFCN])dnl
+@@ -419,7 +419,7 @@ m4_pattern_allow([^LT_CONFIG_H$])dnl
+ m4_ifset([AH_HEADER],
+     [LT_CONFIG_H=AH_HEADER],
+     [m4_ifset([AC_LIST_HEADERS],
+-	    [LT_CONFIG_H=`echo "AC_LIST_HEADERS" | $SED 's,^[[      ]]*,,;s,[[ :]].*$,,'`],
++	    [LT_CONFIG_H=`echo "AC_LIST_HEADERS" | $SED 's|^[[      ]]*||;s|[[ :]].*$||'`],
+ 	[])])])
+ AC_SUBST([LT_CONFIG_H])
+ 
+@@ -449,14 +449,14 @@ m4_define([_LT_ENABLE_INSTALL],
+ [AC_ARG_ENABLE([ltdl-install],
+     [AS_HELP_STRING([--enable-ltdl-install], [install libltdl])])
+ 
+-case ,${enable_ltdl_install},${enable_ltdl_convenience} in
++case ,$enable_ltdl_install,$enable_ltdl_convenience in
+   *yes*) ;;
+   *) enable_ltdl_convenience=yes ;;
+ esac
+ 
+ m4_ifdef([AM_CONDITIONAL],
+-[AM_CONDITIONAL(INSTALL_LTDL, test x"${enable_ltdl_install-no}" != xno)
+- AM_CONDITIONAL(CONVENIENCE_LTDL, test x"${enable_ltdl_convenience-no}" != xno)])
++[AM_CONDITIONAL(INSTALL_LTDL, test no != "${enable_ltdl_install-no}")
++ AM_CONDITIONAL(CONVENIENCE_LTDL, test no != "${enable_ltdl_convenience-no}")])
+ ])# _LT_ENABLE_INSTALL
+ 
+ 
+@@ -474,7 +474,7 @@ AC_CACHE_CHECK([whether deplibs are loaded by dlopen],
+   case $host_os in
+   aix3*|aix4.1.*|aix4.2.*)
+     # Unknown whether this is true for these versions of AIX, but
+-    # we want this `case' here to explicitly catch those versions.
++    # we want this 'case' here to explicitly catch those versions.
+     lt_cv_sys_dlopen_deplibs=unknown
+     ;;
+   aix[[4-9]]*)
+@@ -487,6 +487,9 @@ AC_CACHE_CHECK([whether deplibs are loaded by dlopen],
+       ;;
+     esac
+     ;;
++  bitrig*)
++    lt_cv_sys_dlopen_deplibs=yes
++    ;;
+   darwin*)
+     # Assuming the user has installed a libdl from somewhere, this is true
+     # If you are looking for one http://www.opendarwin.org/projects/dlcompat
+@@ -524,7 +527,7 @@ AC_CACHE_CHECK([whether deplibs are loaded by dlopen],
+   osf[[1234]]*)
+     # dlopen did load deplibs (at least at 4.x), but until the 5.x series,
+     # it did *not* use an RPATH in a shared library to find objects the
+-    # library depends on, so we explicitly say `no'.
++    # library depends on, so we explicitly say 'no'.
+     lt_cv_sys_dlopen_deplibs=no
+     ;;
+   osf5.0|osf5.0a|osf5.1)
+@@ -533,14 +536,14 @@ AC_CACHE_CHECK([whether deplibs are loaded by dlopen],
+     # that the library depends on, but there's no easy way to know if that
+     # patch is installed.  Since this is the case, all we can really
+     # say is unknown -- it depends on the patch being installed.  If
+-    # it is, this changes to `yes'.  Without it, it would be `no'.
++    # it is, this changes to 'yes'.  Without it, it would be 'no'.
+     lt_cv_sys_dlopen_deplibs=unknown
+     ;;
+   osf*)
+     # the two cases above should catch all versions of osf <= 5.1.  Read
+     # the comments above for what we know about them.
+     # At > 5.1, deplibs are loaded *and* any RPATH in a shared library
+-    # is used to find them so we can finally say `yes'.
++    # is used to find them so we can finally say 'yes'.
+     lt_cv_sys_dlopen_deplibs=yes
+     ;;
+   qnx*)
+@@ -554,7 +557,7 @@ AC_CACHE_CHECK([whether deplibs are loaded by dlopen],
+     ;;
+   esac
+   ])
+-if test "$lt_cv_sys_dlopen_deplibs" != yes; then
++if test yes != "$lt_cv_sys_dlopen_deplibs"; then
+  AC_DEFINE([LTDL_DLOPEN_DEPLIBS], [1],
+     [Define if the OS needs help to load dependent libraries for dlopen().])
+ fi
+@@ -570,7 +573,7 @@ dnl AC_DEFUN([AC_LTDL_SYS_DLOPEN_DEPLIBS], [])
+ # -----------------
+ AC_DEFUN([LT_SYS_MODULE_EXT],
+ [m4_require([_LT_SYS_DYNAMIC_LINKER])dnl
+-AC_CACHE_CHECK([which extension is used for runtime loadable modules],
++AC_CACHE_CHECK([what extension is used for runtime loadable modules],
+   [libltdl_cv_shlibext],
+ [
+ module=yes
+@@ -588,6 +591,11 @@ if test "$libltdl_cv_shrext" != "$libltdl_cv_shlibext"; then
+   AC_DEFINE_UNQUOTED([LT_SHARED_EXT], ["$libltdl_cv_shrext"],
+     [Define to the shared library suffix, say, ".dylib".])
+ fi
++if test -n "$shared_archive_member_spec"; then
++  m4_pattern_allow([LT_SHARED_LIB_MEMBER])dnl
++  AC_DEFINE_UNQUOTED([LT_SHARED_LIB_MEMBER], ["($shared_archive_member_spec.o)"],
++    [Define to the shared archive member specification, say "(shr.o)".])
++fi
+ ])# LT_SYS_MODULE_EXT
+ 
+ # Old name:
+@@ -600,8 +608,8 @@ dnl AC_DEFUN([AC_LTDL_SHLIBEXT], [])
+ # ------------------
+ AC_DEFUN([LT_SYS_MODULE_PATH],
+ [m4_require([_LT_SYS_DYNAMIC_LINKER])dnl
+-AC_CACHE_CHECK([which variable specifies run-time module search path],
+-  [lt_cv_module_path_var], [lt_cv_module_path_var="$shlibpath_var"])
++AC_CACHE_CHECK([what variable specifies run-time module search path],
++  [lt_cv_module_path_var], [lt_cv_module_path_var=$shlibpath_var])
+ if test -n "$lt_cv_module_path_var"; then
+   m4_pattern_allow([LT_MODULE_PATH_VAR])dnl
+   AC_DEFINE_UNQUOTED([LT_MODULE_PATH_VAR], ["$lt_cv_module_path_var"],
+@@ -621,14 +629,14 @@ AC_DEFUN([LT_SYS_DLSEARCH_PATH],
+ [m4_require([_LT_SYS_DYNAMIC_LINKER])dnl
+ AC_CACHE_CHECK([for the default library search path],
+   [lt_cv_sys_dlsearch_path],
+-  [lt_cv_sys_dlsearch_path="$sys_lib_dlsearch_path_spec"])
++  [lt_cv_sys_dlsearch_path=$sys_lib_dlsearch_path_spec])
+ if test -n "$lt_cv_sys_dlsearch_path"; then
+   sys_dlsearch_path=
+   for dir in $lt_cv_sys_dlsearch_path; do
+     if test -z "$sys_dlsearch_path"; then
+-      sys_dlsearch_path="$dir"
++      sys_dlsearch_path=$dir
+     else
+-      sys_dlsearch_path="$sys_dlsearch_path$PATH_SEPARATOR$dir"
++      sys_dlsearch_path=$sys_dlsearch_path$PATH_SEPARATOR$dir
+     fi
+   done
+   m4_pattern_allow([LT_DLSEARCH_PATH])dnl
+@@ -655,7 +663,7 @@ AC_CACHE_CHECK([whether libtool supports -dlopen/-dlpreopen],
+     libltdl_cv_preloaded_symbols=no
+   fi
+   ])
+-if test x"$libltdl_cv_preloaded_symbols" = xyes; then
++if test yes = "$libltdl_cv_preloaded_symbols"; then
+   AC_DEFINE([HAVE_PRELOADED_SYMBOLS], [1],
+     [Define if libtool can extract symbol lists from object files.])
+ fi
+@@ -670,15 +678,16 @@ LT_DLLOADERS=
+ AC_SUBST([LT_DLLOADERS])
+ 
+ AC_LANG_PUSH([C])
++lt_dlload_save_LIBS=$LIBS
+ 
+ LIBADD_DLOPEN=
+ AC_SEARCH_LIBS([dlopen], [dl],
+ 	[AC_DEFINE([HAVE_LIBDL], [1],
+ 		   [Define if you have the libdl library or equivalent.])
+-	if test "$ac_cv_search_dlopen" != "none required" ; then
+-	  LIBADD_DLOPEN="-ldl"
++	if test "$ac_cv_search_dlopen" != "none required"; then
++	  LIBADD_DLOPEN=-ldl
+ 	fi
+-	libltdl_cv_lib_dl_dlopen="yes"
++	libltdl_cv_lib_dl_dlopen=yes
+ 	LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}dlopen.la"],
+     [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#if HAVE_DLFCN_H
+ #  include <dlfcn.h>
+@@ -686,19 +695,19 @@ AC_SEARCH_LIBS([dlopen], [dl],
+     ]], [[dlopen(0, 0);]])],
+ 	    [AC_DEFINE([HAVE_LIBDL], [1],
+ 		       [Define if you have the libdl library or equivalent.])
+-	    libltdl_cv_func_dlopen="yes"
++	    libltdl_cv_func_dlopen=yes
+ 	    LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}dlopen.la"],
+ 	[AC_CHECK_LIB([svld], [dlopen],
+ 		[AC_DEFINE([HAVE_LIBDL], [1],
+ 			 [Define if you have the libdl library or equivalent.])
+-	        LIBADD_DLOPEN="-lsvld" libltdl_cv_func_dlopen="yes"
++	        LIBADD_DLOPEN=-lsvld libltdl_cv_func_dlopen=yes
+ 		LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}dlopen.la"])])])
+-if test x"$libltdl_cv_func_dlopen" = xyes || test x"$libltdl_cv_lib_dl_dlopen" = xyes
++if test yes = "$libltdl_cv_func_dlopen" || test yes = "$libltdl_cv_lib_dl_dlopen"
+ then
+-  lt_save_LIBS="$LIBS"
++  lt_save_LIBS=$LIBS
+   LIBS="$LIBS $LIBADD_DLOPEN"
+   AC_CHECK_FUNCS([dlerror])
+-  LIBS="$lt_save_LIBS"
++  LIBS=$lt_save_LIBS
+ fi
+ AC_SUBST([LIBADD_DLOPEN])
+ 
+@@ -711,7 +720,7 @@ AC_CHECK_FUNC([shl_load],
+ 	    [AC_DEFINE([HAVE_SHL_LOAD], [1],
+ 		       [Define if you have the shl_load function.])
+ 	    LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}shl_load.la"
+-	    LIBADD_SHL_LOAD="-ldld"])])
++	    LIBADD_SHL_LOAD=-ldld])])
+ AC_SUBST([LIBADD_SHL_LOAD])
+ 
+ case $host_os in
+@@ -725,7 +734,7 @@ darwin[[1567]].*)
+ beos*)
+   LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}load_add_on.la"
+   ;;
+-cygwin* | mingw* | os2* | pw32*)
++cygwin* | msys* | mingw* | pw32*)
+   AC_CHECK_DECLS([cygwin_conv_path], [], [], [[#include <sys/cygwin.h>]])
+   LT_DLLOADERS="$LT_DLLOADERS ${lt_dlopen_dir+$lt_dlopen_dir/}loadlibrary.la"
+   ;;
+@@ -753,6 +762,7 @@ dnl This isn't used anymore, but set it for backwards compatibility
+ LIBADD_DL="$LIBADD_DLOPEN $LIBADD_SHL_LOAD"
+ AC_SUBST([LIBADD_DL])
+ 
++LIBS=$lt_dlload_save_LIBS
+ AC_LANG_POP
+ ])# LT_LIB_DLLOAD
+ 
+@@ -810,24 +820,106 @@ dnl AC_DEFUN([AC_LTDL_SYMBOL_USCORE], [])
+ # LT_FUNC_DLSYM_USCORE
+ # --------------------
+ AC_DEFUN([LT_FUNC_DLSYM_USCORE],
+-[AC_REQUIRE([LT_SYS_SYMBOL_USCORE])dnl
+-if test x"$lt_cv_sys_symbol_underscore" = xyes; then
+-  if test x"$libltdl_cv_func_dlopen" = xyes ||
+-     test x"$libltdl_cv_lib_dl_dlopen" = xyes ; then
+-	AC_CACHE_CHECK([whether we have to add an underscore for dlsym],
+-	  [libltdl_cv_need_uscore],
+-	  [libltdl_cv_need_uscore=unknown
+-          save_LIBS="$LIBS"
+-          LIBS="$LIBS $LIBADD_DLOPEN"
+-	  _LT_TRY_DLOPEN_SELF(
+-	    [libltdl_cv_need_uscore=no], [libltdl_cv_need_uscore=yes],
+-	    [],				 [libltdl_cv_need_uscore=cross])
+-	  LIBS="$save_LIBS"
+-	])
++[AC_REQUIRE([_LT_COMPILER_PIC])dnl	for lt_prog_compiler_wl
++AC_REQUIRE([LT_SYS_SYMBOL_USCORE])dnl	for lt_cv_sys_symbol_underscore
++AC_REQUIRE([LT_SYS_MODULE_EXT])dnl	for libltdl_cv_shlibext
++if test yes = "$lt_cv_sys_symbol_underscore"; then
++  if test yes = "$libltdl_cv_func_dlopen" || test yes = "$libltdl_cv_lib_dl_dlopen"; then
++    AC_CACHE_CHECK([whether we have to add an underscore for dlsym],
++      [libltdl_cv_need_uscore],
++      [libltdl_cv_need_uscore=unknown
++      dlsym_uscore_save_LIBS=$LIBS
++      LIBS="$LIBS $LIBADD_DLOPEN"
++      libname=conftmod # stay within 8.3 filename limits!
++      cat >$libname.$ac_ext <<_LT_EOF
++[#line $LINENO "configure"
++#include "confdefs.h"
++/* When -fvisibility=hidden is used, assume the code has been annotated
++   correspondingly for the symbols needed.  */
++#if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
++int fnord () __attribute__((visibility("default")));
++#endif
++int fnord () { return 42; }]
++_LT_EOF
++
++      # ltfn_module_cmds module_cmds
++      # Execute tilde-delimited MODULE_CMDS with environment primed for
++      # $module_cmds or $archive_cmds type content.
++      ltfn_module_cmds ()
++      {( # subshell avoids polluting parent global environment
++          module_cmds_save_ifs=$IFS; IFS='~'
++          for cmd in @S|@1; do
++            IFS=$module_cmds_save_ifs
++            libobjs=$libname.$ac_objext; lib=$libname$libltdl_cv_shlibext
++            rpath=/not-exists; soname=$libname$libltdl_cv_shlibext; output_objdir=.
++            major=; versuffix=; verstring=; deplibs=
++            ECHO=echo; wl=$lt_prog_compiler_wl; allow_undefined_flag=
++            eval $cmd
++          done
++          IFS=$module_cmds_save_ifs
++      )}
++
++      # Compile a loadable module using libtool macro expansion results.
++      $CC $pic_flag -c $libname.$ac_ext
++      ltfn_module_cmds "${module_cmds:-$archive_cmds}"
++
++      # Try to fetch fnord with dlsym().
++      libltdl_dlunknown=0; libltdl_dlnouscore=1; libltdl_dluscore=2
++      cat >conftest.$ac_ext <<_LT_EOF
++[#line $LINENO "configure"
++#include "confdefs.h"
++#if HAVE_DLFCN_H
++#include <dlfcn.h>
++#endif
++#include <stdio.h>
++#ifndef RTLD_GLOBAL
++#  ifdef DL_GLOBAL
++#    define RTLD_GLOBAL DL_GLOBAL
++#  else
++#    define RTLD_GLOBAL 0
++#  endif
++#endif
++#ifndef RTLD_NOW
++#  ifdef DL_NOW
++#    define RTLD_NOW DL_NOW
++#  else
++#    define RTLD_NOW 0
++#  endif
++#endif
++int main () {
++  void *handle = dlopen ("`pwd`/$libname$libltdl_cv_shlibext", RTLD_GLOBAL|RTLD_NOW);
++  int status = $libltdl_dlunknown;
++  if (handle) {
++    if (dlsym (handle, "fnord"))
++      status = $libltdl_dlnouscore;
++    else {
++      if (dlsym (handle, "_fnord"))
++        status = $libltdl_dluscore;
++      else
++	puts (dlerror ());
++    }
++    dlclose (handle);
++  } else
++    puts (dlerror ());
++  return status;
++}]
++_LT_EOF
++      if AC_TRY_EVAL(ac_link) && test -s "conftest$ac_exeext" 2>/dev/null; then
++        (./conftest; exit; ) >&AS_MESSAGE_LOG_FD 2>/dev/null
++        libltdl_status=$?
++        case x$libltdl_status in
++          x$libltdl_dlnouscore) libltdl_cv_need_uscore=no ;;
++	  x$libltdl_dluscore) libltdl_cv_need_uscore=yes ;;
++	  x*) libltdl_cv_need_uscore=unknown ;;
++        esac
++      fi
++      rm -rf conftest* $libname*
++      LIBS=$dlsym_uscore_save_LIBS
++    ])
+   fi
+ fi
+ 
+-if test x"$libltdl_cv_need_uscore" = xyes; then
++if test yes = "$libltdl_cv_need_uscore"; then
+   AC_DEFINE([NEED_USCORE], [1],
+     [Define if dlsym() requires a leading underscore in symbol names.])
+ fi
+diff --git a/compile b/compile
+index 531136b..0eb2633 100644
+--- a/compile
++++ b/compile
+@@ -53,7 +53,7 @@ func_file_conv ()
+ 	  MINGW*)
+ 	    file_conv=mingw
+ 	    ;;
+-	  CYGWIN*)
++	  CYGWIN*|MSYS*)
+ 	    file_conv=cygwin
+ 	    ;;
+ 	  *)
+@@ -67,7 +67,7 @@ func_file_conv ()
+ 	mingw/*)
+ 	  file=`cmd //C echo "$file " | sed -e 's/"\(.*\) " *$/\1/'`
+ 	  ;;
+-	cygwin/*)
++	cygwin/*|msys/*)
+ 	  file=`cygpath -m "$file" || echo "$file"`
+ 	  ;;
+ 	wine/*)
+diff --git a/config.guess b/config.guess
+index b79252d..143a875 100644
+--- a/config.guess
++++ b/config.guess
+@@ -866,6 +866,9 @@ EOF
+     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
+ 	echo x86_64-unknown-cygwin
+ 	exit ;;
++    amd64:MSYS*:*:* | x86_64:MSYS*:*:*)
++	echo x86_64-unknown-msys
++	exit ;;
+     p*:CYGWIN*:*)
+ 	echo powerpcle-unknown-cygwin
+ 	exit ;;
+diff --git a/config.sub b/config.sub
+index c765b34..8b612ab 100644
+--- a/config.sub
++++ b/config.sub
+@@ -1006,7 +1006,7 @@ case $basic_machine in
+ 		;;
+ 	ppc64)	basic_machine=powerpc64-unknown
+ 		;;
+-	ppc64-* | ppc64p7-*) basic_machine=powerpc64-`echo $basic_machine | sed 's/^[^-]*-//'`
++	ppc64-*) basic_machine=powerpc64-`echo $basic_machine | sed 's/^[^-]*-//'`
+ 		;;
+ 	ppc64le | powerpc64little | ppc64-le | powerpc64-little)
+ 		basic_machine=powerpc64le-unknown
+diff --git a/configure b/configure
+index c6da467..4557602 100644
+--- a/configure
++++ b/configure
+@@ -738,6 +738,7 @@ MAINTAINER_MODE_TRUE
+ PRTDIAG
+ CXXCPP
+ CPP
++LT_SYS_LIBRARY_PATH
+ OTOOL64
+ OTOOL
+ LIPO
+@@ -875,6 +876,7 @@ enable_shared
+ enable_static
+ with_pic
+ enable_fast_install
++with_aix_soname
+ with_gnu_ld
+ with_sysroot
+ enable_libtool_lock
+@@ -892,6 +894,7 @@ host_alias
+ target_alias
+ CCAS
+ CCASFLAGS
++LT_SYS_LIBRARY_PATH
+ CPP
+ CPPFLAGS
+ CXXCPP'
+@@ -1544,9 +1547,12 @@ Optional Packages:
+   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+   --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
+                           both]
++  --with-aix-soname=aix|svr4|both
++                          shared library versioning (aka "SONAME") variant to
++                          provide on AIX, [default=aix].
+   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
+-  --with-sysroot=DIR Search for dependent libraries within DIR
+-                        (or the compiler's sysroot if not specified).
++  --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
++                          compiler's sysroot if not specified).
+   --with-gcc-arch=<arch>  use architecture <arch> for gcc -march/-mtune,
+                           instead of guessing
+ 
+@@ -1562,6 +1568,8 @@ Some influential environment variables:
+   CXXFLAGS    C++ compiler flags
+   CCAS        assembler compiler command (defaults to CC)
+   CCASFLAGS   assembler compiler flags (defaults to CFLAGS)
++  LT_SYS_LIBRARY_PATH
++              User-defined run-time library search path.
+   CPP         C preprocessor
+   CXXCPP      C++ preprocessor
+ 
+@@ -5145,8 +5153,8 @@ esac
+ 
+ 
+ 
+-macro_version='2.4.2'
+-macro_revision='1.3337'
++macro_version='2.4.6.34-08c5'
++macro_revision='2.4.6.34'
+ 
+ 
+ 
+@@ -5160,7 +5168,7 @@ macro_revision='1.3337'
+ 
+ 
+ 
+-ltmain="$ac_aux_dir/ltmain.sh"
++ltmain=$ac_aux_dir/ltmain.sh
+ 
+ # Backslashify metacharacters that are still active within
+ # double-quoted strings.
+@@ -5209,7 +5217,7 @@ func_echo_all ()
+     $ECHO ""
+ }
+ 
+-case "$ECHO" in
++case $ECHO in
+   printf*) { $as_echo "$as_me:${as_lineno-$LINENO}: result: printf" >&5
+ $as_echo "printf" >&6; } ;;
+   print*) { $as_echo "$as_me:${as_lineno-$LINENO}: result: print -r" >&5
+@@ -5532,19 +5540,19 @@ test -z "$GREP" && GREP=grep
+ 
+ # Check whether --with-gnu-ld was given.
+ if test "${with_gnu_ld+set}" = set; then :
+-  withval=$with_gnu_ld; test "$withval" = no || with_gnu_ld=yes
++  withval=$with_gnu_ld; test no = "$withval" || with_gnu_ld=yes
+ else
+   with_gnu_ld=no
+ fi
+ 
+ ac_prog=ld
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   # Check if gcc -print-prog-name=ld gives a path.
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ld used by $CC" >&5
+ $as_echo_n "checking for ld used by $CC... " >&6; }
+   case $host in
+   *-*-mingw*)
+-    # gcc leaves a trailing carriage return which upsets mingw
++    # gcc leaves a trailing carriage return, which upsets mingw
+     ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
+   *)
+     ac_prog=`($CC -print-prog-name=ld) 2>&5` ;;
+@@ -5558,7 +5566,7 @@ $as_echo_n "checking for ld used by $CC... " >&6; }
+       while $ECHO "$ac_prog" | $GREP "$re_direlt" > /dev/null 2>&1; do
+ 	ac_prog=`$ECHO $ac_prog| $SED "s%$re_direlt%/%"`
+       done
+-      test -z "$LD" && LD="$ac_prog"
++      test -z "$LD" && LD=$ac_prog
+       ;;
+   "")
+     # If it fails, then pretend we aren't using GCC.
+@@ -5569,7 +5577,7 @@ $as_echo_n "checking for ld used by $CC... " >&6; }
+     with_gnu_ld=unknown
+     ;;
+   esac
+-elif test "$with_gnu_ld" = yes; then
++elif test yes = "$with_gnu_ld"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GNU ld" >&5
+ $as_echo_n "checking for GNU ld... " >&6; }
+ else
+@@ -5580,32 +5588,32 @@ if ${lt_cv_path_LD+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   if test -z "$LD"; then
+-  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+   for ac_dir in $PATH; do
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+     test -z "$ac_dir" && ac_dir=.
+     if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
+-      lt_cv_path_LD="$ac_dir/$ac_prog"
++      lt_cv_path_LD=$ac_dir/$ac_prog
+       # Check to see if the program is GNU ld.  I'd rather use --version,
+       # but apparently some variants of GNU ld only accept -v.
+       # Break only if it was the GNU/non-GNU ld that we prefer.
+       case `"$lt_cv_path_LD" -v 2>&1 </dev/null` in
+       *GNU* | *'with BFD'*)
+-	test "$with_gnu_ld" != no && break
++	test no != "$with_gnu_ld" && break
+ 	;;
+       *)
+-	test "$with_gnu_ld" != yes && break
++	test yes != "$with_gnu_ld" && break
+ 	;;
+       esac
+     fi
+   done
+-  IFS="$lt_save_ifs"
++  IFS=$lt_save_ifs
+ else
+-  lt_cv_path_LD="$LD" # Let the user override the test with a path.
++  lt_cv_path_LD=$LD # Let the user override the test with a path.
+ fi
+ fi
+ 
+-LD="$lt_cv_path_LD"
++LD=$lt_cv_path_LD
+ if test -n "$LD"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
+ $as_echo "$LD" >&6; }
+@@ -5648,33 +5656,38 @@ if ${lt_cv_path_NM+:} false; then :
+ else
+   if test -n "$NM"; then
+   # Let the user override the test.
+-  lt_cv_path_NM="$NM"
++  lt_cv_path_NM=$NM
+ else
+-  lt_nm_to_check="${ac_tool_prefix}nm"
++  lt_nm_to_check=${ac_tool_prefix}nm
+   if test -n "$ac_tool_prefix" && test "$build" = "$host"; then
+     lt_nm_to_check="$lt_nm_to_check nm"
+   fi
+   for lt_tmp_nm in $lt_nm_to_check; do
+-    lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++    lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+     for ac_dir in $PATH /usr/ccs/bin/elf /usr/ccs/bin /usr/ucb /bin; do
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       test -z "$ac_dir" && ac_dir=.
+-      tmp_nm="$ac_dir/$lt_tmp_nm"
+-      if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext" ; then
++      tmp_nm=$ac_dir/$lt_tmp_nm
++      if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext"; then
+ 	# Check to see if the nm accepts a BSD-compat flag.
+-	# Adding the `sed 1q' prevents false positives on HP-UX, which says:
++	# Adding the 'sed 1q' prevents false positives on HP-UX, which says:
+ 	#   nm: unknown option "B" ignored
+ 	# Tru64's nm complains that /dev/null is an invalid object file
+-	case `"$tmp_nm" -B /dev/null 2>&1 | sed '1q'` in
+-	*/dev/null* | *'Invalid file or object type'*)
++	# MSYS converts /dev/null to NUL, MinGW nm treats NUL as empty
++	case $build_os in
++	mingw*) lt_bad_file=conftest.nm/nofile ;;
++	*) lt_bad_file=/dev/null ;;
++	esac
++	case `"$tmp_nm" -B $lt_bad_file 2>&1 | sed '1q'` in
++	*$lt_bad_file* | *'Invalid file or object type'*)
+ 	  lt_cv_path_NM="$tmp_nm -B"
+-	  break
++	  break 2
+ 	  ;;
+ 	*)
+ 	  case `"$tmp_nm" -p /dev/null 2>&1 | sed '1q'` in
+ 	  */dev/null*)
+ 	    lt_cv_path_NM="$tmp_nm -p"
+-	    break
++	    break 2
+ 	    ;;
+ 	  *)
+ 	    lt_cv_path_NM=${lt_cv_path_NM="$tmp_nm"} # keep the first match, but
+@@ -5685,15 +5698,15 @@ else
+ 	esac
+       fi
+     done
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+   done
+   : ${lt_cv_path_NM=no}
+ fi
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_path_NM" >&5
+ $as_echo "$lt_cv_path_NM" >&6; }
+-if test "$lt_cv_path_NM" != "no"; then
+-  NM="$lt_cv_path_NM"
++if test no != "$lt_cv_path_NM"; then
++  NM=$lt_cv_path_NM
+ else
+   # Didn't find any BSD compatible name lister, look for dumpbin.
+   if test -n "$DUMPBIN"; then :
+@@ -5799,9 +5812,9 @@ esac
+   fi
+ fi
+ 
+-    case `$DUMPBIN -symbols /dev/null 2>&1 | sed '1q'` in
++    case `$DUMPBIN -symbols -headers /dev/null 2>&1 | sed '1q'` in
+     *COFF*)
+-      DUMPBIN="$DUMPBIN -symbols"
++      DUMPBIN="$DUMPBIN -symbols -headers"
+       ;;
+     *)
+       DUMPBIN=:
+@@ -5809,8 +5822,8 @@ fi
+     esac
+   fi
+ 
+-  if test "$DUMPBIN" != ":"; then
+-    NM="$DUMPBIN"
++  if test : != "$DUMPBIN"; then
++    NM=$DUMPBIN
+   fi
+ fi
+ test -z "$NM" && NM=nm
+@@ -5861,7 +5874,7 @@ if ${lt_cv_sys_max_cmd_len+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+     i=0
+-  teststring="ABCD"
++  teststring=ABCD
+ 
+   case $build_os in
+   msdosdjgpp*)
+@@ -5901,7 +5914,7 @@ else
+     lt_cv_sys_max_cmd_len=8192;
+     ;;
+ 
+-  netbsd* | freebsd* | openbsd* | darwin* | dragonfly*)
++  bitrig* | darwin* | dragonfly* | freebsd* | netbsd* | openbsd*)
+     # This has been around since 386BSD, at least.  Likely further.
+     if test -x /sbin/sysctl; then
+       lt_cv_sys_max_cmd_len=`/sbin/sysctl -n kern.argmax`
+@@ -5951,22 +5964,23 @@ else
+     ;;
+   *)
+     lt_cv_sys_max_cmd_len=`(getconf ARG_MAX) 2> /dev/null`
+-    if test -n "$lt_cv_sys_max_cmd_len"; then
++    if test -n "$lt_cv_sys_max_cmd_len" && \
++       test undefined != "$lt_cv_sys_max_cmd_len"; then
+       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 4`
+       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \* 3`
+     else
+       # Make teststring a little bigger before we do anything with it.
+       # a 1K string should be a reasonable start.
+-      for i in 1 2 3 4 5 6 7 8 ; do
++      for i in 1 2 3 4 5 6 7 8; do
+         teststring=$teststring$teststring
+       done
+       SHELL=${SHELL-${CONFIG_SHELL-/bin/sh}}
+       # If test is not a shell built-in, we'll probably end up computing a
+       # maximum length that is only half of the actual maximum length, but
+       # we can't tell.
+-      while { test "X"`env echo "$teststring$teststring" 2>/dev/null` \
++      while { test X`env echo "$teststring$teststring" 2>/dev/null` \
+ 	         = "X$teststring$teststring"; } >/dev/null 2>&1 &&
+-	      test $i != 17 # 1/2 MB should be enough
++	      test 17 != "$i" # 1/2 MB should be enough
+       do
+         i=`expr $i + 1`
+         teststring=$teststring$teststring
+@@ -5984,7 +5998,7 @@ else
+ 
+ fi
+ 
+-if test -n $lt_cv_sys_max_cmd_len ; then
++if test -n "$lt_cv_sys_max_cmd_len"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_sys_max_cmd_len" >&5
+ $as_echo "$lt_cv_sys_max_cmd_len" >&6; }
+ else
+@@ -6002,30 +6016,6 @@ max_cmd_len=$lt_cv_sys_max_cmd_len
+ : ${MV="mv -f"}
+ : ${RM="rm -f"}
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the shell understands some XSI constructs" >&5
+-$as_echo_n "checking whether the shell understands some XSI constructs... " >&6; }
+-# Try some XSI features
+-xsi_shell=no
+-( _lt_dummy="a/b/c"
+-  test "${_lt_dummy##*/},${_lt_dummy%/*},${_lt_dummy#??}"${_lt_dummy%"$_lt_dummy"}, \
+-      = c,a/b,b/c, \
+-    && eval 'test $(( 1 + 1 )) -eq 2 \
+-    && test "${#_lt_dummy}" -eq 5' ) >/dev/null 2>&1 \
+-  && xsi_shell=yes
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $xsi_shell" >&5
+-$as_echo "$xsi_shell" >&6; }
+-
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the shell understands \"+=\"" >&5
+-$as_echo_n "checking whether the shell understands \"+=\"... " >&6; }
+-lt_shell_append=no
+-( foo=bar; set foo baz; eval "$1+=\$2" && test "$foo" = barbaz ) \
+-    >/dev/null 2>&1 \
+-  && lt_shell_append=yes
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_shell_append" >&5
+-$as_echo "$lt_shell_append" >&6; }
+-
+-
+ if ( (MAIL=60; unset MAIL) || exit) >/dev/null 2>&1; then
+   lt_unset=unset
+ else
+@@ -6148,13 +6138,13 @@ esac
+ reload_cmds='$LD$reload_flag -o $output$reload_objs'
+ case $host_os in
+   cygwin* | mingw* | pw32* | cegcc*)
+-    if test "$GCC" != yes; then
++    if test yes != "$GCC"; then
+       reload_cmds=false
+     fi
+     ;;
+   darwin*)
+-    if test "$GCC" = yes; then
+-      reload_cmds='$LTCC $LTCFLAGS -nostdlib ${wl}-r -o $output$reload_objs'
++    if test yes = "$GCC"; then
++      reload_cmds='$LTCC $LTCFLAGS -nostdlib $wl-r -o $output$reload_objs'
+     else
+       reload_cmds='$LD$reload_flag -o $output$reload_objs'
+     fi
+@@ -6282,13 +6272,13 @@ lt_cv_deplibs_check_method='unknown'
+ # Need to set the preceding variable on all platforms that support
+ # interlibrary dependencies.
+ # 'none' -- dependencies not supported.
+-# `unknown' -- same as none, but documents that we really don't know.
++# 'unknown' -- same as none, but documents that we really don't know.
+ # 'pass_all' -- all dependencies passed with no checks.
+ # 'test_compile' -- check by making test program.
+ # 'file_magic [[regex]]' -- check by looking for files in library path
+-# which responds to the $file_magic_cmd with a given extended regex.
+-# If you have `file' or equivalent on your system and you're not sure
+-# whether `pass_all' will *always* work, you probably want this one.
++# that responds to the $file_magic_cmd with a given extended regex.
++# If you have 'file' or equivalent on your system and you're not sure
++# whether 'pass_all' will *always* work, you probably want this one.
+ 
+ case $host_os in
+ aix[4-9]*)
+@@ -6315,8 +6305,7 @@ mingw* | pw32*)
+   # Base MSYS/MinGW do not provide the 'file' command needed by
+   # func_win32_libid shell function, so use a weaker test based on 'objdump',
+   # unless we find 'file', for example because we are cross-compiling.
+-  # func_win32_libid assumes BSD nm, so disallow it if using MS dumpbin.
+-  if ( test "$lt_cv_nm_interface" = "BSD nm" && file / ) >/dev/null 2>&1; then
++  if ( file / ) >/dev/null 2>&1; then
+     lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+     lt_cv_file_magic_cmd='func_win32_libid'
+   else
+@@ -6352,10 +6341,6 @@ freebsd* | dragonfly*)
+   fi
+   ;;
+ 
+-gnu*)
+-  lt_cv_deplibs_check_method=pass_all
+-  ;;
+-
+ haiku*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+@@ -6394,7 +6379,7 @@ irix5* | irix6* | nonstopux*)
+   ;;
+ 
+ # This must be glibc/ELF.
+-linux* | k*bsd*-gnu | kopensolaris*-gnu)
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
+@@ -6416,8 +6401,8 @@ newos6*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
+-openbsd*)
+-  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++openbsd* | bitrig*)
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
+     lt_cv_deplibs_check_method='match_pattern /lib[^/]+(\.so\.[0-9]+\.[0-9]+|\.so|_pic\.a)$'
+   else
+     lt_cv_deplibs_check_method='match_pattern /lib[^/]+(\.so\.[0-9]+\.[0-9]+|_pic\.a)$'
+@@ -6470,6 +6455,9 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++os2*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -6627,8 +6615,8 @@ else
+ 
+ case $host_os in
+ cygwin* | mingw* | pw32* | cegcc*)
+-  # two different shell functions defined in ltmain.sh
+-  # decide which to use based on capabilities of $DLLTOOL
++  # two different shell functions defined in ltmain.sh;
++  # decide which one to use based on capabilities of $DLLTOOL
+   case `$DLLTOOL --help 2>&1` in
+   *--identify-strict*)
+     lt_cv_sharedlib_from_linklib_cmd=func_cygming_dll_for_implib
+@@ -6640,7 +6628,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+   ;;
+ *)
+   # fallback: assume linklib IS sharedlib
+-  lt_cv_sharedlib_from_linklib_cmd="$ECHO"
++  lt_cv_sharedlib_from_linklib_cmd=$ECHO
+   ;;
+ esac
+ 
+@@ -6758,13 +6746,29 @@ esac
+ fi
+ 
+ : ${AR=ar}
+-: ${AR_FLAGS=cru}
+ 
+ 
+ 
+ 
+ 
+ 
++# Use ARFLAGS variable as AR's operation code to sync the variable naming with
++# Automake.  If both AR_FLAGS and ARFLAGS are specified, AR_FLAGS should have
++# higher priority because thats what people were doing historically (setting
++# ARFLAGS for automake and AR_FLAGS for libtool).  FIXME: Make the AR_FLAGS
++# variable obsoleted/removed.
++
++test ${AR_FLAGS+y} || AR_FLAGS=${ARFLAGS-cr}
++lt_ar_flags=$AR_FLAGS
++
++
++
++
++
++
++# Make AR_FLAGS overridable by 'make ARFLAGS='.  Don't try to run-time override
++# by AR_FLAGS because that was never working and AR_FLAGS is about to die.
++
+ 
+ 
+ 
+@@ -6795,7 +6799,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }
+-      if test "$ac_status" -eq 0; then
++      if test 0 -eq "$ac_status"; then
+ 	# Ensure the archiver fails upon bogus file names.
+ 	rm -f conftest.$ac_objext libconftest.a
+ 	{ { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$lt_ar_try\""; } >&5
+@@ -6803,7 +6807,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }
+-	if test "$ac_status" -ne 0; then
++	if test 0 -ne "$ac_status"; then
+           lt_cv_ar_at_file=@
+         fi
+       fi
+@@ -6816,7 +6820,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ar_at_file" >&5
+ $as_echo "$lt_cv_ar_at_file" >&6; }
+ 
+-if test "x$lt_cv_ar_at_file" = xno; then
++if test no = "$lt_cv_ar_at_file"; then
+   archiver_list_spec=
+ else
+   archiver_list_spec=$lt_cv_ar_at_file
+@@ -7033,7 +7037,7 @@ old_postuninstall_cmds=
+ 
+ if test -n "$RANLIB"; then
+   case $host_os in
+-  openbsd*)
++  bitrig* | openbsd*)
+     old_postinstall_cmds="$old_postinstall_cmds~\$RANLIB -t \$tool_oldlib"
+     ;;
+   *)
+@@ -7123,7 +7127,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+   symcode='[ABCDGISTW]'
+   ;;
+ hpux*)
+-  if test "$host_cpu" = ia64; then
++  if test ia64 = "$host_cpu"; then
+     symcode='[ABCDEGRST]'
+   fi
+   ;;
+@@ -7156,14 +7160,44 @@ case `$NM -V 2>&1` in
+   symcode='[ABCDGIRSTW]' ;;
+ esac
+ 
++if test "$lt_cv_nm_interface" = "MS dumpbin"; then
++  # Gets list of data symbols to import.
++  lt_cv_sys_global_symbol_to_import="sed -n -e 's/^I .* \(.*\)$/\1/p'"
++  # Adjust the below global symbol transforms to fixup imported variables.
++  lt_cdecl_hook=" -e 's/^I .* \(.*\)$/extern __declspec(dllimport) char \1;/p'"
++  lt_c_name_hook=" -e 's/^I .* \(.*\)$/  {\"\1\", (void *) 0},/p'"
++  lt_c_name_lib_hook="\
++  -e 's/^I .* \(lib.*\)$/  {\"\1\", (void *) 0},/p'\
++  -e 's/^I .* \(.*\)$/  {\"lib\1\", (void *) 0},/p'"
++else
++  # Disable hooks by default.
++  lt_cv_sys_global_symbol_to_import=
++  lt_cdecl_hook=
++  lt_c_name_hook=
++  lt_c_name_lib_hook=
++fi
++
+ # Transform an extracted symbol line into a proper C declaration.
+ # Some systems (esp. on ia64) link data and code symbols differently,
+ # so use this general approach.
+-lt_cv_sys_global_symbol_to_cdecl="sed -n -e 's/^T .* \(.*\)$/extern int \1();/p' -e 's/^$symcode* .* \(.*\)$/extern char \1;/p'"
++lt_cv_sys_global_symbol_to_cdecl="sed -n"\
++$lt_cdecl_hook\
++" -e 's/^T .* \(.*\)$/extern int \1();/p'"\
++" -e 's/^$symcode$symcode* .* \(.*\)$/extern char \1;/p'"
+ 
+ # Transform an extracted symbol line into symbol name and symbol address
+-lt_cv_sys_global_symbol_to_c_name_address="sed -n -e 's/^: \([^ ]*\)[ ]*$/  {\\\"\1\\\", (void *) 0},/p' -e 's/^$symcode* \([^ ]*\) \([^ ]*\)$/  {\"\2\", (void *) \&\2},/p'"
+-lt_cv_sys_global_symbol_to_c_name_address_lib_prefix="sed -n -e 's/^: \([^ ]*\)[ ]*$/  {\\\"\1\\\", (void *) 0},/p' -e 's/^$symcode* \([^ ]*\) \(lib[^ ]*\)$/  {\"\2\", (void *) \&\2},/p' -e 's/^$symcode* \([^ ]*\) \([^ ]*\)$/  {\"lib\2\", (void *) \&\2},/p'"
++lt_cv_sys_global_symbol_to_c_name_address="sed -n"\
++$lt_c_name_hook\
++" -e 's/^: \(.*\) .*$/  {\"\1\", (void *) 0},/p'"\
++" -e 's/^$symcode$symcode* .* \(.*\)$/  {\"\1\", (void *) \&\1},/p'"
++
++# Transform an extracted symbol line into symbol name with lib prefix and
++# symbol address.
++lt_cv_sys_global_symbol_to_c_name_address_lib_prefix="sed -n"\
++$lt_c_name_lib_hook\
++" -e 's/^: \(.*\) .*$/  {\"\1\", (void *) 0},/p'"\
++" -e 's/^$symcode$symcode* .* \(lib.*\)$/  {\"\1\", (void *) \&\1},/p'"\
++" -e 's/^$symcode$symcode* .* \(.*\)$/  {\"lib\1\", (void *) \&\1},/p'"
+ 
+ # Handle CRLF in mingw tool chain
+ opt_cr=
+@@ -7181,21 +7215,24 @@ for ac_symprfx in "" "_"; do
+ 
+   # Write the raw and C identifiers.
+   if test "$lt_cv_nm_interface" = "MS dumpbin"; then
+-    # Fake it for dumpbin and say T for any non-static function
+-    # and D for any global variable.
++    # Fake it for dumpbin and say T for any non-static function,
++    # D for any global variable and I for any imported variable.
+     # Also find C++ and __fastcall symbols from MSVC++,
+     # which start with @ or ?.
+     lt_cv_sys_global_symbol_pipe="$AWK '"\
+ "     {last_section=section; section=\$ 3};"\
+ "     /^COFF SYMBOL TABLE/{for(i in hide) delete hide[i]};"\
+ "     /Section length .*#relocs.*(pick any)/{hide[last_section]=1};"\
++"     /^ *Symbol name *: /{split(\$ 0,sn,\":\"); si=substr(sn[2],2)};"\
++"     /^ *Type *: code/{print \"T\",si,substr(si,length(prfx))};"\
++"     /^ *Type *: data/{print \"I\",si,substr(si,length(prfx))};"\
+ "     \$ 0!~/External *\|/{next};"\
+ "     / 0+ UNDEF /{next}; / UNDEF \([^|]\)*()/{next};"\
+ "     {if(hide[section]) next};"\
+-"     {f=0}; \$ 0~/\(\).*\|/{f=1}; {printf f ? \"T \" : \"D \"};"\
+-"     {split(\$ 0, a, /\||\r/); split(a[2], s)};"\
+-"     s[1]~/^[@?]/{print s[1], s[1]; next};"\
+-"     s[1]~prfx {split(s[1],t,\"@\"); print t[1], substr(t[1],length(prfx))}"\
++"     {f=\"D\"}; \$ 0~/\(\).*\|/{f=\"T\"};"\
++"     {split(\$ 0,a,/\||\r/); split(a[2],s)};"\
++"     s[1]~/^[@?]/{print f,s[1],s[1]; next};"\
++"     s[1]~prfx {split(s[1],t,\"@\"); print f,t[1],substr(t[1],length(prfx))}"\
+ "     ' prfx=^$ac_symprfx"
+   else
+     lt_cv_sys_global_symbol_pipe="sed -n -e 's/^.*[	 ]\($symcode$symcode*\)[	 ][	 ]*$ac_symprfx$sympat$opt_cr$/$symxfrm/p'"
+@@ -7243,11 +7280,11 @@ _LT_EOF
+ 	if $GREP ' nm_test_func$' "$nlist" >/dev/null; then
+ 	  cat <<_LT_EOF > conftest.$ac_ext
+ /* Keep this code in sync between libtool.m4, ltmain, lt_system.h, and tests.  */
+-#if defined(_WIN32) || defined(__CYGWIN__) || defined(_WIN32_WCE)
+-/* DATA imports from DLLs on WIN32 con't be const, because runtime
++#if defined _WIN32 || defined __CYGWIN__ || defined _WIN32_WCE
++/* DATA imports from DLLs on WIN32 can't be const, because runtime
+    relocations are performed -- see ld's documentation on pseudo-relocs.  */
+ # define LT_DLSYM_CONST
+-#elif defined(__osf__)
++#elif defined __osf__
+ /* This system does not cope well with relocations in const data.  */
+ # define LT_DLSYM_CONST
+ #else
+@@ -7273,7 +7310,7 @@ lt__PROGRAM__LTX_preloaded_symbols[] =
+ {
+   { "@PROGRAM@", (void *) 0 },
+ _LT_EOF
+-	  $SED "s/^$symcode$symcode* \(.*\) \(.*\)$/  {\"\2\", (void *) \&\2},/" < "$nlist" | $GREP -v main >> conftest.$ac_ext
++	  $SED "s/^$symcode$symcode* .* \(.*\)$/  {\"\1\", (void *) \&\1},/" < "$nlist" | $GREP -v main >> conftest.$ac_ext
+ 	  cat <<\_LT_EOF >> conftest.$ac_ext
+   {0, (void *) 0}
+ };
+@@ -7293,13 +7330,13 @@ _LT_EOF
+ 	  mv conftest.$ac_objext conftstm.$ac_objext
+ 	  lt_globsym_save_LIBS=$LIBS
+ 	  lt_globsym_save_CFLAGS=$CFLAGS
+-	  LIBS="conftstm.$ac_objext"
++	  LIBS=conftstm.$ac_objext
+ 	  CFLAGS="$CFLAGS$lt_prog_compiler_no_builtin_flag"
+ 	  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
+   (eval $ac_link) 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; } && test -s conftest${ac_exeext}; then
++  test $ac_status = 0; } && test -s conftest$ac_exeext; then
+ 	    pipe_works=yes
+ 	  fi
+ 	  LIBS=$lt_globsym_save_LIBS
+@@ -7320,7 +7357,7 @@ _LT_EOF
+   rm -rf conftest* conftst*
+ 
+   # Do not use the global_symbol_pipe unless it works.
+-  if test "$pipe_works" = yes; then
++  if test yes = "$pipe_works"; then
+     break
+   else
+     lt_cv_sys_global_symbol_pipe=
+@@ -7373,6 +7410,16 @@ fi
+ 
+ 
+ 
++
++
++
++
++
++
++
++
++
++
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sysroot" >&5
+ $as_echo_n "checking for sysroot... " >&6; }
+ 
+@@ -7385,9 +7432,9 @@ fi
+ 
+ 
+ lt_sysroot=
+-case ${with_sysroot} in #(
++case $with_sysroot in #(
+  yes)
+-   if test "$GCC" = yes; then
++   if test yes = "$GCC"; then
+      lt_sysroot=`$CC --print-sysroot 2>/dev/null`
+    fi
+    ;; #(
+@@ -7397,8 +7444,8 @@ case ${with_sysroot} in #(
+  no|'')
+    ;; #(
+  *)
+-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${with_sysroot}" >&5
+-$as_echo "${with_sysroot}" >&6; }
++   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_sysroot" >&5
++$as_echo "$with_sysroot" >&6; }
+    as_fn_error $? "The sysroot must be an absolute path." "$LINENO" 5
+    ;;
+ esac
+@@ -7410,18 +7457,99 @@ $as_echo "${lt_sysroot:-no}" >&6; }
+ 
+ 
+ 
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a working dd" >&5
++$as_echo_n "checking for a working dd... " >&6; }
++if ${ac_cv_path_lt_DD+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  printf 0123456789abcdef0123456789abcdef >conftest.i
++cat conftest.i conftest.i >conftest2.i
++: ${lt_DD:=$DD}
++if test -z "$lt_DD"; then
++  ac_path_lt_DD_found=false
++  # Loop through the user's path and test for each of PROGNAME-LIST
++  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  test -z "$as_dir" && as_dir=.
++    for ac_prog in dd; do
++    for ac_exec_ext in '' $ac_executable_extensions; do
++      ac_path_lt_DD="$as_dir/$ac_prog$ac_exec_ext"
++      as_fn_executable_p "$ac_path_lt_DD" || continue
++if "$ac_path_lt_DD" bs=32 count=1 <conftest2.i >conftest.out 2>/dev/null; then
++  cmp -s conftest.i conftest.out \
++  && ac_cv_path_lt_DD="$ac_path_lt_DD" ac_path_lt_DD_found=:
++fi
++      $ac_path_lt_DD_found && break 3
++    done
++  done
++  done
++IFS=$as_save_IFS
++  if test -z "$ac_cv_path_lt_DD"; then
++    :
++  fi
++else
++  ac_cv_path_lt_DD=$lt_DD
++fi
++
++rm -f conftest.i conftest2.i conftest.out
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_lt_DD" >&5
++$as_echo "$ac_cv_path_lt_DD" >&6; }
++
++
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to truncate binary pipes" >&5
++$as_echo_n "checking how to truncate binary pipes... " >&6; }
++if ${lt_cv_truncate_bin+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  printf 0123456789abcdef0123456789abcdef >conftest.i
++cat conftest.i conftest.i >conftest2.i
++lt_cv_truncate_bin=
++if "$ac_cv_path_lt_DD" bs=32 count=1 <conftest2.i >conftest.out 2>/dev/null; then
++  cmp -s conftest.i conftest.out \
++  && lt_cv_truncate_bin="$ac_cv_path_lt_DD bs=4096 count=1"
++fi
++rm -f conftest.i conftest2.i conftest.out
++test -z "$lt_cv_truncate_bin" && lt_cv_truncate_bin="$SED -e 4q"
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_truncate_bin" >&5
++$as_echo "$lt_cv_truncate_bin" >&6; }
++
++
++
++
++
++
++
++# Calculate cc_basename.  Skip known compiler wrappers and cross-prefix.
++func_cc_basename ()
++{
++    for cc_temp in $*""; do
++      case $cc_temp in
++        compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
++        distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
++        \-*) ;;
++        *) break;;
++      esac
++    done
++    func_cc_basename_result=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++}
++
+ # Check whether --enable-libtool-lock was given.
+ if test "${enable_libtool_lock+set}" = set; then :
+   enableval=$enable_libtool_lock;
+ fi
+ 
+-test "x$enable_libtool_lock" != xno && enable_libtool_lock=yes
++test no = "$enable_libtool_lock" || enable_libtool_lock=yes
+ 
+ # Some flags need to be propagated to the compiler or linker for good
+ # libtool support.
+ case $host in
+ ia64-*-hpux*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set mode
++  # options accordingly.
+   echo 'int i;' > conftest.$ac_ext
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+   (eval $ac_compile) 2>&5
+@@ -7430,24 +7558,25 @@ ia64-*-hpux*)
+   test $ac_status = 0; }; then
+     case `/usr/bin/file conftest.$ac_objext` in
+       *ELF-32*)
+-	HPUX_IA64_MODE="32"
++	HPUX_IA64_MODE=32
+ 	;;
+       *ELF-64*)
+-	HPUX_IA64_MODE="64"
++	HPUX_IA64_MODE=64
+ 	;;
+     esac
+   fi
+   rm -rf conftest*
+   ;;
+ *-*-irix6*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.
+   echo '#line '$LINENO' "configure"' > conftest.$ac_ext
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+   (eval $ac_compile) 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-    if test "$lt_cv_prog_gnu_ld" = yes; then
++    if test yes = "$lt_cv_prog_gnu_ld"; then
+       case `/usr/bin/file conftest.$ac_objext` in
+ 	*32-bit*)
+ 	  LD="${LD-ld} -melf32bsmip"
+@@ -7476,9 +7605,50 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|ppc*-*linux*|powerpc*-*linux*| \
++mips64*-*linux*)
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.
++  echo '#line '$LINENO' "configure"' > conftest.$ac_ext
++  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
++  (eval $ac_compile) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++    emul=elf
++    case `/usr/bin/file conftest.$ac_objext` in
++      *32-bit*)
++	emul="${emul}32"
++	;;
++      *64-bit*)
++	emul="${emul}64"
++	;;
++    esac
++    case `/usr/bin/file conftest.$ac_objext` in
++      *MSB*)
++	emul="${emul}btsmip"
++	;;
++      *LSB*)
++	emul="${emul}ltsmip"
++	;;
++    esac
++    case `/usr/bin/file conftest.$ac_objext` in
++      *N32*)
++	emul="${emul}n32"
++	;;
++    esac
++    LD="${LD-ld} -m $emul"
++  fi
++  rm -rf conftest*
++  ;;
++
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.  Note that the listed cases only cover the
++  # situations where additional linker options are needed (such as when
++  # doing 32-bit compilation for a host where ld defaults to 64-bit, or
++  # vice versa); the common cases where no linker options are needed do
++  # not appear in the list.
+   echo 'int i;' > conftest.$ac_ext
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+   (eval $ac_compile) 2>&5
+@@ -7492,9 +7662,19 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+ 	  x86_64-*linux*)
+-	    LD="${LD-ld} -m elf_i386"
++	    case `/usr/bin/file conftest.o` in
++	      *x86-64*)
++		LD="${LD-ld} -m elf32_x86_64"
++		;;
++	      *)
++		LD="${LD-ld} -m elf_i386"
++		;;
++	    esac
++	    ;;
++	  powerpc64le-*linux*)
++	    LD="${LD-ld} -m elf32lppclinux"
+ 	    ;;
+-	  ppc64-*linux*|powerpc64-*linux*)
++	  powerpc64-*linux*)
+ 	    LD="${LD-ld} -m elf32ppclinux"
+ 	    ;;
+ 	  s390x-*linux*)
+@@ -7513,7 +7693,10 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*linux*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+-	  ppc*-*linux*|powerpc*-*linux*)
++	  powerpcle-*linux*)
++	    LD="${LD-ld} -m elf64lppc"
++	    ;;
++	  powerpc-*linux*)
+ 	    LD="${LD-ld} -m elf64ppc"
+ 	    ;;
+ 	  s390*-*linux*|s390*-*tpf*)
+@@ -7531,7 +7714,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 
+ *-*-sco3.2v5*)
+   # On SCO OpenServer 5, we need -belf to get full-featured binaries.
+-  SAVE_CFLAGS="$CFLAGS"
++  SAVE_CFLAGS=$CFLAGS
+   CFLAGS="$CFLAGS -belf"
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler needs -belf" >&5
+ $as_echo_n "checking whether the C compiler needs -belf... " >&6; }
+@@ -7571,13 +7754,14 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_cc_needs_belf" >&5
+ $as_echo "$lt_cv_cc_needs_belf" >&6; }
+-  if test x"$lt_cv_cc_needs_belf" != x"yes"; then
++  if test yes != "$lt_cv_cc_needs_belf"; then
+     # this is probably gcc 2.8.0, egcs 1.0 or newer; no need for -belf
+-    CFLAGS="$SAVE_CFLAGS"
++    CFLAGS=$SAVE_CFLAGS
+   fi
+   ;;
+ *-*solaris*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.
+   echo 'int i;' > conftest.$ac_ext
+   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+   (eval $ac_compile) 2>&5
+@@ -7589,7 +7773,7 @@ $as_echo "$lt_cv_cc_needs_belf" >&6; }
+       case $lt_cv_prog_gnu_ld in
+       yes*)
+         case $host in
+-        i?86-*-solaris*)
++        i?86-*-solaris*|x86_64-*-solaris*)
+           LD="${LD-ld} -m elf_x86_64"
+           ;;
+         sparc*-*-solaris*)
+@@ -7598,7 +7782,7 @@ $as_echo "$lt_cv_cc_needs_belf" >&6; }
+         esac
+         # GNU ld 2.21 introduced _sol2 emulations.  Use them if available.
+         if ${LD-ld} -V | grep _sol2 >/dev/null 2>&1; then
+-          LD="${LD-ld}_sol2"
++          LD=${LD-ld}_sol2
+         fi
+         ;;
+       *)
+@@ -7614,7 +7798,7 @@ $as_echo "$lt_cv_cc_needs_belf" >&6; }
+   ;;
+ esac
+ 
+-need_locks="$enable_libtool_lock"
++need_locks=$enable_libtool_lock
+ 
+ if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}mt", so it can be a program name with args.
+@@ -7725,7 +7909,7 @@ else
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_path_mainfest_tool" >&5
+ $as_echo "$lt_cv_path_mainfest_tool" >&6; }
+-if test "x$lt_cv_path_mainfest_tool" != xyes; then
++if test yes != "$lt_cv_path_mainfest_tool"; then
+   MANIFEST_TOOL=:
+ fi
+ 
+@@ -8228,7 +8412,7 @@ if ${lt_cv_apple_cc_single_mod+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   lt_cv_apple_cc_single_mod=no
+-      if test -z "${LT_MULTI_MODULE}"; then
++      if test -z "$LT_MULTI_MODULE"; then
+ 	# By default we will add the -single_module flag. You can override
+ 	# by either setting the environment variable LT_MULTI_MODULE
+ 	# non-empty at configure time, or by adding -multi_module to the
+@@ -8246,7 +8430,7 @@ else
+ 	  cat conftest.err >&5
+ 	# Otherwise, if the output was created with a 0 exit code from
+ 	# the compiler, it worked.
+-	elif test -f libconftest.dylib && test $_lt_result -eq 0; then
++	elif test -f libconftest.dylib && test 0 = "$_lt_result"; then
+ 	  lt_cv_apple_cc_single_mod=yes
+ 	else
+ 	  cat conftest.err >&5
+@@ -8285,7 +8469,7 @@ else
+ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+-	LDFLAGS="$save_LDFLAGS"
++	LDFLAGS=$save_LDFLAGS
+ 
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_exported_symbols_list" >&5
+@@ -8302,8 +8486,8 @@ int forced_loaded() { return 2;}
+ _LT_EOF
+       echo "$LTCC $LTCFLAGS -c -o conftest.o conftest.c" >&5
+       $LTCC $LTCFLAGS -c -o conftest.o conftest.c 2>&5
+-      echo "$AR cru libconftest.a conftest.o" >&5
+-      $AR cru libconftest.a conftest.o 2>&5
++      echo "$AR $AR_FLAGS libconftest.a conftest.o" >&5
++      $AR $AR_FLAGS libconftest.a conftest.o 2>&5
+       echo "$RANLIB libconftest.a" >&5
+       $RANLIB libconftest.a 2>&5
+       cat > conftest.c << _LT_EOF
+@@ -8314,7 +8498,7 @@ _LT_EOF
+       _lt_result=$?
+       if test -s conftest.err && $GREP force_load conftest.err; then
+ 	cat conftest.err >&5
+-      elif test -f conftest && test $_lt_result -eq 0 && $GREP forced_load conftest >/dev/null 2>&1 ; then
++      elif test -f conftest && test 0 = "$_lt_result" && $GREP forced_load conftest >/dev/null 2>&1; then
+ 	lt_cv_ld_force_load=yes
+       else
+ 	cat conftest.err >&5
+@@ -8327,32 +8511,32 @@ fi
+ $as_echo "$lt_cv_ld_force_load" >&6; }
+     case $host_os in
+     rhapsody* | darwin1.[012])
+-      _lt_dar_allow_undefined='${wl}-undefined ${wl}suppress' ;;
++      _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+-      _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++      _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+     darwin*) # darwin 5.x on
+       # if running on 10.5 or later, the deployment target defaults
+       # to the OS version, if on x86, and 10.4, the deployment
+       # target defaults to 10.4. Don't you love it?
+       case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+ 	10.0,*86*-darwin8*|10.0,*-darwin[91]*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+-	10.[012]*)
+-	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
++	10.[012][,.]*)
++	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+ 	10.*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
++	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;
+   esac
+-    if test "$lt_cv_apple_cc_single_mod" = "yes"; then
++    if test yes = "$lt_cv_apple_cc_single_mod"; then
+       _lt_dar_single_mod='$single_module'
+     fi
+-    if test "$lt_cv_ld_exported_symbols_list" = "yes"; then
+-      _lt_dar_export_syms=' ${wl}-exported_symbols_list,$output_objdir/${libname}-symbols.expsym'
++    if test yes = "$lt_cv_ld_exported_symbols_list"; then
++      _lt_dar_export_syms=' $wl-exported_symbols_list,$output_objdir/$libname-symbols.expsym'
+     else
+-      _lt_dar_export_syms='~$NMEDIT -s $output_objdir/${libname}-symbols.expsym ${lib}'
++      _lt_dar_export_syms='~$NMEDIT -s $output_objdir/$libname-symbols.expsym $lib'
+     fi
+-    if test "$DSYMUTIL" != ":" && test "$lt_cv_ld_force_load" = "no"; then
++    if test : != "$DSYMUTIL" && test no = "$lt_cv_ld_force_load"; then
+       _lt_dsymutil='~$DSYMUTIL $lib || :'
+     else
+       _lt_dsymutil=
+@@ -8360,6 +8544,41 @@ $as_echo "$lt_cv_ld_force_load" >&6; }
+     ;;
+   esac
+ 
++# func_munge_path_list VARIABLE PATH
++# -----------------------------------
++# VARIABLE is name of variable containing _space_ separated list of
++# directories to be munged by the contents of PATH, which is string
++# having a format:
++# "DIR[:DIR]:"
++#       string "DIR[ DIR]" will be prepended to VARIABLE
++# ":DIR[:DIR]"
++#       string "DIR[ DIR]" will be appended to VARIABLE
++# "DIRP[:DIRP]::[DIRA:]DIRA"
++#       string "DIRP[ DIRP]" will be prepended to VARIABLE and string
++#       "DIRA[ DIRA]" will be appended to VARIABLE
++# "DIR[:DIR]"
++#       VARIABLE will be replaced by "DIR[ DIR]"
++func_munge_path_list ()
++{
++    case x$2 in
++    x)
++        ;;
++    *:)
++        eval $1=\"`$ECHO $2 | $SED 's/:/ /g'` \$$1\"
++        ;;
++    x:*)
++        eval $1=\"\$$1 `$ECHO $2 | $SED 's/:/ /g'`\"
++        ;;
++    *::*)
++        eval $1=\"\$$1\ `$ECHO $2 | $SED -e 's/.*:://' -e 's/:/ /g'`\"
++        eval $1=\"`$ECHO $2 | $SED -e 's/::.*//' -e 's/:/ /g'`\ \$$1\"
++        ;;
++    *)
++        eval $1=\"`$ECHO $2 | $SED 's/:/ /g'`\"
++        ;;
++    esac
++}
++
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -8645,9 +8864,9 @@ done
+ 
+ func_stripname_cnf ()
+ {
+-  case ${2} in
+-  .*) func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%\\\\${2}\$%%"`;;
+-  *)  func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%${2}\$%%"`;;
++  case $2 in
++  .*) func_stripname_result=`$ECHO "$3" | $SED "s%^$1%%; s%\\\\$2\$%%"`;;
++  *)  func_stripname_result=`$ECHO "$3" | $SED "s%^$1%%; s%$2\$%%"`;;
+   esac
+ } # func_stripname_cnf
+ 
+@@ -8674,14 +8893,14 @@ if test "${enable_shared+set}" = set; then :
+     *)
+       enable_shared=no
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for pkg in $enableval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$pkg" = "X$p"; then
+ 	  enable_shared=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac
+ else
+@@ -8705,14 +8924,14 @@ if test "${enable_static+set}" = set; then :
+     *)
+      enable_static=no
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for pkg in $enableval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$pkg" = "X$p"; then
+ 	  enable_static=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac
+ else
+@@ -8736,14 +8955,14 @@ if test "${with_pic+set}" = set; then :
+     *)
+       pic_mode=default
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for lt_pkg in $withval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$lt_pkg" = "X$lt_p"; then
+ 	  pic_mode=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac
+ else
+@@ -8751,8 +8970,6 @@ else
+ fi
+ 
+ 
+-test -z "$pic_mode" && pic_mode=default
+-
+ 
+ 
+ 
+@@ -8768,14 +8985,14 @@ if test "${enable_fast_install+set}" = set; then :
+     *)
+       enable_fast_install=no
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for pkg in $enableval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$pkg" = "X$p"; then
+ 	  enable_fast_install=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac
+ else
+@@ -8789,11 +9006,63 @@ fi
+ 
+ 
+ 
++  shared_archive_member_spec=
++case $host,$enable_shared in
++power*-*-aix[5-9]*,yes)
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking which variant of shared library versioning to provide" >&5
++$as_echo_n "checking which variant of shared library versioning to provide... " >&6; }
++
++# Check whether --with-aix-soname was given.
++if test "${with_aix_soname+set}" = set; then :
++  withval=$with_aix_soname; case $withval in
++    aix|svr4|both)
++      ;;
++    *)
++      as_fn_error $? "Unknown argument to --with-aix-soname" "$LINENO" 5
++      ;;
++    esac
++    lt_cv_with_aix_soname=$with_aix_soname
++else
++  if ${lt_cv_with_aix_soname+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  lt_cv_with_aix_soname=aix
++fi
++
++    with_aix_soname=$lt_cv_with_aix_soname
++fi
++
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_aix_soname" >&5
++$as_echo "$with_aix_soname" >&6; }
++  if test aix != "$with_aix_soname"; then
++    # For the AIX way of multilib, we name the shared archive member
++    # based on the bitwidth used, traditionally 'shr.o' or 'shr_64.o',
++    # and 'shr.imp' or 'shr_64.imp', respectively, for the Import File.
++    # Even when GNU compilers ignore OBJECT_MODE but need '-maix64' flag,
++    # the AIX toolchain works better with OBJECT_MODE set (default 32).
++    if test 64 = "${OBJECT_MODE-32}"; then
++      shared_archive_member_spec=shr_64
++    else
++      shared_archive_member_spec=shr
++    fi
++  fi
++  ;;
++*)
++  with_aix_soname=aix
++  ;;
++esac
++
++
++
++
++
++
++
+ 
+ 
+ 
+ # This can be used to rebuild libtool when needed
+-LIBTOOL_DEPS="$ltmain"
++LIBTOOL_DEPS=$ltmain
+ 
+ # Always use our own libtool.
+ LIBTOOL='$(SHELL) $(top_builddir)/libtool'
+@@ -8842,7 +9111,7 @@ test -z "$LN_S" && LN_S="ln -s"
+ 
+ 
+ 
+-if test -n "${ZSH_VERSION+set}" ; then
++if test -n "${ZSH_VERSION+set}"; then
+    setopt NO_GLOB_SUBST
+ fi
+ 
+@@ -8881,7 +9150,7 @@ aix3*)
+   # AIX sometimes has problems with the GCC collect2 program.  For some
+   # reason, if we set the COLLECT_NAMES environment variable, the problems
+   # vanish in a puff of smoke.
+-  if test "X${COLLECT_NAMES+set}" != Xset; then
++  if test set != "${COLLECT_NAMES+set}"; then
+     COLLECT_NAMES=
+     export COLLECT_NAMES
+   fi
+@@ -8892,14 +9161,14 @@ esac
+ ofile=libtool
+ can_build_shared=yes
+ 
+-# All known linkers require a `.a' archive for static linking (except MSVC,
++# All known linkers require a '.a' archive for static linking (except MSVC,
+ # which needs '.lib').
+ libext=a
+ 
+-with_gnu_ld="$lt_cv_prog_gnu_ld"
++with_gnu_ld=$lt_cv_prog_gnu_ld
+ 
+-old_CC="$CC"
+-old_CFLAGS="$CFLAGS"
++old_CC=$CC
++old_CFLAGS=$CFLAGS
+ 
+ # Set sane defaults for various variables
+ test -z "$CC" && CC=cc
+@@ -8908,15 +9177,8 @@ test -z "$LTCFLAGS" && LTCFLAGS=$CFLAGS
+ test -z "$LD" && LD=ld
+ test -z "$ac_objext" && ac_objext=o
+ 
+-for cc_temp in $compiler""; do
+-  case $cc_temp in
+-    compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
+-    distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
+-    \-*) ;;
+-    *) break;;
+-  esac
+-done
+-cc_basename=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++func_cc_basename $compiler
++cc_basename=$func_cc_basename_result
+ 
+ 
+ # Only perform the check for file, if the check method requires it
+@@ -8931,22 +9193,22 @@ if ${lt_cv_path_MAGIC_CMD+:} false; then :
+ else
+   case $MAGIC_CMD in
+ [\\/*] |  ?:[\\/]*)
+-  lt_cv_path_MAGIC_CMD="$MAGIC_CMD" # Let the user override the test with a path.
++  lt_cv_path_MAGIC_CMD=$MAGIC_CMD # Let the user override the test with a path.
+   ;;
+ *)
+-  lt_save_MAGIC_CMD="$MAGIC_CMD"
+-  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  lt_save_MAGIC_CMD=$MAGIC_CMD
++  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+   ac_dummy="/usr/bin$PATH_SEPARATOR$PATH"
+   for ac_dir in $ac_dummy; do
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+     test -z "$ac_dir" && ac_dir=.
+-    if test -f $ac_dir/${ac_tool_prefix}file; then
+-      lt_cv_path_MAGIC_CMD="$ac_dir/${ac_tool_prefix}file"
++    if test -f "$ac_dir/${ac_tool_prefix}file"; then
++      lt_cv_path_MAGIC_CMD=$ac_dir/"${ac_tool_prefix}file"
+       if test -n "$file_magic_test_file"; then
+ 	case $deplibs_check_method in
+ 	"file_magic "*)
+ 	  file_magic_regex=`expr "$deplibs_check_method" : "file_magic \(.*\)"`
+-	  MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++	  MAGIC_CMD=$lt_cv_path_MAGIC_CMD
+ 	  if eval $file_magic_cmd \$file_magic_test_file 2> /dev/null |
+ 	    $EGREP "$file_magic_regex" > /dev/null; then
+ 	    :
+@@ -8969,13 +9231,13 @@ _LT_EOF
+       break
+     fi
+   done
+-  IFS="$lt_save_ifs"
+-  MAGIC_CMD="$lt_save_MAGIC_CMD"
++  IFS=$lt_save_ifs
++  MAGIC_CMD=$lt_save_MAGIC_CMD
+   ;;
+ esac
+ fi
+ 
+-MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++MAGIC_CMD=$lt_cv_path_MAGIC_CMD
+ if test -n "$MAGIC_CMD"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MAGIC_CMD" >&5
+ $as_echo "$MAGIC_CMD" >&6; }
+@@ -8997,22 +9259,22 @@ if ${lt_cv_path_MAGIC_CMD+:} false; then :
+ else
+   case $MAGIC_CMD in
+ [\\/*] |  ?:[\\/]*)
+-  lt_cv_path_MAGIC_CMD="$MAGIC_CMD" # Let the user override the test with a path.
++  lt_cv_path_MAGIC_CMD=$MAGIC_CMD # Let the user override the test with a path.
+   ;;
+ *)
+-  lt_save_MAGIC_CMD="$MAGIC_CMD"
+-  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  lt_save_MAGIC_CMD=$MAGIC_CMD
++  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+   ac_dummy="/usr/bin$PATH_SEPARATOR$PATH"
+   for ac_dir in $ac_dummy; do
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+     test -z "$ac_dir" && ac_dir=.
+-    if test -f $ac_dir/file; then
+-      lt_cv_path_MAGIC_CMD="$ac_dir/file"
++    if test -f "$ac_dir/file"; then
++      lt_cv_path_MAGIC_CMD=$ac_dir/"file"
+       if test -n "$file_magic_test_file"; then
+ 	case $deplibs_check_method in
+ 	"file_magic "*)
+ 	  file_magic_regex=`expr "$deplibs_check_method" : "file_magic \(.*\)"`
+-	  MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++	  MAGIC_CMD=$lt_cv_path_MAGIC_CMD
+ 	  if eval $file_magic_cmd \$file_magic_test_file 2> /dev/null |
+ 	    $EGREP "$file_magic_regex" > /dev/null; then
+ 	    :
+@@ -9035,13 +9297,13 @@ _LT_EOF
+       break
+     fi
+   done
+-  IFS="$lt_save_ifs"
+-  MAGIC_CMD="$lt_save_MAGIC_CMD"
++  IFS=$lt_save_ifs
++  MAGIC_CMD=$lt_save_MAGIC_CMD
+   ;;
+ esac
+ fi
+ 
+-MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++MAGIC_CMD=$lt_cv_path_MAGIC_CMD
+ if test -n "$MAGIC_CMD"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MAGIC_CMD" >&5
+ $as_echo "$MAGIC_CMD" >&6; }
+@@ -9062,7 +9324,7 @@ esac
+ 
+ # Use C for the default configuration in the libtool script
+ 
+-lt_save_CC="$CC"
++lt_save_CC=$CC
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -9124,7 +9386,7 @@ if test -n "$compiler"; then
+ 
+ lt_prog_compiler_no_builtin_flag=
+ 
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   case $cc_basename in
+   nvcc*)
+     lt_prog_compiler_no_builtin_flag=' -Xcompiler -fno-builtin' ;;
+@@ -9140,7 +9402,7 @@ else
+   lt_cv_prog_compiler_rtti_exceptions=no
+    ac_outfile=conftest.$ac_objext
+    echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-   lt_compiler_flag="-fno-rtti -fno-exceptions"
++   lt_compiler_flag="-fno-rtti -fno-exceptions"  ## exclude from sc_useless_quotes_in_assignment
+    # Insert the option either (1) after the last *FLAGS variable, or
+    # (2) before a word containing "conftest.", or (3) at the end.
+    # Note that $ac_compile itself does not contain backslashes and begins
+@@ -9170,7 +9432,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_rtti_exceptions" >&5
+ $as_echo "$lt_cv_prog_compiler_rtti_exceptions" >&6; }
+ 
+-if test x"$lt_cv_prog_compiler_rtti_exceptions" = xyes; then
++if test yes = "$lt_cv_prog_compiler_rtti_exceptions"; then
+     lt_prog_compiler_no_builtin_flag="$lt_prog_compiler_no_builtin_flag -fno-rtti -fno-exceptions"
+ else
+     :
+@@ -9188,17 +9450,18 @@ lt_prog_compiler_pic=
+ lt_prog_compiler_static=
+ 
+ 
+-  if test "$GCC" = yes; then
++  if test yes = "$GCC"; then
+     lt_prog_compiler_wl='-Wl,'
+     lt_prog_compiler_static='-static'
+ 
+     case $host_os in
+       aix*)
+       # All AIX code is PIC.
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	lt_prog_compiler_static='-Bstatic'
+       fi
++      lt_prog_compiler_pic='-fPIC'
+       ;;
+ 
+     amigaos*)
+@@ -9209,8 +9472,8 @@ lt_prog_compiler_static=
+         ;;
+       m68k)
+             # FIXME: we need at least 68020 code to build shared libraries, but
+-            # adding the `-m68020' flag to GCC prevents building anything better,
+-            # like `-m68040'.
++            # adding the '-m68020' flag to GCC prevents building anything better,
++            # like '-m68040'.
+             lt_prog_compiler_pic='-m68020 -resident32 -malways-restore-a4'
+         ;;
+       esac
+@@ -9226,6 +9489,11 @@ lt_prog_compiler_static=
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+       # (--disable-auto-import) libraries
+       lt_prog_compiler_pic='-DDLL_EXPORT'
++      case $host_os in
++      os2*)
++	lt_prog_compiler_static='$wl-static'
++	;;
++      esac
+       ;;
+ 
+     darwin* | rhapsody*)
+@@ -9296,7 +9564,7 @@ lt_prog_compiler_static=
+     case $host_os in
+     aix*)
+       lt_prog_compiler_wl='-Wl,'
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	lt_prog_compiler_static='-Bstatic'
+       else
+@@ -9304,10 +9572,29 @@ lt_prog_compiler_static=
+       fi
+       ;;
+ 
++    darwin* | rhapsody*)
++      # PIC is the default on this platform
++      # Common symbols not allowed in MH_DYLIB files
++      lt_prog_compiler_pic='-fno-common'
++      case $cc_basename in
++      nagfor*)
++        # NAG Fortran compiler
++        lt_prog_compiler_wl='-Wl,-Wl,,'
++        lt_prog_compiler_pic='-PIC'
++        lt_prog_compiler_static='-Bstatic'
++        ;;
++      esac
++      ;;
++
+     mingw* | cygwin* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       lt_prog_compiler_pic='-DDLL_EXPORT'
++      case $host_os in
++      os2*)
++	lt_prog_compiler_static='$wl-static'
++	;;
++      esac
+       ;;
+ 
+     hpux9* | hpux10* | hpux11*)
+@@ -9323,7 +9610,7 @@ lt_prog_compiler_static=
+ 	;;
+       esac
+       # Is there a better lt_prog_compiler_static that works with the bundled CC?
+-      lt_prog_compiler_static='${wl}-a ${wl}archive'
++      lt_prog_compiler_static='$wl-a ${wl}archive'
+       ;;
+ 
+     irix5* | irix6* | nonstopux*)
+@@ -9332,9 +9619,9 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-non_shared'
+       ;;
+ 
+-    linux* | k*bsd*-gnu | kopensolaris*-gnu)
++    linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+       case $cc_basename in
+-      # old Intel for x86_64 which still supported -KPIC.
++      # old Intel for x86_64, which still supported -KPIC.
+       ecc*)
+ 	lt_prog_compiler_wl='-Wl,'
+ 	lt_prog_compiler_pic='-KPIC'
+@@ -9359,6 +9646,12 @@ lt_prog_compiler_static=
+ 	lt_prog_compiler_pic='-PIC'
+ 	lt_prog_compiler_static='-Bstatic'
+ 	;;
++      tcc*)
++	# Fabrice Bellard et al's Tiny C Compiler
++	lt_prog_compiler_wl='-Wl,'
++	lt_prog_compiler_pic='-fPIC'
++	lt_prog_compiler_static='-static'
++	;;
+       pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)
+         # Portland Group compilers (*not* the Pentium gcc compiler,
+ 	# which looks to be a dead project)
+@@ -9456,7 +9749,7 @@ lt_prog_compiler_static=
+       ;;
+ 
+     sysv4*MP*)
+-      if test -d /usr/nec ;then
++      if test -d /usr/nec; then
+ 	lt_prog_compiler_pic='-Kconform_pic'
+ 	lt_prog_compiler_static='-Bstatic'
+       fi
+@@ -9485,7 +9778,7 @@ lt_prog_compiler_static=
+   fi
+ 
+ case $host_os in
+-  # For platforms which do not support PIC, -DPIC is meaningless:
++  # For platforms that do not support PIC, -DPIC is meaningless:
+   *djgpp*)
+     lt_prog_compiler_pic=
+     ;;
+@@ -9517,7 +9810,7 @@ else
+   lt_cv_prog_compiler_pic_works=no
+    ac_outfile=conftest.$ac_objext
+    echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-   lt_compiler_flag="$lt_prog_compiler_pic -DPIC"
++   lt_compiler_flag="$lt_prog_compiler_pic -DPIC"  ## exclude from sc_useless_quotes_in_assignment
+    # Insert the option either (1) after the last *FLAGS variable, or
+    # (2) before a word containing "conftest.", or (3) at the end.
+    # Note that $ac_compile itself does not contain backslashes and begins
+@@ -9547,7 +9840,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic_works" >&5
+ $as_echo "$lt_cv_prog_compiler_pic_works" >&6; }
+ 
+-if test x"$lt_cv_prog_compiler_pic_works" = xyes; then
++if test yes = "$lt_cv_prog_compiler_pic_works"; then
+     case $lt_prog_compiler_pic in
+      "" | " "*) ;;
+      *) lt_prog_compiler_pic=" $lt_prog_compiler_pic" ;;
+@@ -9579,7 +9872,7 @@ if ${lt_cv_prog_compiler_static_works+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   lt_cv_prog_compiler_static_works=no
+-   save_LDFLAGS="$LDFLAGS"
++   save_LDFLAGS=$LDFLAGS
+    LDFLAGS="$LDFLAGS $lt_tmp_static_flag"
+    echo "$lt_simple_link_test_code" > conftest.$ac_ext
+    if (eval $ac_link 2>conftest.err) && test -s conftest$ac_exeext; then
+@@ -9598,13 +9891,13 @@ else
+      fi
+    fi
+    $RM -r conftest*
+-   LDFLAGS="$save_LDFLAGS"
++   LDFLAGS=$save_LDFLAGS
+ 
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_static_works" >&5
+ $as_echo "$lt_cv_prog_compiler_static_works" >&6; }
+ 
+-if test x"$lt_cv_prog_compiler_static_works" = xyes; then
++if test yes = "$lt_cv_prog_compiler_static_works"; then
+     :
+ else
+     lt_prog_compiler_static=
+@@ -9724,8 +10017,8 @@ $as_echo "$lt_cv_prog_compiler_c_o" >&6; }
+ 
+ 
+ 
+-hard_links="nottested"
+-if test "$lt_cv_prog_compiler_c_o" = no && test "$need_locks" != no; then
++hard_links=nottested
++if test no = "$lt_cv_prog_compiler_c_o" && test no != "$need_locks"; then
+   # do not overwrite the value of need_locks provided by the user
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can lock with hard links" >&5
+ $as_echo_n "checking if we can lock with hard links... " >&6; }
+@@ -9737,9 +10030,9 @@ $as_echo_n "checking if we can lock with hard links... " >&6; }
+   ln conftest.a conftest.b 2>/dev/null && hard_links=no
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $hard_links" >&5
+ $as_echo "$hard_links" >&6; }
+-  if test "$hard_links" = no; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe" >&5
+-$as_echo "$as_me: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe" >&2;}
++  if test no = "$hard_links"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&5
++$as_echo "$as_me: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&2;}
+     need_locks=warn
+   fi
+ else
+@@ -9782,9 +10075,9 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   # included in the symbol list
+   include_expsyms=
+   # exclude_expsyms can be an extended regexp of symbols to exclude
+-  # it will be wrapped by ` (' and `)$', so one must not match beginning or
+-  # end of line.  Example: `a|bc|.*d.*' will exclude the symbols `a' and `bc',
+-  # as well as any symbol that contains `d'.
++  # it will be wrapped by ' (' and ')$', so one must not match beginning or
++  # end of line.  Example: 'a|bc|.*d.*' will exclude the symbols 'a' and 'bc',
++  # as well as any symbol that contains 'd'.
+   exclude_expsyms='_GLOBAL_OFFSET_TABLE_|_GLOBAL__F[ID]_.*'
+   # Although _GLOBAL_OFFSET_TABLE_ is a valid symbol C name, most a.out
+   # platforms (ab)use it in PIC code, but their linkers get confused if
+@@ -9799,7 +10092,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+-    if test "$GCC" != yes; then
++    if test yes != "$GCC"; then
+       with_gnu_ld=no
+     fi
+     ;;
+@@ -9807,7 +10100,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+     # we just hope/assume this is gcc and not c89 (= MSVC++)
+     with_gnu_ld=yes
+     ;;
+-  openbsd*)
++  openbsd* | bitrig*)
+     with_gnu_ld=no
+     ;;
+   esac
+@@ -9817,7 +10110,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   # On some targets, GNU ld is compatible enough with the native linker
+   # that we're better off using the native interface for both.
+   lt_use_gnu_ld_interface=no
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     case $host_os in
+       aix*)
+ 	# The AIX port of GNU ld has always aspired to compatibility
+@@ -9839,24 +10132,24 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+     esac
+   fi
+ 
+-  if test "$lt_use_gnu_ld_interface" = yes; then
++  if test yes = "$lt_use_gnu_ld_interface"; then
+     # If archive_cmds runs LD, not CC, wlarc should be empty
+-    wlarc='${wl}'
++    wlarc='$wl'
+ 
+     # Set some defaults for GNU ld with shared library support. These
+     # are reset later if shared libraries are not supported. Putting them
+     # here allows them to be overridden if necessary.
+     runpath_var=LD_RUN_PATH
+-    hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+-    export_dynamic_flag_spec='${wl}--export-dynamic'
++    hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
++    export_dynamic_flag_spec='$wl--export-dynamic'
+     # ancient GNU ld didn't support --whole-archive et. al.
+     if $LD --help 2>&1 | $GREP 'no-whole-archive' > /dev/null; then
+-      whole_archive_flag_spec="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++      whole_archive_flag_spec=$wlarc'--whole-archive$convenience '$wlarc'--no-whole-archive'
+     else
+       whole_archive_flag_spec=
+     fi
+     supports_anon_versioning=no
+-    case `$LD -v 2>&1` in
++    case `$LD -v | $SED -e 's/(^)\+)\s\+//' 2>&1` in
+       *GNU\ gold*) supports_anon_versioning=yes ;;
+       *\ [01].* | *\ 2.[0-9].* | *\ 2.10.*) ;; # catch versions < 2.11
+       *\ 2.11.93.0.2\ *) supports_anon_versioning=yes ;; # RH7.3 ...
+@@ -9869,7 +10162,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+     case $host_os in
+     aix[3-9]*)
+       # On AIX/PPC, the GNU linker is very broken
+-      if test "$host_cpu" != ia64; then
++      if test ia64 != "$host_cpu"; then
+ 	ld_shlibs=no
+ 	cat <<_LT_EOF 1>&2
+ 
+@@ -9888,7 +10181,7 @@ _LT_EOF
+       case $host_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+-            archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++            archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+             archive_expsym_cmds=''
+         ;;
+       m68k)
+@@ -9904,7 +10197,7 @@ _LT_EOF
+ 	allow_undefined_flag=unsupported
+ 	# Joseph Beckenbach <jrb3@best.com> says some releases of gcc
+ 	# support --undefined.  This deserves some investigation.  FIXME
+-	archive_cmds='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	archive_cmds='$CC -nostart $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+       else
+ 	ld_shlibs=no
+       fi
+@@ -9914,7 +10207,7 @@ _LT_EOF
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, ) is actually meaningless,
+       # as there is no search path for DLLs.
+       hardcode_libdir_flag_spec='-L$libdir'
+-      export_dynamic_flag_spec='${wl}--export-all-symbols'
++      export_dynamic_flag_spec='$wl--export-all-symbols'
+       allow_undefined_flag=unsupported
+       always_export_symbols=no
+       enable_shared_with_static_runtimes=yes
+@@ -9922,61 +10215,90 @@ _LT_EOF
+       exclude_expsyms='[_]+GLOBAL_OFFSET_TABLE_|[_]+GLOBAL__[FID]_.*|[_]+head_[A-Za-z0-9_]+_dll|[A-Za-z0-9_]+_dll_iname'
+ 
+       if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+-        archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-	# If the export-symbols file already is a .def file (1st line
+-	# is EXPORTS), use it as is; otherwise, prepend...
+-	archive_expsym_cmds='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	  cp $export_symbols $output_objdir/$soname.def;
+-	else
+-	  echo EXPORTS > $output_objdir/$soname.def;
+-	  cat $export_symbols >> $output_objdir/$soname.def;
+-	fi~
+-	$CC -shared $output_objdir/$soname.def $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++        archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	# If the export-symbols file already is a .def file, use it as
++	# is; otherwise, prepend EXPORTS...
++	archive_expsym_cmds='if   test DEF = "`$SED -n     -e '\''s/^[	 ]*//'\''     -e '\''/^\(;.*\)*$/d'\''     -e '\''s/^\(EXPORTS\|LIBRARY\)\([	 ].*\)*$/DEF/p'\''     -e q     $export_symbols`" ; then
++          cp $export_symbols $output_objdir/$soname.def;
++        else
++          echo EXPORTS > $output_objdir/$soname.def;
++          cat $export_symbols >> $output_objdir/$soname.def;
++        fi~
++        $CC -shared $output_objdir/$soname.def $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+       else
+ 	ld_shlibs=no
+       fi
+       ;;
+ 
+     haiku*)
+-      archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++      archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+       link_all_deplibs=yes
+       ;;
+ 
++    os2*)
++      hardcode_libdir_flag_spec='-L$libdir'
++      hardcode_minus_L=yes
++      allow_undefined_flag=unsupported
++      shrext_cmds=.dll
++      archive_cmds='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	emxexp $libobjs | $SED /"_DLL_InitTerm"/d >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      archive_expsym_cmds='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	prefix_cmds="$SED"~
++	if test EXPORTS = "`$SED 1q $export_symbols`"; then
++	  prefix_cmds="$prefix_cmds -e 1d";
++	fi~
++	prefix_cmds="$prefix_cmds -e \"s/^\(.*\)$/_\1/g\""~
++	cat $export_symbols | $prefix_cmds >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      old_archive_From_new_cmds='emximp -o $output_objdir/${libname}_dll.a $output_objdir/$libname.def'
++      enable_shared_with_static_runtimes=yes
++      file_list_spec='@'
++      ;;
++
+     interix[3-9]*)
+       hardcode_direct=no
+       hardcode_shlibpath_var=no
+-      hardcode_libdir_flag_spec='${wl}-rpath,$libdir'
+-      export_dynamic_flag_spec='${wl}-E'
++      hardcode_libdir_flag_spec='$wl-rpath,$libdir'
++      export_dynamic_flag_spec='$wl-E'
+       # Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
+       # Instead, shared libraries are loaded at an image base (0x10000000 by
+       # default) and relocated if they conflict, which is a slow very memory
+       # consuming and fragmenting process.  To avoid this, we pick a random,
+       # 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
+       # time.  Moving up from 0x10000000 also allows more sbrk(2) space.
+-      archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+-      archive_expsym_cmds='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++      archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++      archive_expsym_cmds='sed "s|^|_|" $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--retain-symbols-file,$output_objdir/$soname.expsym $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+       ;;
+ 
+     gnu* | linux* | tpf* | k*bsd*-gnu | kopensolaris*-gnu)
+       tmp_diet=no
+-      if test "$host_os" = linux-dietlibc; then
++      if test linux-dietlibc = "$host_os"; then
+ 	case $cc_basename in
+ 	  diet\ *) tmp_diet=yes;;	# linux-dietlibc with static linking (!diet-dyn)
+ 	esac
+       fi
+       if $LD --help 2>&1 | $EGREP ': supported targets:.* elf' > /dev/null \
+-	 && test "$tmp_diet" = no
++	 && test no = "$tmp_diet"
+       then
+ 	tmp_addflag=' $pic_flag'
+ 	tmp_sharedflag='-shared'
+ 	case $cc_basename,$host_cpu in
+         pgcc*)				# Portland Group C compiler
+-	  whole_archive_flag_spec='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  whole_archive_flag_spec='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag'
+ 	  ;;
+ 	pgf77* | pgf90* | pgf95* | pgfortran*)
+ 					# Portland Group f77 and f90 compilers
+-	  whole_archive_flag_spec='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  whole_archive_flag_spec='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag -Mnomain' ;;
+ 	ecc*,ia64* | icc*,ia64*)	# Intel C compiler on ia64
+ 	  tmp_addflag=' -i_dynamic' ;;
+@@ -9987,42 +10309,47 @@ _LT_EOF
+ 	lf95*)				# Lahey Fortran 8.1
+ 	  whole_archive_flag_spec=
+ 	  tmp_sharedflag='--shared' ;;
++        nagfor*)                        # NAGFOR 5.3
++          tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+ 	  tmp_addflag= ;;
+ 	nvcc*)	# Cuda Compiler Driver 2.2
+-	  whole_archive_flag_spec='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  whole_archive_flag_spec='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  compiler_needs_object=yes
+ 	  ;;
+ 	esac
+ 	case `$CC -V 2>&1 | sed 5q` in
+ 	*Sun\ C*)			# Sun C 5.9
+-	  whole_archive_flag_spec='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  whole_archive_flag_spec='$wl--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  compiler_needs_object=yes
+ 	  tmp_sharedflag='-G' ;;
+ 	*Sun\ F*)			# Sun Fortran 8.3
+ 	  tmp_sharedflag='-G' ;;
+ 	esac
+-	archive_cmds='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	archive_cmds='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+ 
+-        if test "x$supports_anon_versioning" = xyes; then
++        if test yes = "$supports_anon_versioning"; then
+           archive_expsym_cmds='echo "{ global:" > $output_objdir/$libname.ver~
+-	    cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-	    echo "local: *; };" >> $output_objdir/$libname.ver~
+-	    $CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
++            cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++            echo "local: *; };" >> $output_objdir/$libname.ver~
++            $CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-version-script $wl$output_objdir/$libname.ver -o $lib'
+         fi
+ 
+ 	case $cc_basename in
++	tcc*)
++	  export_dynamic_flag_spec='-rdynamic'
++	  ;;
+ 	xlf* | bgf* | bgxlf* | mpixlf*)
+ 	  # IBM XL Fortran 10.1 on PPC cannot create shared libs itself
+ 	  whole_archive_flag_spec='--whole-archive$convenience --no-whole-archive'
+-	  hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
++	  hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
+ 	  archive_cmds='$LD -shared $libobjs $deplibs $linker_flags -soname $soname -o $lib'
+-	  if test "x$supports_anon_versioning" = xyes; then
++	  if test yes = "$supports_anon_versioning"; then
+ 	    archive_expsym_cmds='echo "{ global:" > $output_objdir/$libname.ver~
+-	      cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-	      echo "local: *; };" >> $output_objdir/$libname.ver~
+-	      $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
++              cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++              echo "local: *; };" >> $output_objdir/$libname.ver~
++              $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
+ 	  fi
+ 	  ;;
+ 	esac
+@@ -10036,8 +10363,8 @@ _LT_EOF
+ 	archive_cmds='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
+ 	wlarc=
+       else
+-	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+       fi
+       ;;
+ 
+@@ -10055,8 +10382,8 @@ _LT_EOF
+ 
+ _LT_EOF
+       elif $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+       else
+ 	ld_shlibs=no
+       fi
+@@ -10068,7 +10395,7 @@ _LT_EOF
+ 	ld_shlibs=no
+ 	cat <<_LT_EOF 1>&2
+ 
+-*** Warning: Releases of the GNU linker prior to 2.16.91.0.3 can not
++*** Warning: Releases of the GNU linker prior to 2.16.91.0.3 cannot
+ *** reliably create shared libraries on SCO systems.  Therefore, libtool
+ *** is disabling shared libraries support.  We urge you to upgrade GNU
+ *** binutils to release 2.16.91.0.3 or newer.  Another option is to modify
+@@ -10083,9 +10410,9 @@ _LT_EOF
+ 	  # DT_RUNPATH tag from executables and libraries.  But doing so
+ 	  # requires that you compile everything twice, which is a pain.
+ 	  if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	    hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
+-	    archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    archive_expsym_cmds='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	    hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
++	    archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	    archive_expsym_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	  else
+ 	    ld_shlibs=no
+ 	  fi
+@@ -10102,15 +10429,15 @@ _LT_EOF
+ 
+     *)
+       if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+       else
+ 	ld_shlibs=no
+       fi
+       ;;
+     esac
+ 
+-    if test "$ld_shlibs" = no; then
++    if test no = "$ld_shlibs"; then
+       runpath_var=
+       hardcode_libdir_flag_spec=
+       export_dynamic_flag_spec=
+@@ -10126,7 +10453,7 @@ _LT_EOF
+       # Note: this linker hardcodes the directories in LIBPATH if there
+       # are no directories specified by -L.
+       hardcode_minus_L=yes
+-      if test "$GCC" = yes && test -z "$lt_prog_compiler_static"; then
++      if test yes = "$GCC" && test -z "$lt_prog_compiler_static"; then
+ 	# Neither direct hardcoding nor static linking is supported with a
+ 	# broken collect2.
+ 	hardcode_direct=unsupported
+@@ -10134,34 +10461,57 @@ _LT_EOF
+       ;;
+ 
+     aix[4-9]*)
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# On IA64, the linker does run time linking by default, so we don't
+ 	# have to do anything special.
+ 	aix_use_runtimelinking=no
+ 	exp_sym_flag='-Bexport'
+-	no_entry_flag=""
++	no_entry_flag=
+       else
+ 	# If we're using GNU nm, then we don't want the "-C" option.
+-	# -C means demangle to AIX nm, but means don't demangle with GNU nm
+-	# Also, AIX nm treats weak defined symbols like other global
+-	# defined symbols, whereas GNU nm marks them as "W".
++	# -C means demangle to GNU nm, but means don't demangle to AIX nm.
++	# Without the "-l" option, or with the "-B" option, AIX nm treats
++	# weak defined symbols like other global defined symbols, whereas
++	# GNU nm marks them as "W".
++	# While the 'weak' keyword is ignored in the Export File, we need
++	# it in the Import File for the 'aix-soname' feature, so we have
++	# to replace the "-B" option with "-P" for AIX nm.
+ 	if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
+-	  export_symbols_cmds='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && (substr(\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++	  export_symbols_cmds='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && (substr(\$ 3,1,1) != ".")) { if (\$ 2 == "W") { print \$ 3 " weak" } else { print \$ 3 } } }'\'' | sort -u > $export_symbols'
+ 	else
+-	  export_symbols_cmds='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && (substr(\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++	  export_symbols_cmds='`func_echo_all $NM | $SED -e '\''s/B\([^B]*\)$/P\1/'\''` -PCpgl $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "L") || (\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) && (substr(\$ 1,1,1) != ".")) { if ((\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) { print \$ 1 " weak" } else { print \$ 1 } } }'\'' | sort -u > $export_symbols'
+ 	fi
+ 	aix_use_runtimelinking=no
+ 
+ 	# Test if we are trying to use run time linking or normal
+ 	# AIX style linking. If -brtl is somewhere in LDFLAGS, we
+-	# need to do runtime linking.
++	# have runtime linking enabled, and use it for executables.
++	# For shared libraries, we enable/disable runtime linking
++	# depending on the kind of the shared library created -
++	# when "with_aix_soname,aix_use_runtimelinking" is:
++	# "aix,no"   lib.a(lib.so.V) shared, rtl:no,  for executables
++	# "aix,yes"  lib.so          shared, rtl:yes, for executables
++	#            lib.a           static archive
++	# "both,no"  lib.so.V(shr.o) shared, rtl:yes
++	#            lib.a(lib.so.V) shared, rtl:no,  for executables
++	# "both,yes" lib.so.V(shr.o) shared, rtl:yes, for executables
++	#            lib.a(lib.so.V) shared, rtl:no
++	# "svr4,*"   lib.so.V(shr.o) shared, rtl:yes, for executables
++	#            lib.a           static archive
+ 	case $host_os in aix4.[23]|aix4.[23].*|aix[5-9]*)
+ 	  for ld_flag in $LDFLAGS; do
+-	  if (test $ld_flag = "-brtl" || test $ld_flag = "-Wl,-brtl"); then
++	  if (test x-brtl = "x$ld_flag" || test x-Wl,-brtl = "x$ld_flag"); then
+ 	    aix_use_runtimelinking=yes
+ 	    break
+ 	  fi
+ 	  done
++	  if test svr4,no = "$with_aix_soname,$aix_use_runtimelinking"; then
++	    # With aix-soname=svr4, we create the lib.so.V shared archives only,
++	    # so we don't have lib.a shared libs to link our executables.
++	    # We have to force runtime linking in this case.
++	    aix_use_runtimelinking=yes
++	    LDFLAGS="$LDFLAGS -Wl,-brtl"
++	  fi
+ 	  ;;
+ 	esac
+ 
+@@ -10180,13 +10530,21 @@ _LT_EOF
+       hardcode_direct_absolute=yes
+       hardcode_libdir_separator=':'
+       link_all_deplibs=yes
+-      file_list_spec='${wl}-f,'
++      file_list_spec='$wl-f,'
++      case $with_aix_soname,$aix_use_runtimelinking in
++      aix,*) ;; # traditional, no import file
++      svr4,* | *,yes) # use import file
++	# The Import File defines what to hardcode.
++	hardcode_direct=no
++	hardcode_direct_absolute=no
++	;;
++      esac
+ 
+-      if test "$GCC" = yes; then
++      if test yes = "$GCC"; then
+ 	case $host_os in aix4.[012]|aix4.[012].*)
+ 	# We only want to do this on AIX 4.2 and lower, the check
+ 	# below for broken collect2 doesn't work under 4.3+
+-	  collect2name=`${CC} -print-prog-name=collect2`
++	  collect2name=`$CC -print-prog-name=collect2`
+ 	  if test -f "$collect2name" &&
+ 	   strings "$collect2name" | $GREP resolve_lib_name >/dev/null
+ 	  then
+@@ -10205,35 +10563,42 @@ _LT_EOF
+ 	  ;;
+ 	esac
+ 	shared_flag='-shared'
+-	if test "$aix_use_runtimelinking" = yes; then
+-	  shared_flag="$shared_flag "'${wl}-G'
++	if test yes = "$aix_use_runtimelinking"; then
++	  shared_flag="$shared_flag "'$wl-G'
+ 	fi
++	# Need to ensure runtime linking is disabled for the traditional
++	# shared library, or the linker may eventually find shared libraries
++	# /with/ Import File - we do not want to mix them.
++	shared_flag_aix='-shared'
++	shared_flag_svr4='-shared $wl-G'
+       else
+ 	# not using gcc
+-	if test "$host_cpu" = ia64; then
++	if test ia64 = "$host_cpu"; then
+ 	# VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
+ 	# chokes on -Wl,-G. The following line is correct:
+ 	  shared_flag='-G'
+ 	else
+-	  if test "$aix_use_runtimelinking" = yes; then
+-	    shared_flag='${wl}-G'
++	  if test yes = "$aix_use_runtimelinking"; then
++	    shared_flag='$wl-G'
+ 	  else
+-	    shared_flag='${wl}-bM:SRE'
++	    shared_flag='$wl-bM:SRE'
+ 	  fi
++	  shared_flag_aix='$wl-bM:SRE'
++	  shared_flag_svr4='$wl-G'
+ 	fi
+       fi
+ 
+-      export_dynamic_flag_spec='${wl}-bexpall'
++      export_dynamic_flag_spec='$wl-bexpall'
+       # It seems that -bexpall does not export symbols beginning with
+       # underscore (_), so it is better to generate a list of symbols to export.
+       always_export_symbols=yes
+-      if test "$aix_use_runtimelinking" = yes; then
++      if test aix,yes = "$with_aix_soname,$aix_use_runtimelinking"; then
+ 	# Warning - without using the other runtime loading flags (-brtl),
+ 	# -berok will link without error, but may produce a broken library.
+ 	allow_undefined_flag='-berok'
+         # Determine the default libpath from the value encoded in an
+         # empty executable.
+-        if test "${lt_cv_aix_libpath+set}" = set; then
++        if test set = "${lt_cv_aix_libpath+set}"; then
+   aix_libpath=$lt_cv_aix_libpath
+ else
+   if ${lt_cv_aix_libpath_+:} false; then :
+@@ -10268,7 +10633,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+   if test -z "$lt_cv_aix_libpath_"; then
+-    lt_cv_aix_libpath_="/usr/lib:/lib"
++    lt_cv_aix_libpath_=/usr/lib:/lib
+   fi
+ 
+ fi
+@@ -10276,17 +10641,17 @@ fi
+   aix_libpath=$lt_cv_aix_libpath_
+ fi
+ 
+-        hardcode_libdir_flag_spec='${wl}-blibpath:$libdir:'"$aix_libpath"
+-        archive_expsym_cmds='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
++        hardcode_libdir_flag_spec='$wl-blibpath:$libdir:'"$aix_libpath"
++        archive_expsym_cmds='$CC -o $output_objdir/$soname $libobjs $deplibs $wl'$no_entry_flag' $compiler_flags `if test -n "$allow_undefined_flag"; then func_echo_all "$wl$allow_undefined_flag"; else :; fi` $wl'$exp_sym_flag:\$export_symbols' '$shared_flag
+       else
+-	if test "$host_cpu" = ia64; then
+-	  hardcode_libdir_flag_spec='${wl}-R $libdir:/usr/lib:/lib'
++	if test ia64 = "$host_cpu"; then
++	  hardcode_libdir_flag_spec='$wl-R $libdir:/usr/lib:/lib'
+ 	  allow_undefined_flag="-z nodefs"
+-	  archive_expsym_cmds="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
++	  archive_expsym_cmds="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\$wl$no_entry_flag"' $compiler_flags $wl$allow_undefined_flag '"\$wl$exp_sym_flag:\$export_symbols"
+ 	else
+ 	 # Determine the default libpath from the value encoded in an
+ 	 # empty executable.
+-	 if test "${lt_cv_aix_libpath+set}" = set; then
++	 if test set = "${lt_cv_aix_libpath+set}"; then
+   aix_libpath=$lt_cv_aix_libpath
+ else
+   if ${lt_cv_aix_libpath_+:} false; then :
+@@ -10321,7 +10686,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+   if test -z "$lt_cv_aix_libpath_"; then
+-    lt_cv_aix_libpath_="/usr/lib:/lib"
++    lt_cv_aix_libpath_=/usr/lib:/lib
+   fi
+ 
+ fi
+@@ -10329,21 +10694,33 @@ fi
+   aix_libpath=$lt_cv_aix_libpath_
+ fi
+ 
+-	 hardcode_libdir_flag_spec='${wl}-blibpath:$libdir:'"$aix_libpath"
++	 hardcode_libdir_flag_spec='$wl-blibpath:$libdir:'"$aix_libpath"
+ 	  # Warning - without using the other run time loading flags,
+ 	  # -berok will link without error, but may produce a broken library.
+-	  no_undefined_flag=' ${wl}-bernotok'
+-	  allow_undefined_flag=' ${wl}-berok'
+-	  if test "$with_gnu_ld" = yes; then
++	  no_undefined_flag=' $wl-bernotok'
++	  allow_undefined_flag=' $wl-berok'
++	  if test yes = "$with_gnu_ld"; then
+ 	    # We only use this code for GNU lds that support --whole-archive.
+-	    whole_archive_flag_spec='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	    whole_archive_flag_spec='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	  else
+ 	    # Exported symbols can be pulled into shared objects from archives
+ 	    whole_archive_flag_spec='$convenience'
+ 	  fi
+ 	  archive_cmds_need_lc=yes
+-	  # This is similar to how AIX traditionally builds its shared libraries.
+-	  archive_expsym_cmds="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
++	  archive_expsym_cmds='$RM -r $output_objdir/$realname.d~$MKDIR $output_objdir/$realname.d'
++	  # -brtl affects multiple linker settings, -berok does not and is overridden later
++	  compiler_flags_filtered='`func_echo_all "$compiler_flags " | $SED -e "s%-brtl\\([, ]\\)%-berok\\1%g"`'
++	  if test svr4 != "$with_aix_soname"; then
++	    # This is similar to how AIX traditionally builds its shared libraries.
++	    archive_expsym_cmds="$archive_expsym_cmds"'~$CC '$shared_flag_aix' -o $output_objdir/$realname.d/$soname $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$realname.d/$soname'
++	  fi
++	  if test aix != "$with_aix_soname"; then
++	    archive_expsym_cmds="$archive_expsym_cmds"'~$CC '$shared_flag_svr4' -o $output_objdir/$realname.d/$shared_archive_member_spec.o $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$STRIP -e $output_objdir/$realname.d/$shared_archive_member_spec.o~( func_echo_all "#! $soname($shared_archive_member_spec.o)"; if test shr_64 = "$shared_archive_member_spec"; then func_echo_all "# 64"; else func_echo_all "# 32"; fi; cat $export_symbols ) > $output_objdir/$realname.d/$shared_archive_member_spec.imp~$AR $AR_FLAGS $output_objdir/$soname $output_objdir/$realname.d/$shared_archive_member_spec.o $output_objdir/$realname.d/$shared_archive_member_spec.imp'
++	  else
++	    # used by -dlpreopen to get the symbols
++	    archive_expsym_cmds="$archive_expsym_cmds"'~$MV  $output_objdir/$realname.d/$soname $output_objdir'
++	  fi
++	  archive_expsym_cmds="$archive_expsym_cmds"'~$RM -r $output_objdir/$realname.d'
+ 	fi
+       fi
+       ;;
+@@ -10352,7 +10729,7 @@ fi
+       case $host_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+-            archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++            archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+             archive_expsym_cmds=''
+         ;;
+       m68k)
+@@ -10382,16 +10759,17 @@ fi
+ 	# Tell ltmain to make .lib files, not .a files.
+ 	libext=lib
+ 	# Tell ltmain to make .dll files, not .so files.
+-	shrext_cmds=".dll"
++	shrext_cmds=.dll
+ 	# FIXME: Setting linknames here is a bad hack.
+-	archive_cmds='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
+-	archive_expsym_cmds='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	    sed -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
+-	  else
+-	    sed -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
+-	  fi~
+-	  $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
+-	  linknames='
++	archive_cmds='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~linknames='
++	archive_expsym_cmds='if   test DEF = "`$SED -n     -e '\''s/^[	 ]*//'\''     -e '\''/^\(;.*\)*$/d'\''     -e '\''s/^\(EXPORTS\|LIBRARY\)\([	 ].*\)*$/DEF/p'\''     -e q     $export_symbols`" ; then
++            cp "$export_symbols" "$output_objdir/$soname.def";
++            echo "$tool_output_objdir$soname.def" > "$output_objdir/$soname.exp";
++          else
++            $SED -e '\''s/^/-link -EXPORT:/'\'' < $export_symbols > $output_objdir/$soname.exp;
++          fi~
++          $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
++          linknames='
+ 	# The linker will not automatically build a static lib if we build a DLL.
+ 	# _LT_TAGVAR(old_archive_from_new_cmds, )='true'
+ 	enable_shared_with_static_runtimes=yes
+@@ -10400,18 +10778,18 @@ fi
+ 	# Don't use ranlib
+ 	old_postinstall_cmds='chmod 644 $oldlib'
+ 	postlink_cmds='lt_outputfile="@OUTPUT@"~
+-	  lt_tool_outputfile="@TOOL_OUTPUT@"~
+-	  case $lt_outputfile in
+-	    *.exe|*.EXE) ;;
+-	    *)
+-	      lt_outputfile="$lt_outputfile.exe"
+-	      lt_tool_outputfile="$lt_tool_outputfile.exe"
+-	      ;;
+-	  esac~
+-	  if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
+-	    $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
+-	    $RM "$lt_outputfile.manifest";
+-	  fi'
++          lt_tool_outputfile="@TOOL_OUTPUT@"~
++          case $lt_outputfile in
++            *.exe|*.EXE) ;;
++            *)
++              lt_outputfile=$lt_outputfile.exe
++              lt_tool_outputfile=$lt_tool_outputfile.exe
++              ;;
++          esac~
++          if test : != "$MANIFEST_TOOL" && test -f "$lt_outputfile.manifest"; then
++            $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
++            $RM "$lt_outputfile.manifest";
++          fi'
+ 	;;
+       *)
+ 	# Assume MSVC wrapper
+@@ -10420,7 +10798,7 @@ fi
+ 	# Tell ltmain to make .lib files, not .a files.
+ 	libext=lib
+ 	# Tell ltmain to make .dll files, not .so files.
+-	shrext_cmds=".dll"
++	shrext_cmds=.dll
+ 	# FIXME: Setting linknames here is a bad hack.
+ 	archive_cmds='$CC -o $lib $libobjs $compiler_flags `func_echo_all "$deplibs" | $SED '\''s/ -lc$//'\''` -link -dll~linknames='
+ 	# The linker will automatically build a .lib file if we build a DLL.
+@@ -10439,24 +10817,24 @@ fi
+   hardcode_direct=no
+   hardcode_automatic=yes
+   hardcode_shlibpath_var=unsupported
+-  if test "$lt_cv_ld_force_load" = "yes"; then
+-    whole_archive_flag_spec='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience ${wl}-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
++  if test yes = "$lt_cv_ld_force_load"; then
++    whole_archive_flag_spec='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience $wl-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
+ 
+   else
+     whole_archive_flag_spec=''
+   fi
+   link_all_deplibs=yes
+-  allow_undefined_flag="$_lt_dar_allow_undefined"
++  allow_undefined_flag=$_lt_dar_allow_undefined
+   case $cc_basename in
+-     ifort*) _lt_dar_can_shared=yes ;;
++     ifort*|nagfor*) _lt_dar_can_shared=yes ;;
+      *) _lt_dar_can_shared=$GCC ;;
+   esac
+-  if test "$_lt_dar_can_shared" = "yes"; then
++  if test yes = "$_lt_dar_can_shared"; then
+     output_verbose_link_cmd=func_echo_all
+-    archive_cmds="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod${_lt_dsymutil}"
+-    module_cmds="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dsymutil}"
+-    archive_expsym_cmds="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring ${_lt_dar_single_mod}${_lt_dar_export_syms}${_lt_dsymutil}"
+-    module_expsym_cmds="sed -e 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dar_export_syms}${_lt_dsymutil}"
++    archive_cmds="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dsymutil"
++    module_cmds="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dsymutil"
++    archive_expsym_cmds="sed 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dar_export_syms$_lt_dsymutil"
++    module_expsym_cmds="sed -e 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dar_export_syms$_lt_dsymutil"
+ 
+   else
+   ld_shlibs=no
+@@ -10498,33 +10876,33 @@ fi
+       ;;
+ 
+     hpux9*)
+-      if test "$GCC" = yes; then
+-	archive_cmds='$RM $output_objdir/$soname~$CC -shared $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $libobjs $deplibs $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++      if test yes = "$GCC"; then
++	archive_cmds='$RM $output_objdir/$soname~$CC -shared $pic_flag $wl+b $wl$install_libdir -o $output_objdir/$soname $libobjs $deplibs $compiler_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+       else
+-	archive_cmds='$RM $output_objdir/$soname~$LD -b +b $install_libdir -o $output_objdir/$soname $libobjs $deplibs $linker_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++	archive_cmds='$RM $output_objdir/$soname~$LD -b +b $install_libdir -o $output_objdir/$soname $libobjs $deplibs $linker_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+       fi
+-      hardcode_libdir_flag_spec='${wl}+b ${wl}$libdir'
++      hardcode_libdir_flag_spec='$wl+b $wl$libdir'
+       hardcode_libdir_separator=:
+       hardcode_direct=yes
+ 
+       # hardcode_minus_L: Not really in the search PATH,
+       # but as the default location of the library.
+       hardcode_minus_L=yes
+-      export_dynamic_flag_spec='${wl}-E'
++      export_dynamic_flag_spec='$wl-E'
+       ;;
+ 
+     hpux10*)
+-      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
+-	archive_cmds='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes,no = "$GCC,$with_gnu_ld"; then
++	archive_cmds='$CC -shared $pic_flag $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+       else
+ 	archive_cmds='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'
+       fi
+-      if test "$with_gnu_ld" = no; then
+-	hardcode_libdir_flag_spec='${wl}+b ${wl}$libdir'
++      if test no = "$with_gnu_ld"; then
++	hardcode_libdir_flag_spec='$wl+b $wl$libdir'
+ 	hardcode_libdir_separator=:
+ 	hardcode_direct=yes
+ 	hardcode_direct_absolute=yes
+-	export_dynamic_flag_spec='${wl}-E'
++	export_dynamic_flag_spec='$wl-E'
+ 	# hardcode_minus_L: Not really in the search PATH,
+ 	# but as the default location of the library.
+ 	hardcode_minus_L=yes
+@@ -10532,25 +10910,25 @@ fi
+       ;;
+ 
+     hpux11*)
+-      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
++      if test yes,no = "$GCC,$with_gnu_ld"; then
+ 	case $host_cpu in
+ 	hppa*64*)
+-	  archive_cmds='$CC -shared ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds='$CC -shared $wl+h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	ia64*)
+-	  archive_cmds='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds='$CC -shared $pic_flag $wl+h $wl$soname $wl+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	*)
+-	  archive_cmds='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds='$CC -shared $pic_flag $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	esac
+       else
+ 	case $host_cpu in
+ 	hppa*64*)
+-	  archive_cmds='$CC -b ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds='$CC -b $wl+h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	ia64*)
+-	  archive_cmds='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds='$CC -b $wl+h $wl$soname $wl+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	*)
+ 
+@@ -10562,7 +10940,7 @@ if ${lt_cv_prog_compiler__b+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   lt_cv_prog_compiler__b=no
+-   save_LDFLAGS="$LDFLAGS"
++   save_LDFLAGS=$LDFLAGS
+    LDFLAGS="$LDFLAGS -b"
+    echo "$lt_simple_link_test_code" > conftest.$ac_ext
+    if (eval $ac_link 2>conftest.err) && test -s conftest$ac_exeext; then
+@@ -10581,14 +10959,14 @@ else
+      fi
+    fi
+    $RM -r conftest*
+-   LDFLAGS="$save_LDFLAGS"
++   LDFLAGS=$save_LDFLAGS
+ 
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler__b" >&5
+ $as_echo "$lt_cv_prog_compiler__b" >&6; }
+ 
+-if test x"$lt_cv_prog_compiler__b" = xyes; then
+-    archive_cmds='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++if test yes = "$lt_cv_prog_compiler__b"; then
++    archive_cmds='$CC -b $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+ else
+     archive_cmds='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'
+ fi
+@@ -10596,8 +10974,8 @@ fi
+ 	  ;;
+ 	esac
+       fi
+-      if test "$with_gnu_ld" = no; then
+-	hardcode_libdir_flag_spec='${wl}+b ${wl}$libdir'
++      if test no = "$with_gnu_ld"; then
++	hardcode_libdir_flag_spec='$wl+b $wl$libdir'
+ 	hardcode_libdir_separator=:
+ 
+ 	case $host_cpu in
+@@ -10608,7 +10986,7 @@ fi
+ 	*)
+ 	  hardcode_direct=yes
+ 	  hardcode_direct_absolute=yes
+-	  export_dynamic_flag_spec='${wl}-E'
++	  export_dynamic_flag_spec='$wl-E'
+ 
+ 	  # hardcode_minus_L: Not really in the search PATH,
+ 	  # but as the default location of the library.
+@@ -10619,8 +10997,8 @@ fi
+       ;;
+ 
+     irix5* | irix6* | nonstopux*)
+-      if test "$GCC" = yes; then
+-	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++      if test yes = "$GCC"; then
++	archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 	# Try to use the -exported_symbol ld option, if it does not
+ 	# work, assume that -exports_file does not work either and
+ 	# implicitly export all symbols.
+@@ -10630,8 +11008,8 @@ $as_echo_n "checking whether the $host_os linker accepts -exported_symbol... " >
+ if ${lt_cv_irix_exported_symbol+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-  save_LDFLAGS="$LDFLAGS"
+-	   LDFLAGS="$LDFLAGS -shared ${wl}-exported_symbol ${wl}foo ${wl}-update_registry ${wl}/dev/null"
++  save_LDFLAGS=$LDFLAGS
++	   LDFLAGS="$LDFLAGS -shared $wl-exported_symbol ${wl}foo $wl-update_registry $wl/dev/null"
+ 	   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ int foo (void) { return 0; }
+@@ -10643,24 +11021,34 @@ else
+ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+-           LDFLAGS="$save_LDFLAGS"
++           LDFLAGS=$save_LDFLAGS
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_irix_exported_symbol" >&5
+ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+-	if test "$lt_cv_irix_exported_symbol" = yes; then
+-          archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations ${wl}-exports_file ${wl}$export_symbols -o $lib'
++	if test yes = "$lt_cv_irix_exported_symbol"; then
++          archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations $wl-exports_file $wl$export_symbols -o $lib'
+ 	fi
+       else
+-	archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-	archive_expsym_cmds='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -exports_file $export_symbols -o $lib'
++	archive_cmds='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
++	archive_expsym_cmds='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -exports_file $export_symbols -o $lib'
+       fi
+       archive_cmds_need_lc='no'
+-      hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
++      hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
+       hardcode_libdir_separator=:
+       inherit_rpath=yes
+       link_all_deplibs=yes
+       ;;
+ 
++    linux*)
++      case $cc_basename in
++      tcc*)
++	# Fabrice Bellard et al's Tiny C Compiler
++	ld_shlibs=yes
++	archive_cmds='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++	;;
++      esac
++      ;;
++
+     netbsd*)
+       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+ 	archive_cmds='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
+@@ -10675,7 +11063,7 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+     newsos6)
+       archive_cmds='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+       hardcode_direct=yes
+-      hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
++      hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
+       hardcode_libdir_separator=:
+       hardcode_shlibpath_var=no
+       ;;
+@@ -10683,27 +11071,19 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+     *nto* | *qnx*)
+       ;;
+ 
+-    openbsd*)
++    openbsd* | bitrig*)
+       if test -f /usr/libexec/ld.so; then
+ 	hardcode_direct=yes
+ 	hardcode_shlibpath_var=no
+ 	hardcode_direct_absolute=yes
+-	if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++	if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
+ 	  archive_cmds='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-	  archive_expsym_cmds='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags ${wl}-retain-symbols-file,$export_symbols'
+-	  hardcode_libdir_flag_spec='${wl}-rpath,$libdir'
+-	  export_dynamic_flag_spec='${wl}-E'
++	  archive_expsym_cmds='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags $wl-retain-symbols-file,$export_symbols'
++	  hardcode_libdir_flag_spec='$wl-rpath,$libdir'
++	  export_dynamic_flag_spec='$wl-E'
+ 	else
+-	  case $host_os in
+-	   openbsd[01].* | openbsd2.[0-7] | openbsd2.[0-7].*)
+-	     archive_cmds='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
+-	     hardcode_libdir_flag_spec='-R$libdir'
+-	     ;;
+-	   *)
+-	     archive_cmds='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-	     hardcode_libdir_flag_spec='${wl}-rpath,$libdir'
+-	     ;;
+-	  esac
++	  archive_cmds='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++	  hardcode_libdir_flag_spec='$wl-rpath,$libdir'
+ 	fi
+       else
+ 	ld_shlibs=no
+@@ -10714,33 +11094,54 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_libdir_flag_spec='-L$libdir'
+       hardcode_minus_L=yes
+       allow_undefined_flag=unsupported
+-      archive_cmds='$ECHO "LIBRARY $libname INITINSTANCE" > $output_objdir/$libname.def~$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~echo DATA >> $output_objdir/$libname.def~echo " SINGLE NONSHARED" >> $output_objdir/$libname.def~echo EXPORTS >> $output_objdir/$libname.def~emxexp $libobjs >> $output_objdir/$libname.def~$CC -Zdll -Zcrtdll -o $lib $libobjs $deplibs $compiler_flags $output_objdir/$libname.def'
+-      old_archive_from_new_cmds='emximp -o $output_objdir/$libname.a $output_objdir/$libname.def'
++      shrext_cmds=.dll
++      archive_cmds='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	emxexp $libobjs | $SED /"_DLL_InitTerm"/d >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      archive_expsym_cmds='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	prefix_cmds="$SED"~
++	if test EXPORTS = "`$SED 1q $export_symbols`"; then
++	  prefix_cmds="$prefix_cmds -e 1d";
++	fi~
++	prefix_cmds="$prefix_cmds -e \"s/^\(.*\)$/_\1/g\""~
++	cat $export_symbols | $prefix_cmds >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      old_archive_From_new_cmds='emximp -o $output_objdir/${libname}_dll.a $output_objdir/$libname.def'
++      enable_shared_with_static_runtimes=yes
++      file_list_spec='@'
+       ;;
+ 
+     osf3*)
+-      if test "$GCC" = yes; then
+-	allow_undefined_flag=' ${wl}-expect_unresolved ${wl}\*'
+-	archive_cmds='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++      if test yes = "$GCC"; then
++	allow_undefined_flag=' $wl-expect_unresolved $wl\*'
++	archive_cmds='$CC -shared$allow_undefined_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+       else
+ 	allow_undefined_flag=' -expect_unresolved \*'
+-	archive_cmds='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	archive_cmds='$CC -shared$allow_undefined_flag $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+       fi
+       archive_cmds_need_lc='no'
+-      hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
++      hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
+       hardcode_libdir_separator=:
+       ;;
+ 
+     osf4* | osf5*)	# as osf3* with the addition of -msym flag
+-      if test "$GCC" = yes; then
+-	allow_undefined_flag=' ${wl}-expect_unresolved ${wl}\*'
+-	archive_cmds='$CC -shared${allow_undefined_flag} $pic_flag $libobjs $deplibs $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
+-	hardcode_libdir_flag_spec='${wl}-rpath ${wl}$libdir'
++      if test yes = "$GCC"; then
++	allow_undefined_flag=' $wl-expect_unresolved $wl\*'
++	archive_cmds='$CC -shared$allow_undefined_flag $pic_flag $libobjs $deplibs $compiler_flags $wl-msym $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
++	hardcode_libdir_flag_spec='$wl-rpath $wl$libdir'
+       else
+ 	allow_undefined_flag=' -expect_unresolved \*'
+-	archive_cmds='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	archive_cmds='$CC -shared$allow_undefined_flag $libobjs $deplibs $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+ 	archive_expsym_cmds='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done; printf "%s\\n" "-hidden">> $lib.exp~
+-	$CC -shared${allow_undefined_flag} ${wl}-input ${wl}$lib.exp $compiler_flags $libobjs $deplibs -soname $soname `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~$RM $lib.exp'
++          $CC -shared$allow_undefined_flag $wl-input $wl$lib.exp $compiler_flags $libobjs $deplibs -soname $soname `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib~$RM $lib.exp'
+ 
+ 	# Both c and cxx compiler support -rpath directly
+ 	hardcode_libdir_flag_spec='-rpath $libdir'
+@@ -10751,24 +11152,24 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+ 
+     solaris*)
+       no_undefined_flag=' -z defs'
+-      if test "$GCC" = yes; then
+-	wlarc='${wl}'
+-	archive_cmds='$CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes = "$GCC"; then
++	wlarc='$wl'
++	archive_cmds='$CC -shared $pic_flag $wl-z ${wl}text $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	archive_expsym_cmds='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-M ${wl}$lib.exp ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++          $CC -shared $pic_flag $wl-z ${wl}text $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+       else
+ 	case `$CC -V 2>&1` in
+ 	*"Compilers 5.0"*)
+ 	  wlarc=''
+-	  archive_cmds='$LD -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $linker_flags'
++	  archive_cmds='$LD -G$allow_undefined_flag -h $soname -o $lib $libobjs $deplibs $linker_flags'
+ 	  archive_expsym_cmds='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $LD -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $linker_flags~$RM $lib.exp'
++            $LD -G$allow_undefined_flag -M $lib.exp -h $soname -o $lib $libobjs $deplibs $linker_flags~$RM $lib.exp'
+ 	  ;;
+ 	*)
+-	  wlarc='${wl}'
+-	  archive_cmds='$CC -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $compiler_flags'
++	  wlarc='$wl'
++	  archive_cmds='$CC -G$allow_undefined_flag -h $soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  archive_expsym_cmds='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $CC -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++            $CC -G$allow_undefined_flag -M $lib.exp -h $soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+ 	  ;;
+ 	esac
+       fi
+@@ -10778,11 +11179,11 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       solaris2.[0-5] | solaris2.[0-5].*) ;;
+       *)
+ 	# The compiler driver will combine and reorder linker options,
+-	# but understands `-z linker_flag'.  GCC discards it without `$wl',
++	# but understands '-z linker_flag'.  GCC discards it without '$wl',
+ 	# but is careful enough not to reorder.
+ 	# Supported since Solaris 2.6 (maybe 2.5.1?)
+-	if test "$GCC" = yes; then
+-	  whole_archive_flag_spec='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
++	if test yes = "$GCC"; then
++	  whole_archive_flag_spec='$wl-z ${wl}allextract$convenience $wl-z ${wl}defaultextract'
+ 	else
+ 	  whole_archive_flag_spec='-z allextract$convenience -z defaultextract'
+ 	fi
+@@ -10792,10 +11193,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       ;;
+ 
+     sunos4*)
+-      if test "x$host_vendor" = xsequent; then
++      if test sequent = "$host_vendor"; then
+ 	# Use $CC to link under sequent, because it throws in some extra .o
+ 	# files that make .init and .fini sections work.
+-	archive_cmds='$CC -G ${wl}-h $soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_cmds='$CC -G $wl-h $soname -o $lib $libobjs $deplibs $compiler_flags'
+       else
+ 	archive_cmds='$LD -assert pure-text -Bstatic -o $lib $libobjs $deplibs $linker_flags'
+       fi
+@@ -10844,43 +11245,43 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       ;;
+ 
+     sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[01].[10]* | unixware7* | sco3.2v5.0.[024]*)
+-      no_undefined_flag='${wl}-z,text'
++      no_undefined_flag='$wl-z,text'
+       archive_cmds_need_lc=no
+       hardcode_shlibpath_var=no
+       runpath_var='LD_RUN_PATH'
+ 
+-      if test "$GCC" = yes; then
+-	archive_cmds='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes = "$GCC"; then
++	archive_cmds='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_expsym_cmds='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       else
+-	archive_cmds='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_cmds='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_expsym_cmds='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       fi
+       ;;
+ 
+     sysv5* | sco3.2v5* | sco5v6*)
+-      # Note: We can NOT use -z defs as we might desire, because we do not
++      # Note: We CANNOT use -z defs as we might desire, because we do not
+       # link with -lc, and that would cause any symbols used from libc to
+       # always be unresolved, which means just about no library would
+       # ever link correctly.  If we're not using GNU ld we use -z text
+       # though, which does catch some bad symbols but isn't as heavy-handed
+       # as -z defs.
+-      no_undefined_flag='${wl}-z,text'
+-      allow_undefined_flag='${wl}-z,nodefs'
++      no_undefined_flag='$wl-z,text'
++      allow_undefined_flag='$wl-z,nodefs'
+       archive_cmds_need_lc=no
+       hardcode_shlibpath_var=no
+-      hardcode_libdir_flag_spec='${wl}-R,$libdir'
++      hardcode_libdir_flag_spec='$wl-R,$libdir'
+       hardcode_libdir_separator=':'
+       link_all_deplibs=yes
+-      export_dynamic_flag_spec='${wl}-Bexport'
++      export_dynamic_flag_spec='$wl-Bexport'
+       runpath_var='LD_RUN_PATH'
+ 
+-      if test "$GCC" = yes; then
+-	archive_cmds='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes = "$GCC"; then
++	archive_cmds='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_expsym_cmds='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       else
+-	archive_cmds='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_cmds='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	archive_expsym_cmds='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       fi
+       ;;
+ 
+@@ -10895,10 +11296,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       ;;
+     esac
+ 
+-    if test x$host_vendor = xsni; then
++    if test sni = "$host_vendor"; then
+       case $host in
+       sysv4 | sysv4.2uw2* | sysv4.3* | sysv5*)
+-	export_dynamic_flag_spec='${wl}-Blargedynsym'
++	export_dynamic_flag_spec='$wl-Blargedynsym'
+ 	;;
+       esac
+     fi
+@@ -10906,7 +11307,7 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ld_shlibs" >&5
+ $as_echo "$ld_shlibs" >&6; }
+-test "$ld_shlibs" = no && can_build_shared=no
++test no = "$ld_shlibs" && can_build_shared=no
+ 
+ with_gnu_ld=$with_gnu_ld
+ 
+@@ -10932,7 +11333,7 @@ x|xyes)
+   # Assume -lc should be added
+   archive_cmds_need_lc=yes
+ 
+-  if test "$enable_shared" = yes && test "$GCC" = yes; then
++  if test yes,yes = "$GCC,$enable_shared"; then
+     case $archive_cmds in
+     *'~'*)
+       # FIXME: we may have to deal with multi-command sequences.
+@@ -11147,14 +11548,14 @@ esac
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking dynamic linker characteristics" >&5
+ $as_echo_n "checking dynamic linker characteristics... " >&6; }
+ 
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   case $host_os in
+-    darwin*) lt_awk_arg="/^libraries:/,/LR/" ;;
+-    *) lt_awk_arg="/^libraries:/" ;;
++    darwin*) lt_awk_arg='/^libraries:/,/LR/' ;;
++    *) lt_awk_arg='/^libraries:/' ;;
+   esac
+   case $host_os in
+-    mingw* | cegcc*) lt_sed_strip_eq="s,=\([A-Za-z]:\),\1,g" ;;
+-    *) lt_sed_strip_eq="s,=/,/,g" ;;
++    mingw* | cegcc*) lt_sed_strip_eq='s|=\([A-Za-z]:\)|\1|g' ;;
++    *) lt_sed_strip_eq='s|=/|/|g' ;;
+   esac
+   lt_search_path_spec=`$CC -print-search-dirs | awk $lt_awk_arg | $SED -e "s/^libraries://" -e $lt_sed_strip_eq`
+   case $lt_search_path_spec in
+@@ -11170,28 +11571,35 @@ if test "$GCC" = yes; then
+     ;;
+   esac
+   # Ok, now we have the path, separated by spaces, we can step through it
+-  # and add multilib dir if necessary.
++  # and add multilib dir if necessary...
+   lt_tmp_lt_search_path_spec=
+-  lt_multi_os_dir=`$CC $CPPFLAGS $CFLAGS $LDFLAGS -print-multi-os-directory 2>/dev/null`
++  lt_multi_os_dir=/`$CC $CPPFLAGS $CFLAGS $LDFLAGS -print-multi-os-directory 2>/dev/null`
++  # ...but if some path component already ends with the multilib dir we assume
++  # that all is fine and trust -print-search-dirs as is (GCC 4.2? or newer).
++  case "$lt_multi_os_dir; $lt_search_path_spec " in
++  "/; "* | "/.; "* | "/./; "* | *"$lt_multi_os_dir "* | *"$lt_multi_os_dir/ "*)
++    lt_multi_os_dir=
++    ;;
++  esac
+   for lt_sys_path in $lt_search_path_spec; do
+-    if test -d "$lt_sys_path/$lt_multi_os_dir"; then
+-      lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path/$lt_multi_os_dir"
+-    else
++    if test -d "$lt_sys_path$lt_multi_os_dir"; then
++      lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path$lt_multi_os_dir"
++    elif test -n "$lt_multi_os_dir"; then
+       test -d "$lt_sys_path" && \
+ 	lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path"
+     fi
+   done
+   lt_search_path_spec=`$ECHO "$lt_tmp_lt_search_path_spec" | awk '
+-BEGIN {RS=" "; FS="/|\n";} {
+-  lt_foo="";
+-  lt_count=0;
++BEGIN {RS = " "; FS = "/|\n";} {
++  lt_foo = "";
++  lt_count = 0;
+   for (lt_i = NF; lt_i > 0; lt_i--) {
+     if ($lt_i != "" && $lt_i != ".") {
+       if ($lt_i == "..") {
+         lt_count++;
+       } else {
+         if (lt_count == 0) {
+-          lt_foo="/" $lt_i lt_foo;
++          lt_foo = "/" $lt_i lt_foo;
+         } else {
+           lt_count--;
+         }
+@@ -11205,7 +11613,7 @@ BEGIN {RS=" "; FS="/|\n";} {
+   # for these hosts.
+   case $host_os in
+     mingw* | cegcc*) lt_search_path_spec=`$ECHO "$lt_search_path_spec" |\
+-      $SED 's,/\([A-Za-z]:\),\1,g'` ;;
++      $SED 's|/\([A-Za-z]:\)|\1|g'` ;;
+   esac
+   sys_lib_search_path_spec=`$ECHO "$lt_search_path_spec" | $lt_NL2SP`
+ else
+@@ -11214,7 +11622,7 @@ fi
+ library_names_spec=
+ libname_spec='lib$name'
+ soname_spec=
+-shrext_cmds=".so"
++shrext_cmds=.so
+ postinstall_cmds=
+ postuninstall_cmds=
+ finish_cmds=
+@@ -11231,14 +11639,16 @@ hardcode_into_libs=no
+ # flags to be left without arguments
+ need_version=unknown
+ 
++
++
+ case $host_os in
+ aix3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix $libname.a'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname.a'
+   shlibpath_var=LIBPATH
+ 
+   # AIX 3 has no versioning support, so we append a major version to the name.
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  soname_spec='$libname$release$shared_ext$major'
+   ;;
+ 
+ aix[4-9]*)
+@@ -11246,41 +11656,91 @@ aix[4-9]*)
+   need_lib_prefix=no
+   need_version=no
+   hardcode_into_libs=yes
+-  if test "$host_cpu" = ia64; then
++  if test ia64 = "$host_cpu"; then
+     # AIX 5 supports IA64
+-    library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
++    library_names_spec='$libname$release$shared_ext$major $libname$release$shared_ext$versuffix $libname$shared_ext'
+     shlibpath_var=LD_LIBRARY_PATH
+   else
+     # With GCC up to 2.95.x, collect2 would create an import file
+     # for dependence libraries.  The import file would start with
+-    # the line `#! .'.  This would cause the generated library to
+-    # depend on `.', always an invalid library.  This was fixed in
++    # the line '#! .'.  This would cause the generated library to
++    # depend on '.', always an invalid library.  This was fixed in
+     # development snapshots of GCC prior to 3.0.
+     case $host_os in
+       aix4 | aix4.[01] | aix4.[01].*)
+       if { echo '#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 97)'
+ 	   echo ' yes '
+-	   echo '#endif'; } | ${CC} -E - | $GREP yes > /dev/null; then
++	   echo '#endif'; } | $CC -E - | $GREP yes > /dev/null; then
+ 	:
+       else
+ 	can_build_shared=no
+       fi
+       ;;
+     esac
+-    # AIX (on Power*) has no versioning support, so currently we can not hardcode correct
++    # Using Import Files as archive members, it is possible to support
++    # filename-based versioning of shared library archives on AIX. While
++    # this would work for both with and without runtime linking, it will
++    # prevent static linking of such archives. So we do filename-based
++    # shared library versioning with .so extension only, which is used
++    # when both runtime linking and shared linking is enabled.
++    # Unfortunately, runtime linking may impact performance, so we do
++    # not want this to be the default eventually. Also, we use the
++    # versioned .so libs for executables only if there is the -brtl
++    # linker flag in LDFLAGS as well, or --with-aix-soname=svr4 only.
++    # To allow for filename-based versioning support, we need to create
++    # libNAME.so.V as an archive file, containing:
++    # *) an Import File, referring to the versioned filename of the
++    #    archive as well as the shared archive member, telling the
++    #    bitwidth (32 or 64) of that shared object, and providing the
++    #    list of exported symbols of that shared object, eventually
++    #    decorated with the 'weak' keyword
++    # *) the shared object with the F_LOADONLY flag set, to really avoid
++    #    it being seen by the linker.
++    # At run time we better use the real file rather than another symlink,
++    # but for link time we create the symlink libNAME.so -> libNAME.so.V
++
++    case $with_aix_soname,$aix_use_runtimelinking in
++    # AIX (on Power*) has no versioning support, so currently we cannot hardcode correct
+     # soname into executable. Probably we can add versioning support to
+     # collect2, so additional links can be useful in future.
+-    if test "$aix_use_runtimelinking" = yes; then
++    aix,yes) # traditional libtool
++      dynamic_linker='AIX unversionable lib.so'
+       # If using run time linking (on AIX 4.2 or later) use lib<name>.so
+       # instead of lib<name>.a to let people know that these are not
+       # typical AIX shared libraries.
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    else
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++      ;;
++    aix,no) # traditional AIX only
++      dynamic_linker='AIX lib.a(lib.so.V)'
+       # We preserve .a as extension for shared libraries through AIX4.2
+       # and later when we are not doing run time linking.
+-      library_names_spec='${libname}${release}.a $libname.a'
+-      soname_spec='${libname}${release}${shared_ext}$major'
+-    fi
++      library_names_spec='$libname$release.a $libname.a'
++      soname_spec='$libname$release$shared_ext$major'
++      ;;
++    svr4,*) # full svr4 only
++      dynamic_linker="AIX lib.so.V($shared_archive_member_spec.o)"
++      library_names_spec='$libname$release$shared_ext$major $libname$shared_ext'
++      # We do not specify a path in Import Files, so LIBPATH fires.
++      shlibpath_overrides_runpath=yes
++      ;;
++    *,yes) # both, prefer svr4
++      dynamic_linker="AIX lib.so.V($shared_archive_member_spec.o), lib.a(lib.so.V)"
++      library_names_spec='$libname$release$shared_ext$major $libname$shared_ext'
++      # unpreferred sharedlib libNAME.a needs extra handling
++      postinstall_cmds='test -n "$linkname" || linkname="$realname"~func_stripname "" ".so" "$linkname"~$install_shared_prog "$dir/$func_stripname_result.$libext" "$destdir/$func_stripname_result.$libext"~test -z "$tstripme" || test -z "$striplib" || $striplib "$destdir/$func_stripname_result.$libext"'
++      postuninstall_cmds='for n in $library_names $old_library; do :; done~func_stripname "" ".so" "$n"~test "$func_stripname_result" = "$n" || func_append rmfiles " $odir/$func_stripname_result.$libext"'
++      # We do not specify a path in Import Files, so LIBPATH fires.
++      shlibpath_overrides_runpath=yes
++      ;;
++    *,no) # both, prefer aix
++      dynamic_linker="AIX lib.a(lib.so.V), lib.so.V($shared_archive_member_spec.o)"
++      library_names_spec='$libname$release.a $libname.a'
++      soname_spec='$libname$release$shared_ext$major'
++      # unpreferred sharedlib libNAME.so.V and symlink libNAME.so need extra handling
++      postinstall_cmds='test -z "$dlname" || $install_shared_prog $dir/$dlname $destdir/$dlname~test -z "$tstripme" || test -z "$striplib" || $striplib $destdir/$dlname~test -n "$linkname" || linkname=$realname~func_stripname "" ".a" "$linkname"~(cd "$destdir" && $LN_S -f $dlname $func_stripname_result.so)'
++      postuninstall_cmds='test -z "$dlname" || func_append rmfiles " $odir/$dlname"~for n in $old_library $library_names; do :; done~func_stripname "" ".a" "$n"~func_append rmfiles " $odir/$func_stripname_result.so"'
++      ;;
++    esac
+     shlibpath_var=LIBPATH
+   fi
+   ;;
+@@ -11290,18 +11750,18 @@ amigaos*)
+   powerpc)
+     # Since July 2007 AmigaOS4 officially supports .so libraries.
+     # When compiling the executable, add -use-dynld -Lsobjs: to the compileline.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+     ;;
+   m68k)
+     library_names_spec='$libname.ixlibrary $libname.a'
+     # Create ${libname}_ixlibrary.a entries in /sys/libs.
+-    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([^/]*\)\.ixlibrary$%\1%'\''`; test $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
++    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([^/]*\)\.ixlibrary$%\1%'\''`; $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
+     ;;
+   esac
+   ;;
+ 
+ beos*)
+-  library_names_spec='${libname}${shared_ext}'
++  library_names_spec='$libname$shared_ext'
+   dynamic_linker="$host_os ld.so"
+   shlibpath_var=LIBRARY_PATH
+   ;;
+@@ -11309,8 +11769,8 @@ beos*)
+ bsdi[45]*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   sys_lib_search_path_spec="/shlib /usr/lib /usr/X11/lib /usr/contrib/lib /lib /usr/local/lib"
+@@ -11322,7 +11782,7 @@ bsdi[45]*)
+ 
+ cygwin* | mingw* | pw32* | cegcc*)
+   version_type=windows
+-  shrext_cmds=".dll"
++  shrext_cmds=.dll
+   need_version=no
+   need_lib_prefix=no
+ 
+@@ -11331,8 +11791,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+     # gcc
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++    postinstall_cmds='base_file=`basename \$file`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; echo \$dlname'\''`~
+       dldir=$destdir/`dirname \$dlpath`~
+       test -d \$dldir || mkdir -p \$dldir~
+       $install_prog $dir/$dlname \$dldir/$dlname~
+@@ -11348,17 +11808,17 @@ cygwin* | mingw* | pw32* | cegcc*)
+     case $host_os in
+     cygwin*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+ 
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"
+       ;;
+     mingw* | cegcc*)
+       # MinGW DLLs use traditional 'lib' prefix
+-      soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++      soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+       ;;
+     pw32*)
+       # pw32 DLLs use 'pw' prefix rather than 'lib'
+-      library_names_spec='`echo ${libname} | sed -e 's/^lib/pw/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++      library_names_spec='`echo $libname | sed -e 's/^lib/pw/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+       ;;
+     esac
+     dynamic_linker='Win32 ld.exe'
+@@ -11367,8 +11827,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+   *,cl*)
+     # Native MSVC
+     libname_spec='$name'
+-    soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+-    library_names_spec='${libname}.dll.lib'
++    soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
++    library_names_spec='$libname.dll.lib'
+ 
+     case $build_os in
+     mingw*)
+@@ -11395,7 +11855,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+       sys_lib_search_path_spec=`cygpath --path --unix "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
+       ;;
+     *)
+-      sys_lib_search_path_spec="$LIB"
++      sys_lib_search_path_spec=$LIB
+       if $ECHO "$sys_lib_search_path_spec" | $GREP ';[c-zC-Z]:/' >/dev/null; then
+         # It is most probably a Windows format PATH.
+         sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e 's/;/ /g'`
+@@ -11408,8 +11868,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+     esac
+ 
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++    postinstall_cmds='base_file=`basename \$file`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; echo \$dlname'\''`~
+       dldir=$destdir/`dirname \$dlpath`~
+       test -d \$dldir || mkdir -p \$dldir~
+       $install_prog $dir/$dlname \$dldir/$dlname'
+@@ -11422,7 +11882,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+ 
+   *)
+     # Assume MSVC wrapper
+-    library_names_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext} $libname.lib'
++    library_names_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext $libname.lib'
+     dynamic_linker='Win32 ld.exe'
+     ;;
+   esac
+@@ -11435,8 +11895,8 @@ darwin* | rhapsody*)
+   version_type=darwin
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${major}$shared_ext ${libname}$shared_ext'
+-  soname_spec='${libname}${release}${major}$shared_ext'
++  library_names_spec='$libname$release$major$shared_ext $libname$shared_ext'
++  soname_spec='$libname$release$major$shared_ext'
+   shlibpath_overrides_runpath=yes
+   shlibpath_var=DYLD_LIBRARY_PATH
+   shrext_cmds='`test .$module = .yes && echo .so || echo .dylib`'
+@@ -11449,8 +11909,8 @@ dgux*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname$shared_ext'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
+@@ -11468,12 +11928,13 @@ freebsd* | dragonfly*)
+   version_type=freebsd-$objformat
+   case $version_type in
+     freebsd-elf*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++      soname_spec='$libname$release$shared_ext$major'
+       need_version=no
+       need_lib_prefix=no
+       ;;
+     freebsd-*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix $libname${shared_ext}$versuffix'
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+       need_version=yes
+       ;;
+   esac
+@@ -11498,26 +11959,15 @@ freebsd* | dragonfly*)
+   esac
+   ;;
+ 
+-gnu*)
+-  version_type=linux # correct to gnu/linux during the next big refactor
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
+-  ;;
+-
+ haiku*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+   dynamic_linker="$host_os runtime_loader"
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
++  shlibpath_overrides_runpath=no
+   sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+   hardcode_into_libs=yes
+   ;;
+@@ -11535,14 +11985,15 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    if test "X$HPUX_IA64_MODE" = X32; then
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
++    if test 32 = "$HPUX_IA64_MODE"; then
+       sys_lib_search_path_spec="/usr/lib/hpux32 /usr/local/lib/hpux32 /usr/local/lib"
++      sys_lib_dlsearch_path_spec=/usr/lib/hpux32
+     else
+       sys_lib_search_path_spec="/usr/lib/hpux64 /usr/local/lib/hpux64"
++      sys_lib_dlsearch_path_spec=/usr/lib/hpux64
+     fi
+-    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+     ;;
+   hppa*64*)
+     shrext_cmds='.sl'
+@@ -11550,8 +12001,8 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     sys_lib_search_path_spec="/usr/lib/pa20_64 /usr/ccs/lib/pa20_64"
+     sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+     ;;
+@@ -11560,8 +12011,8 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=SHLIB_PATH
+     shlibpath_overrides_runpath=no # +s is required to enable SHLIB_PATH
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     ;;
+   esac
+   # HP-UX runs *really* slowly unless shared libraries are mode 555, ...
+@@ -11574,8 +12025,8 @@ interix[3-9]*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+@@ -11586,7 +12037,7 @@ irix5* | irix6* | nonstopux*)
+   case $host_os in
+     nonstopux*) version_type=nonstopux ;;
+     *)
+-	if test "$lt_cv_prog_gnu_ld" = yes; then
++	if test yes = "$lt_cv_prog_gnu_ld"; then
+ 		version_type=linux # correct to gnu/linux during the next big refactor
+ 	else
+ 		version_type=irix
+@@ -11594,8 +12045,8 @@ irix5* | irix6* | nonstopux*)
+   esac
+   need_lib_prefix=no
+   need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext} $libname${shared_ext}'
++  soname_spec='$libname$release$shared_ext$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$release$shared_ext $libname$shared_ext'
+   case $host_os in
+   irix5* | nonstopux*)
+     libsuff= shlibsuff=
+@@ -11614,8 +12065,8 @@ irix5* | irix6* | nonstopux*)
+   esac
+   shlibpath_var=LD_LIBRARY${shlibsuff}_PATH
+   shlibpath_overrides_runpath=no
+-  sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+-  sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
++  sys_lib_search_path_spec="/usr/lib$libsuff /lib$libsuff /usr/local/lib$libsuff"
++  sys_lib_dlsearch_path_spec="/usr/lib$libsuff /lib$libsuff"
+   hardcode_into_libs=yes
+   ;;
+ 
+@@ -11624,13 +12075,33 @@ linux*oldld* | linux*aout* | linux*coff*)
+   dynamic_linker=no
+   ;;
+ 
++linux*android*)
++  version_type=none # Android doesn't support versioned libraries.
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='$libname$release$shared_ext'
++  soname_spec='$libname$release$shared_ext'
++  finish_cmds=
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++
++  # This implies no fast_install, which is unacceptable.
++  # Some rework will be needed to allow for fast_install
++  # before this can be enabled.
++  hardcode_into_libs=yes
++
++  dynamic_linker='Android linker'
++  # Don't embed -rpath directories since the linker doesn't support them.
++  hardcode_libdir_flag_spec='-L$libdir'
++  ;;
++
+ # This must be glibc/ELF.
+-linux* | k*bsd*-gnu | kopensolaris*-gnu)
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+@@ -11674,14 +12145,15 @@ fi
+   # before this can be enabled.
+   hardcode_into_libs=yes
+ 
+-  # Add ABI-specific directories to the system library path.
+-  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+-
+-  # Append ld.so.conf contents to the search path
++  # Ideally, we could use ldconfig to report *all* directores which are
++  # searched for libraries, however this is still not possible.  Aside from not
++  # being certain /sbin/ldconfig is available, command
++  # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
++  # even though it is searched at run-time.  Try to do the best guess by
++  # appending ld.so.conf contents (and includes) to the search path.
+   if test -f /etc/ld.so.conf; then
+     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
+-    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+-
++    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+   fi
+ 
+   # We used to test for /lib/ld.so.1 and disable shared libraries on
+@@ -11698,12 +12170,12 @@ netbsd*)
+   need_lib_prefix=no
+   need_version=no
+   if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+     finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+     dynamic_linker='NetBSD (a.out) ld.so'
+   else
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     dynamic_linker='NetBSD ld.elf_so'
+   fi
+   shlibpath_var=LD_LIBRARY_PATH
+@@ -11713,7 +12185,7 @@ netbsd*)
+ 
+ newsos6)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   ;;
+@@ -11722,58 +12194,68 @@ newsos6)
+   version_type=qnx
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+   hardcode_into_libs=yes
+   dynamic_linker='ldqnx.so'
+   ;;
+ 
+-openbsd*)
++openbsd* | bitrig*)
+   version_type=sunos
+-  sys_lib_dlsearch_path_spec="/usr/lib"
++  sys_lib_dlsearch_path_spec=/usr/lib
+   need_lib_prefix=no
+-  # Some older versions of OpenBSD (3.3 at least) *do* need versioned libs.
+-  case $host_os in
+-    openbsd3.3 | openbsd3.3.*)	need_version=yes ;;
+-    *)				need_version=no  ;;
+-  esac
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-    case $host_os in
+-      openbsd2.[89] | openbsd2.[89].*)
+-	shlibpath_overrides_runpath=no
+-	;;
+-      *)
+-	shlibpath_overrides_runpath=yes
+-	;;
+-      esac
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
++    need_version=no
+   else
+-    shlibpath_overrides_runpath=yes
++    need_version=yes
+   fi
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
++  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
+   ;;
+ 
+ os2*)
+   libname_spec='$name'
+-  shrext_cmds=".dll"
++  version_type=windows
++  shrext_cmds=.dll
++  need_version=no
+   need_lib_prefix=no
+-  library_names_spec='$libname${shared_ext} $libname.a'
++  # OS/2 can only load a DLL with a base name of 8 characters or less.
++  soname_spec='`test -n "$os2dllname" && libname="$os2dllname";
++    v=$($ECHO $release$versuffix | tr -d .-);
++    n=$($ECHO $libname | cut -b -$((8 - ${#v})) | tr . _);
++    $ECHO $n$v`$shared_ext'
++  library_names_spec='${libname}_dll.$libext'
+   dynamic_linker='OS/2 ld.exe'
+-  shlibpath_var=LIBPATH
++  shlibpath_var=BEGINLIBPATH
++  sys_lib_search_path_spec="/lib /usr/lib /usr/local/lib"
++  sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
++  postinstall_cmds='base_file=`basename \$file`~
++    dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; $ECHO \$dlname'\''`~
++    dldir=$destdir/`dirname \$dlpath`~
++    test -d \$dldir || mkdir -p \$dldir~
++    $install_prog $dir/$dlname \$dldir/$dlname~
++    chmod a+x \$dldir/$dlname~
++    if test -n '\''$stripme'\'' && test -n '\''$striplib'\''; then
++      eval '\''$striplib \$dldir/$dlname'\'' || exit \$?;
++    fi'
++  postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; $ECHO \$dlname'\''`~
++    dlpath=$dir/\$dldll~
++    $RM \$dlpath'
+   ;;
+ 
+ osf3* | osf4* | osf5*)
+   version_type=osf
+   need_lib_prefix=no
+   need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='$libname$release$shared_ext$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   sys_lib_search_path_spec="/usr/shlib /usr/ccs/lib /usr/lib/cmplrs/cc /usr/lib /usr/local/lib /var/shlib"
+-  sys_lib_dlsearch_path_spec="$sys_lib_search_path_spec"
++  sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+   ;;
+ 
+ rdos*)
+@@ -11784,8 +12266,8 @@ solaris*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   hardcode_into_libs=yes
+@@ -11795,11 +12277,11 @@ solaris*)
+ 
+ sunos4*)
+   version_type=sunos
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+   finish_cmds='PATH="\$PATH:/usr/etc" ldconfig $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     need_lib_prefix=no
+   fi
+   need_version=yes
+@@ -11807,8 +12289,8 @@ sunos4*)
+ 
+ sysv4 | sysv4.3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   case $host_vendor in
+     sni)
+@@ -11829,24 +12311,24 @@ sysv4 | sysv4.3*)
+   ;;
+ 
+ sysv4*MP*)
+-  if test -d /usr/nec ;then
++  if test -d /usr/nec; then
+     version_type=linux # correct to gnu/linux during the next big refactor
+-    library_names_spec='$libname${shared_ext}.$versuffix $libname${shared_ext}.$major $libname${shared_ext}'
+-    soname_spec='$libname${shared_ext}.$major'
++    library_names_spec='$libname$shared_ext.$versuffix $libname$shared_ext.$major $libname$shared_ext'
++    soname_spec='$libname$shared_ext.$major'
+     shlibpath_var=LD_LIBRARY_PATH
+   fi
+   ;;
+ 
+ sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
+-  version_type=freebsd-elf
++  version_type=sco
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   hardcode_into_libs=yes
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+     sys_lib_search_path_spec='/usr/ccs/lib /usr/lib'
+@@ -11864,7 +12346,7 @@ tpf*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+   hardcode_into_libs=yes
+@@ -11872,8 +12354,8 @@ tpf*)
+ 
+ uts4*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
+@@ -11883,20 +12365,35 @@ uts4*)
+ esac
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $dynamic_linker" >&5
+ $as_echo "$dynamic_linker" >&6; }
+-test "$dynamic_linker" = no && can_build_shared=no
++test no = "$dynamic_linker" && can_build_shared=no
+ 
+ variables_saved_for_relink="PATH $shlibpath_var $runpath_var"
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   variables_saved_for_relink="$variables_saved_for_relink GCC_EXEC_PREFIX COMPILER_PATH LIBRARY_PATH"
+ fi
+ 
+-if test "${lt_cv_sys_lib_search_path_spec+set}" = set; then
+-  sys_lib_search_path_spec="$lt_cv_sys_lib_search_path_spec"
++if test set = "${lt_cv_sys_lib_search_path_spec+set}"; then
++  sys_lib_search_path_spec=$lt_cv_sys_lib_search_path_spec
+ fi
+-if test "${lt_cv_sys_lib_dlsearch_path_spec+set}" = set; then
+-  sys_lib_dlsearch_path_spec="$lt_cv_sys_lib_dlsearch_path_spec"
++
++if test set = "${lt_cv_sys_lib_dlsearch_path_spec+set}"; then
++  sys_lib_dlsearch_path_spec=$lt_cv_sys_lib_dlsearch_path_spec
+ fi
+ 
++# remember unaugmented sys_lib_dlsearch_path content for libtool script decls...
++configure_time_dlsearch_path=$sys_lib_dlsearch_path_spec
++
++# ... but it needs LT_SYS_LIBRARY_PATH munging for other configure-time code
++func_munge_path_list sys_lib_dlsearch_path_spec "$LT_SYS_LIBRARY_PATH"
++
++# to be used as default LT_SYS_LIBRARY_PATH value in generated libtool
++configure_time_lt_sys_library_path=$LT_SYS_LIBRARY_PATH
++
++
++
++
++
++
+ 
+ 
+ 
+@@ -11993,15 +12490,15 @@ $as_echo_n "checking how to hardcode library paths into programs... " >&6; }
+ hardcode_action=
+ if test -n "$hardcode_libdir_flag_spec" ||
+    test -n "$runpath_var" ||
+-   test "X$hardcode_automatic" = "Xyes" ; then
++   test yes = "$hardcode_automatic"; then
+ 
+   # We can hardcode non-existent directories.
+-  if test "$hardcode_direct" != no &&
++  if test no != "$hardcode_direct" &&
+      # If the only mechanism to avoid hardcoding is shlibpath_var, we
+      # have to relink, otherwise we might link with an installed library
+      # when we should be linking with a yet-to-be-installed one
+-     ## test "$_LT_TAGVAR(hardcode_shlibpath_var, )" != no &&
+-     test "$hardcode_minus_L" != no; then
++     ## test no != "$_LT_TAGVAR(hardcode_shlibpath_var, )" &&
++     test no != "$hardcode_minus_L"; then
+     # Linking always hardcodes the temporary library directory.
+     hardcode_action=relink
+   else
+@@ -12016,12 +12513,12 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $hardcode_action" >&5
+ $as_echo "$hardcode_action" >&6; }
+ 
+-if test "$hardcode_action" = relink ||
+-   test "$inherit_rpath" = yes; then
++if test relink = "$hardcode_action" ||
++   test yes = "$inherit_rpath"; then
+   # Fast installation is not supported
+   enable_fast_install=no
+-elif test "$shlibpath_overrides_runpath" = yes ||
+-     test "$enable_shared" = no; then
++elif test yes = "$shlibpath_overrides_runpath" ||
++     test no = "$enable_shared"; then
+   # Fast installation is not necessary
+   enable_fast_install=needless
+ fi
+@@ -12031,7 +12528,7 @@ fi
+ 
+ 
+ 
+-  if test "x$enable_dlopen" != xyes; then
++  if test yes != "$enable_dlopen"; then
+   enable_dlopen=unknown
+   enable_dlopen_self=unknown
+   enable_dlopen_self_static=unknown
+@@ -12041,23 +12538,23 @@ else
+ 
+   case $host_os in
+   beos*)
+-    lt_cv_dlopen="load_add_on"
++    lt_cv_dlopen=load_add_on
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+     ;;
+ 
+   mingw* | pw32* | cegcc*)
+-    lt_cv_dlopen="LoadLibrary"
++    lt_cv_dlopen=LoadLibrary
+     lt_cv_dlopen_libs=
+     ;;
+ 
+   cygwin*)
+-    lt_cv_dlopen="dlopen"
++    lt_cv_dlopen=dlopen
+     lt_cv_dlopen_libs=
+     ;;
+ 
+   darwin*)
+-  # if libdl is installed we need to link against it
++    # if libdl is installed we need to link against it
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+ $as_echo_n "checking for dlopen in -ldl... " >&6; }
+ if ${ac_cv_lib_dl_dlopen+:} false; then :
+@@ -12095,10 +12592,10 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+ $as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+ if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
+-  lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-ldl"
++  lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-ldl
+ else
+ 
+-    lt_cv_dlopen="dyld"
++    lt_cv_dlopen=dyld
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+ 
+@@ -12106,10 +12603,18 @@ fi
+ 
+     ;;
+ 
++  tpf*)
++    # Don't try to run any link tests for TPF.  We know it's impossible
++    # because TPF is a cross-compiler, and we know how we open DSOs.
++    lt_cv_dlopen=dlopen
++    lt_cv_dlopen_libs=
++    lt_cv_dlopen_self=no
++    ;;
++
+   *)
+     ac_fn_c_check_func "$LINENO" "shl_load" "ac_cv_func_shl_load"
+ if test "x$ac_cv_func_shl_load" = xyes; then :
+-  lt_cv_dlopen="shl_load"
++  lt_cv_dlopen=shl_load
+ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shl_load in -ldld" >&5
+ $as_echo_n "checking for shl_load in -ldld... " >&6; }
+@@ -12148,11 +12653,11 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dld_shl_load" >&5
+ $as_echo "$ac_cv_lib_dld_shl_load" >&6; }
+ if test "x$ac_cv_lib_dld_shl_load" = xyes; then :
+-  lt_cv_dlopen="shl_load" lt_cv_dlopen_libs="-ldld"
++  lt_cv_dlopen=shl_load lt_cv_dlopen_libs=-ldld
+ else
+   ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
+ if test "x$ac_cv_func_dlopen" = xyes; then :
+-  lt_cv_dlopen="dlopen"
++  lt_cv_dlopen=dlopen
+ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+ $as_echo_n "checking for dlopen in -ldl... " >&6; }
+@@ -12191,7 +12696,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+ $as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+ if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
+-  lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-ldl"
++  lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-ldl
+ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -lsvld" >&5
+ $as_echo_n "checking for dlopen in -lsvld... " >&6; }
+@@ -12230,7 +12735,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_svld_dlopen" >&5
+ $as_echo "$ac_cv_lib_svld_dlopen" >&6; }
+ if test "x$ac_cv_lib_svld_dlopen" = xyes; then :
+-  lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-lsvld"
++  lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-lsvld
+ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dld_link in -ldld" >&5
+ $as_echo_n "checking for dld_link in -ldld... " >&6; }
+@@ -12269,7 +12774,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dld_dld_link" >&5
+ $as_echo "$ac_cv_lib_dld_dld_link" >&6; }
+ if test "x$ac_cv_lib_dld_dld_link" = xyes; then :
+-  lt_cv_dlopen="dld_link" lt_cv_dlopen_libs="-ldld"
++  lt_cv_dlopen=dld_link lt_cv_dlopen_libs=-ldld
+ fi
+ 
+ 
+@@ -12290,21 +12795,21 @@ fi
+     ;;
+   esac
+ 
+-  if test "x$lt_cv_dlopen" != xno; then
+-    enable_dlopen=yes
+-  else
++  if test no = "$lt_cv_dlopen"; then
+     enable_dlopen=no
++  else
++    enable_dlopen=yes
+   fi
+ 
+   case $lt_cv_dlopen in
+   dlopen)
+-    save_CPPFLAGS="$CPPFLAGS"
+-    test "x$ac_cv_header_dlfcn_h" = xyes && CPPFLAGS="$CPPFLAGS -DHAVE_DLFCN_H"
++    save_CPPFLAGS=$CPPFLAGS
++    test yes = "$ac_cv_header_dlfcn_h" && CPPFLAGS="$CPPFLAGS -DHAVE_DLFCN_H"
+ 
+-    save_LDFLAGS="$LDFLAGS"
++    save_LDFLAGS=$LDFLAGS
+     wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $export_dynamic_flag_spec\"
+ 
+-    save_LIBS="$LIBS"
++    save_LIBS=$LIBS
+     LIBS="$lt_cv_dlopen_libs $LIBS"
+ 
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a program can dlopen itself" >&5
+@@ -12312,7 +12817,7 @@ $as_echo_n "checking whether a program can dlopen itself... " >&6; }
+ if ${lt_cv_dlopen_self+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-  	  if test "$cross_compiling" = yes; then :
++  	  if test yes = "$cross_compiling"; then :
+   lt_cv_dlopen_self=cross
+ else
+   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
+@@ -12359,9 +12864,9 @@ else
+ #  endif
+ #endif
+ 
+-/* When -fvisbility=hidden is used, assume the code has been annotated
++/* When -fvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+-#if defined(__GNUC__) && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
++#if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+ #endif
+ 
+@@ -12391,7 +12896,7 @@ _LT_EOF
+   (eval $ac_link) 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; } && test -s conftest${ac_exeext} 2>/dev/null; then
++  test $ac_status = 0; } && test -s "conftest$ac_exeext" 2>/dev/null; then
+     (./conftest; exit; ) >&5 2>/dev/null
+     lt_status=$?
+     case x$lt_status in
+@@ -12411,14 +12916,14 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_dlopen_self" >&5
+ $as_echo "$lt_cv_dlopen_self" >&6; }
+ 
+-    if test "x$lt_cv_dlopen_self" = xyes; then
++    if test yes = "$lt_cv_dlopen_self"; then
+       wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $lt_prog_compiler_static\"
+       { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a statically linked program can dlopen itself" >&5
+ $as_echo_n "checking whether a statically linked program can dlopen itself... " >&6; }
+ if ${lt_cv_dlopen_self_static+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-  	  if test "$cross_compiling" = yes; then :
++  	  if test yes = "$cross_compiling"; then :
+   lt_cv_dlopen_self_static=cross
+ else
+   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
+@@ -12465,9 +12970,9 @@ else
+ #  endif
+ #endif
+ 
+-/* When -fvisbility=hidden is used, assume the code has been annotated
++/* When -fvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+-#if defined(__GNUC__) && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
++#if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+ #endif
+ 
+@@ -12497,7 +13002,7 @@ _LT_EOF
+   (eval $ac_link) 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; } && test -s conftest${ac_exeext} 2>/dev/null; then
++  test $ac_status = 0; } && test -s "conftest$ac_exeext" 2>/dev/null; then
+     (./conftest; exit; ) >&5 2>/dev/null
+     lt_status=$?
+     case x$lt_status in
+@@ -12518,9 +13023,9 @@ fi
+ $as_echo "$lt_cv_dlopen_self_static" >&6; }
+     fi
+ 
+-    CPPFLAGS="$save_CPPFLAGS"
+-    LDFLAGS="$save_LDFLAGS"
+-    LIBS="$save_LIBS"
++    CPPFLAGS=$save_CPPFLAGS
++    LDFLAGS=$save_LDFLAGS
++    LIBS=$save_LIBS
+     ;;
+   esac
+ 
+@@ -12555,30 +13060,41 @@ striplib=
+ old_striplib=
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether stripping libraries is possible" >&5
+ $as_echo_n "checking whether stripping libraries is possible... " >&6; }
+-if test -n "$STRIP" && $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
+-  test -z "$old_striplib" && old_striplib="$STRIP --strip-debug"
+-  test -z "$striplib" && striplib="$STRIP --strip-unneeded"
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
++if test -z "$STRIP"; then
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
+ else
+-# FIXME - insert some real tests, host_os isn't really good enough
+-  case $host_os in
+-  darwin*)
+-    if test -n "$STRIP" ; then
++  if $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
++    old_striplib="$STRIP --strip-debug"
++    striplib="$STRIP --strip-unneeded"
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++  else
++    case $host_os in
++    darwin*)
++      # FIXME - insert some real tests, host_os isn't really good enough
+       striplib="$STRIP -x"
+       old_striplib="$STRIP -S"
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+-    else
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++      ;;
++    freebsd*)
++      if $STRIP -V 2>&1 | $GREP "elftoolchain" >/dev/null; then
++        old_striplib="$STRIP --strip-debug"
++        striplib="$STRIP --strip-unneeded"
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++      else
++        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }
+-    fi
+-    ;;
+-  *)
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++      fi
++      ;;
++    *)
++      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }
+-    ;;
+-  esac
++      ;;
++    esac
++  fi
+ fi
+ 
+ 
+@@ -12592,7 +13108,7 @@ fi
+ 
+ 
+ 
+-  # Report which library types will actually be built
++  # Report what library types will actually be built
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if libtool supports shared libraries" >&5
+ $as_echo_n "checking if libtool supports shared libraries... " >&6; }
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $can_build_shared" >&5
+@@ -12600,13 +13116,13 @@ $as_echo "$can_build_shared" >&6; }
+ 
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build shared libraries" >&5
+ $as_echo_n "checking whether to build shared libraries... " >&6; }
+-  test "$can_build_shared" = "no" && enable_shared=no
++  test no = "$can_build_shared" && enable_shared=no
+ 
+   # On AIX, shared libraries and static libraries use the same namespace, and
+   # are all built from PIC.
+   case $host_os in
+   aix3*)
+-    test "$enable_shared" = yes && enable_static=no
++    test yes = "$enable_shared" && enable_static=no
+     if test -n "$RANLIB"; then
+       archive_cmds="$archive_cmds~\$RANLIB \$lib"
+       postinstall_cmds='$RANLIB $lib'
+@@ -12614,8 +13130,12 @@ $as_echo_n "checking whether to build shared libraries... " >&6; }
+     ;;
+ 
+   aix[4-9]*)
+-    if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
+-      test "$enable_shared" = yes && enable_static=no
++    if test ia64 != "$host_cpu"; then
++      case $enable_shared,$with_aix_soname,$aix_use_runtimelinking in
++      yes,aix,yes) ;;			# shared object as lib.so file only
++      yes,svr4,*) ;;			# shared object as lib.so archive member only
++      yes,*) enable_static=no ;;	# shared object in lib.a archive as well
++      esac
+     fi
+     ;;
+   esac
+@@ -12625,7 +13145,7 @@ $as_echo "$enable_shared" >&6; }
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build static libraries" >&5
+ $as_echo_n "checking whether to build static libraries... " >&6; }
+   # Make sure either enable_shared or enable_static is yes.
+-  test "$enable_shared" = yes || enable_static=yes
++  test yes = "$enable_shared" || enable_static=yes
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_static" >&5
+ $as_echo "$enable_static" >&6; }
+ 
+@@ -12639,11 +13159,11 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+-CC="$lt_save_CC"
++CC=$lt_save_CC
+ 
+-      if test -n "$CXX" && ( test "X$CXX" != "Xno" &&
+-    ( (test "X$CXX" = "Xg++" && `g++ -v >/dev/null 2>&1` ) ||
+-    (test "X$CXX" != "Xg++"))) ; then
++      if test -n "$CXX" && ( test no != "$CXX" &&
++    ( (test g++ = "$CXX" && `g++ -v >/dev/null 2>&1` ) ||
++    (test g++ != "$CXX"))); then
+   ac_ext=cpp
+ ac_cpp='$CXXCPP $CPPFLAGS'
+ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -12822,7 +13342,7 @@ objext_CXX=$objext
+ # the CXX compiler isn't working.  Some variables (like enable_shared)
+ # are currently assumed to apply to all compilers on this platform,
+ # and will be corrupted by setting them based on a non-working compiler.
+-if test "$_lt_caught_CXX_error" != yes; then
++if test yes != "$_lt_caught_CXX_error"; then
+   # Code to be used in simple compile tests
+   lt_simple_compile_test_code="int some_variable = 0;"
+ 
+@@ -12883,46 +13403,39 @@ $RM -r conftest*
+   CFLAGS=$CXXFLAGS
+   compiler=$CC
+   compiler_CXX=$CC
+-  for cc_temp in $compiler""; do
+-  case $cc_temp in
+-    compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
+-    distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
+-    \-*) ;;
+-    *) break;;
+-  esac
+-done
+-cc_basename=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++  func_cc_basename $compiler
++cc_basename=$func_cc_basename_result
+ 
+ 
+   if test -n "$compiler"; then
+     # We don't want -fno-exception when compiling C++ code, so set the
+     # no_builtin_flag separately
+-    if test "$GXX" = yes; then
++    if test yes = "$GXX"; then
+       lt_prog_compiler_no_builtin_flag_CXX=' -fno-builtin'
+     else
+       lt_prog_compiler_no_builtin_flag_CXX=
+     fi
+ 
+-    if test "$GXX" = yes; then
++    if test yes = "$GXX"; then
+       # Set up default GNU C++ configuration
+ 
+ 
+ 
+ # Check whether --with-gnu-ld was given.
+ if test "${with_gnu_ld+set}" = set; then :
+-  withval=$with_gnu_ld; test "$withval" = no || with_gnu_ld=yes
++  withval=$with_gnu_ld; test no = "$withval" || with_gnu_ld=yes
+ else
+   with_gnu_ld=no
+ fi
+ 
+ ac_prog=ld
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   # Check if gcc -print-prog-name=ld gives a path.
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ld used by $CC" >&5
+ $as_echo_n "checking for ld used by $CC... " >&6; }
+   case $host in
+   *-*-mingw*)
+-    # gcc leaves a trailing carriage return which upsets mingw
++    # gcc leaves a trailing carriage return, which upsets mingw
+     ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
+   *)
+     ac_prog=`($CC -print-prog-name=ld) 2>&5` ;;
+@@ -12936,7 +13449,7 @@ $as_echo_n "checking for ld used by $CC... " >&6; }
+       while $ECHO "$ac_prog" | $GREP "$re_direlt" > /dev/null 2>&1; do
+ 	ac_prog=`$ECHO $ac_prog| $SED "s%$re_direlt%/%"`
+       done
+-      test -z "$LD" && LD="$ac_prog"
++      test -z "$LD" && LD=$ac_prog
+       ;;
+   "")
+     # If it fails, then pretend we aren't using GCC.
+@@ -12947,7 +13460,7 @@ $as_echo_n "checking for ld used by $CC... " >&6; }
+     with_gnu_ld=unknown
+     ;;
+   esac
+-elif test "$with_gnu_ld" = yes; then
++elif test yes = "$with_gnu_ld"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GNU ld" >&5
+ $as_echo_n "checking for GNU ld... " >&6; }
+ else
+@@ -12958,32 +13471,32 @@ if ${lt_cv_path_LD+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   if test -z "$LD"; then
+-  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+   for ac_dir in $PATH; do
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+     test -z "$ac_dir" && ac_dir=.
+     if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
+-      lt_cv_path_LD="$ac_dir/$ac_prog"
++      lt_cv_path_LD=$ac_dir/$ac_prog
+       # Check to see if the program is GNU ld.  I'd rather use --version,
+       # but apparently some variants of GNU ld only accept -v.
+       # Break only if it was the GNU/non-GNU ld that we prefer.
+       case `"$lt_cv_path_LD" -v 2>&1 </dev/null` in
+       *GNU* | *'with BFD'*)
+-	test "$with_gnu_ld" != no && break
++	test no != "$with_gnu_ld" && break
+ 	;;
+       *)
+-	test "$with_gnu_ld" != yes && break
++	test yes != "$with_gnu_ld" && break
+ 	;;
+       esac
+     fi
+   done
+-  IFS="$lt_save_ifs"
++  IFS=$lt_save_ifs
+ else
+-  lt_cv_path_LD="$LD" # Let the user override the test with a path.
++  lt_cv_path_LD=$LD # Let the user override the test with a path.
+ fi
+ fi
+ 
+-LD="$lt_cv_path_LD"
++LD=$lt_cv_path_LD
+ if test -n "$LD"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
+ $as_echo "$LD" >&6; }
+@@ -13019,22 +13532,22 @@ with_gnu_ld=$lt_cv_prog_gnu_ld
+ 
+       # Check if GNU C++ uses GNU ld as the underlying linker, since the
+       # archiving commands below assume that GNU ld is being used.
+-      if test "$with_gnu_ld" = yes; then
+-        archive_cmds_CXX='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-        archive_expsym_cmds_CXX='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++      if test yes = "$with_gnu_ld"; then
++        archive_cmds_CXX='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++        archive_expsym_cmds_CXX='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 
+-        hardcode_libdir_flag_spec_CXX='${wl}-rpath ${wl}$libdir'
+-        export_dynamic_flag_spec_CXX='${wl}--export-dynamic'
++        hardcode_libdir_flag_spec_CXX='$wl-rpath $wl$libdir'
++        export_dynamic_flag_spec_CXX='$wl--export-dynamic'
+ 
+         # If archive_cmds runs LD, not CC, wlarc should be empty
+         # XXX I think wlarc can be eliminated in ltcf-cxx, but I need to
+         #     investigate it a little bit more. (MM)
+-        wlarc='${wl}'
++        wlarc='$wl'
+ 
+         # ancient GNU ld didn't support --whole-archive et. al.
+         if eval "`$CC -print-prog-name=ld` --help 2>&1" |
+ 	  $GREP 'no-whole-archive' > /dev/null; then
+-          whole_archive_flag_spec_CXX="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++          whole_archive_flag_spec_CXX=$wlarc'--whole-archive$convenience '$wlarc'--no-whole-archive'
+         else
+           whole_archive_flag_spec_CXX=
+         fi
+@@ -13071,18 +13584,30 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+         ld_shlibs_CXX=no
+         ;;
+       aix[4-9]*)
+-        if test "$host_cpu" = ia64; then
++        if test ia64 = "$host_cpu"; then
+           # On IA64, the linker does run time linking by default, so we don't
+           # have to do anything special.
+           aix_use_runtimelinking=no
+           exp_sym_flag='-Bexport'
+-          no_entry_flag=""
++          no_entry_flag=
+         else
+           aix_use_runtimelinking=no
+ 
+           # Test if we are trying to use run time linking or normal
+           # AIX style linking. If -brtl is somewhere in LDFLAGS, we
+-          # need to do runtime linking.
++          # have runtime linking enabled, and use it for executables.
++          # For shared libraries, we enable/disable runtime linking
++          # depending on the kind of the shared library created -
++          # when "with_aix_soname,aix_use_runtimelinking" is:
++          # "aix,no"   lib.a(lib.so.V) shared, rtl:no,  for executables
++          # "aix,yes"  lib.so          shared, rtl:yes, for executables
++          #            lib.a           static archive
++          # "both,no"  lib.so.V(shr.o) shared, rtl:yes
++          #            lib.a(lib.so.V) shared, rtl:no,  for executables
++          # "both,yes" lib.so.V(shr.o) shared, rtl:yes, for executables
++          #            lib.a(lib.so.V) shared, rtl:no
++          # "svr4,*"   lib.so.V(shr.o) shared, rtl:yes, for executables
++          #            lib.a           static archive
+           case $host_os in aix4.[23]|aix4.[23].*|aix[5-9]*)
+ 	    for ld_flag in $LDFLAGS; do
+ 	      case $ld_flag in
+@@ -13092,6 +13617,13 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+ 	        ;;
+ 	      esac
+ 	    done
++	    if test svr4,no = "$with_aix_soname,$aix_use_runtimelinking"; then
++	      # With aix-soname=svr4, we create the lib.so.V shared archives only,
++	      # so we don't have lib.a shared libs to link our executables.
++	      # We have to force runtime linking in this case.
++	      aix_use_runtimelinking=yes
++	      LDFLAGS="$LDFLAGS -Wl,-brtl"
++	    fi
+ 	    ;;
+           esac
+ 
+@@ -13110,13 +13642,21 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+         hardcode_direct_absolute_CXX=yes
+         hardcode_libdir_separator_CXX=':'
+         link_all_deplibs_CXX=yes
+-        file_list_spec_CXX='${wl}-f,'
++        file_list_spec_CXX='$wl-f,'
++        case $with_aix_soname,$aix_use_runtimelinking in
++        aix,*) ;;	# no import file
++        svr4,* | *,yes) # use import file
++          # The Import File defines what to hardcode.
++          hardcode_direct_CXX=no
++          hardcode_direct_absolute_CXX=no
++          ;;
++        esac
+ 
+-        if test "$GXX" = yes; then
++        if test yes = "$GXX"; then
+           case $host_os in aix4.[012]|aix4.[012].*)
+           # We only want to do this on AIX 4.2 and lower, the check
+           # below for broken collect2 doesn't work under 4.3+
+-	  collect2name=`${CC} -print-prog-name=collect2`
++	  collect2name=`$CC -print-prog-name=collect2`
+ 	  if test -f "$collect2name" &&
+ 	     strings "$collect2name" | $GREP resolve_lib_name >/dev/null
+ 	  then
+@@ -13134,36 +13674,44 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+ 	  fi
+           esac
+           shared_flag='-shared'
+-	  if test "$aix_use_runtimelinking" = yes; then
+-	    shared_flag="$shared_flag "'${wl}-G'
++	  if test yes = "$aix_use_runtimelinking"; then
++	    shared_flag=$shared_flag' $wl-G'
+ 	  fi
++	  # Need to ensure runtime linking is disabled for the traditional
++	  # shared library, or the linker may eventually find shared libraries
++	  # /with/ Import File - we do not want to mix them.
++	  shared_flag_aix='-shared'
++	  shared_flag_svr4='-shared $wl-G'
+         else
+           # not using gcc
+-          if test "$host_cpu" = ia64; then
++          if test ia64 = "$host_cpu"; then
+ 	  # VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
+ 	  # chokes on -Wl,-G. The following line is correct:
+ 	  shared_flag='-G'
+           else
+-	    if test "$aix_use_runtimelinking" = yes; then
+-	      shared_flag='${wl}-G'
++	    if test yes = "$aix_use_runtimelinking"; then
++	      shared_flag='$wl-G'
+ 	    else
+-	      shared_flag='${wl}-bM:SRE'
++	      shared_flag='$wl-bM:SRE'
+ 	    fi
++	    shared_flag_aix='$wl-bM:SRE'
++	    shared_flag_svr4='$wl-G'
+           fi
+         fi
+ 
+-        export_dynamic_flag_spec_CXX='${wl}-bexpall'
++        export_dynamic_flag_spec_CXX='$wl-bexpall'
+         # It seems that -bexpall does not export symbols beginning with
+         # underscore (_), so it is better to generate a list of symbols to
+ 	# export.
+         always_export_symbols_CXX=yes
+-        if test "$aix_use_runtimelinking" = yes; then
++	if test aix,yes = "$with_aix_soname,$aix_use_runtimelinking"; then
+           # Warning - without using the other runtime loading flags (-brtl),
+           # -berok will link without error, but may produce a broken library.
+-          allow_undefined_flag_CXX='-berok'
++          # The "-G" linker flag allows undefined symbols.
++          no_undefined_flag_CXX='-bernotok'
+           # Determine the default libpath from the value encoded in an empty
+           # executable.
+-          if test "${lt_cv_aix_libpath+set}" = set; then
++          if test set = "${lt_cv_aix_libpath+set}"; then
+   aix_libpath=$lt_cv_aix_libpath
+ else
+   if ${lt_cv_aix_libpath__CXX+:} false; then :
+@@ -13198,7 +13746,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+   if test -z "$lt_cv_aix_libpath__CXX"; then
+-    lt_cv_aix_libpath__CXX="/usr/lib:/lib"
++    lt_cv_aix_libpath__CXX=/usr/lib:/lib
+   fi
+ 
+ fi
+@@ -13206,18 +13754,18 @@ fi
+   aix_libpath=$lt_cv_aix_libpath__CXX
+ fi
+ 
+-          hardcode_libdir_flag_spec_CXX='${wl}-blibpath:$libdir:'"$aix_libpath"
++          hardcode_libdir_flag_spec_CXX='$wl-blibpath:$libdir:'"$aix_libpath"
+ 
+-          archive_expsym_cmds_CXX='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
++          archive_expsym_cmds_CXX='$CC -o $output_objdir/$soname $libobjs $deplibs $wl'$no_entry_flag' $compiler_flags `if test -n "$allow_undefined_flag"; then func_echo_all "$wl$allow_undefined_flag"; else :; fi` $wl'$exp_sym_flag:\$export_symbols' '$shared_flag
+         else
+-          if test "$host_cpu" = ia64; then
+-	    hardcode_libdir_flag_spec_CXX='${wl}-R $libdir:/usr/lib:/lib'
++          if test ia64 = "$host_cpu"; then
++	    hardcode_libdir_flag_spec_CXX='$wl-R $libdir:/usr/lib:/lib'
+ 	    allow_undefined_flag_CXX="-z nodefs"
+-	    archive_expsym_cmds_CXX="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
++	    archive_expsym_cmds_CXX="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\$wl$no_entry_flag"' $compiler_flags $wl$allow_undefined_flag '"\$wl$exp_sym_flag:\$export_symbols"
+           else
+ 	    # Determine the default libpath from the value encoded in an
+ 	    # empty executable.
+-	    if test "${lt_cv_aix_libpath+set}" = set; then
++	    if test set = "${lt_cv_aix_libpath+set}"; then
+   aix_libpath=$lt_cv_aix_libpath
+ else
+   if ${lt_cv_aix_libpath__CXX+:} false; then :
+@@ -13252,7 +13800,7 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+   if test -z "$lt_cv_aix_libpath__CXX"; then
+-    lt_cv_aix_libpath__CXX="/usr/lib:/lib"
++    lt_cv_aix_libpath__CXX=/usr/lib:/lib
+   fi
+ 
+ fi
+@@ -13260,22 +13808,34 @@ fi
+   aix_libpath=$lt_cv_aix_libpath__CXX
+ fi
+ 
+-	    hardcode_libdir_flag_spec_CXX='${wl}-blibpath:$libdir:'"$aix_libpath"
++	    hardcode_libdir_flag_spec_CXX='$wl-blibpath:$libdir:'"$aix_libpath"
+ 	    # Warning - without using the other run time loading flags,
+ 	    # -berok will link without error, but may produce a broken library.
+-	    no_undefined_flag_CXX=' ${wl}-bernotok'
+-	    allow_undefined_flag_CXX=' ${wl}-berok'
+-	    if test "$with_gnu_ld" = yes; then
++	    no_undefined_flag_CXX=' $wl-bernotok'
++	    allow_undefined_flag_CXX=' $wl-berok'
++	    if test yes = "$with_gnu_ld"; then
+ 	      # We only use this code for GNU lds that support --whole-archive.
+-	      whole_archive_flag_spec_CXX='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	      whole_archive_flag_spec_CXX='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	    else
+ 	      # Exported symbols can be pulled into shared objects from archives
+ 	      whole_archive_flag_spec_CXX='$convenience'
+ 	    fi
+ 	    archive_cmds_need_lc_CXX=yes
+-	    # This is similar to how AIX traditionally builds its shared
+-	    # libraries.
+-	    archive_expsym_cmds_CXX="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
++	    archive_expsym_cmds_CXX='$RM -r $output_objdir/$realname.d~$MKDIR $output_objdir/$realname.d'
++	    # -brtl affects multiple linker settings, -berok does not and is overridden later
++	    compiler_flags_filtered='`func_echo_all "$compiler_flags " | $SED -e "s%-brtl\\([, ]\\)%-berok\\1%g"`'
++	    if test svr4 != "$with_aix_soname"; then
++	      # This is similar to how AIX traditionally builds its shared
++	      # libraries. Need -bnortl late, we may have -brtl in LDFLAGS.
++	      archive_expsym_cmds_CXX="$archive_expsym_cmds_CXX"'~$CC '$shared_flag_aix' -o $output_objdir/$realname.d/$soname $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$realname.d/$soname'
++	    fi
++	    if test aix != "$with_aix_soname"; then
++	      archive_expsym_cmds_CXX="$archive_expsym_cmds_CXX"'~$CC '$shared_flag_svr4' -o $output_objdir/$realname.d/$shared_archive_member_spec.o $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$STRIP -e $output_objdir/$realname.d/$shared_archive_member_spec.o~( func_echo_all "#! $soname($shared_archive_member_spec.o)"; if test shr_64 = "$shared_archive_member_spec"; then func_echo_all "# 64"; else func_echo_all "# 32"; fi; cat $export_symbols ) > $output_objdir/$realname.d/$shared_archive_member_spec.imp~$AR $AR_FLAGS $output_objdir/$soname $output_objdir/$realname.d/$shared_archive_member_spec.o $output_objdir/$realname.d/$shared_archive_member_spec.imp'
++	    else
++	      # used by -dlpreopen to get the symbols
++	      archive_expsym_cmds_CXX="$archive_expsym_cmds_CXX"'~$MV  $output_objdir/$realname.d/$soname $output_objdir'
++	    fi
++	    archive_expsym_cmds_CXX="$archive_expsym_cmds_CXX"'~$RM -r $output_objdir/$realname.d'
+           fi
+         fi
+         ;;
+@@ -13285,7 +13845,7 @@ fi
+ 	  allow_undefined_flag_CXX=unsupported
+ 	  # Joseph Beckenbach <jrb3@best.com> says some releases of gcc
+ 	  # support --undefined.  This deserves some investigation.  FIXME
+-	  archive_cmds_CXX='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	  archive_cmds_CXX='$CC -nostart $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+ 	else
+ 	  ld_shlibs_CXX=no
+ 	fi
+@@ -13313,57 +13873,58 @@ fi
+ 	  # Tell ltmain to make .lib files, not .a files.
+ 	  libext=lib
+ 	  # Tell ltmain to make .dll files, not .so files.
+-	  shrext_cmds=".dll"
++	  shrext_cmds=.dll
+ 	  # FIXME: Setting linknames here is a bad hack.
+-	  archive_cmds_CXX='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
+-	  archive_expsym_cmds_CXX='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	      $SED -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
+-	    else
+-	      $SED -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
+-	    fi~
+-	    $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
+-	    linknames='
++	  archive_cmds_CXX='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~linknames='
++	  archive_expsym_cmds_CXX='if   test DEF = "`$SED -n     -e '\''s/^[	 ]*//'\''     -e '\''/^\(;.*\)*$/d'\''     -e '\''s/^\(EXPORTS\|LIBRARY\)\([	 ].*\)*$/DEF/p'\''     -e q     $export_symbols`" ; then
++              cp "$export_symbols" "$output_objdir/$soname.def";
++              echo "$tool_output_objdir$soname.def" > "$output_objdir/$soname.exp";
++            else
++              $SED -e '\''s/^/-link -EXPORT:/'\'' < $export_symbols > $output_objdir/$soname.exp;
++            fi~
++            $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
++            linknames='
+ 	  # The linker will not automatically build a static lib if we build a DLL.
+ 	  # _LT_TAGVAR(old_archive_from_new_cmds, CXX)='true'
+ 	  enable_shared_with_static_runtimes_CXX=yes
+ 	  # Don't use ranlib
+ 	  old_postinstall_cmds_CXX='chmod 644 $oldlib'
+ 	  postlink_cmds_CXX='lt_outputfile="@OUTPUT@"~
+-	    lt_tool_outputfile="@TOOL_OUTPUT@"~
+-	    case $lt_outputfile in
+-	      *.exe|*.EXE) ;;
+-	      *)
+-		lt_outputfile="$lt_outputfile.exe"
+-		lt_tool_outputfile="$lt_tool_outputfile.exe"
+-		;;
+-	    esac~
+-	    func_to_tool_file "$lt_outputfile"~
+-	    if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
+-	      $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
+-	      $RM "$lt_outputfile.manifest";
+-	    fi'
++            lt_tool_outputfile="@TOOL_OUTPUT@"~
++            case $lt_outputfile in
++              *.exe|*.EXE) ;;
++              *)
++                lt_outputfile=$lt_outputfile.exe
++                lt_tool_outputfile=$lt_tool_outputfile.exe
++                ;;
++            esac~
++            func_to_tool_file "$lt_outputfile"~
++            if test : != "$MANIFEST_TOOL" && test -f "$lt_outputfile.manifest"; then
++              $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
++              $RM "$lt_outputfile.manifest";
++            fi'
+ 	  ;;
+ 	*)
+ 	  # g++
+ 	  # _LT_TAGVAR(hardcode_libdir_flag_spec, CXX) is actually meaningless,
+ 	  # as there is no search path for DLLs.
+ 	  hardcode_libdir_flag_spec_CXX='-L$libdir'
+-	  export_dynamic_flag_spec_CXX='${wl}--export-all-symbols'
++	  export_dynamic_flag_spec_CXX='$wl--export-all-symbols'
+ 	  allow_undefined_flag_CXX=unsupported
+ 	  always_export_symbols_CXX=no
+ 	  enable_shared_with_static_runtimes_CXX=yes
+ 
+ 	  if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+-	    archive_cmds_CXX='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-	    # If the export-symbols file already is a .def file (1st line
+-	    # is EXPORTS), use it as is; otherwise, prepend...
+-	    archive_expsym_cmds_CXX='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	      cp $export_symbols $output_objdir/$soname.def;
+-	    else
+-	      echo EXPORTS > $output_objdir/$soname.def;
+-	      cat $export_symbols >> $output_objdir/$soname.def;
+-	    fi~
+-	    $CC -shared -nostdlib $output_objdir/$soname.def $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	    archive_cmds_CXX='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	    # If the export-symbols file already is a .def file, use it as
++	    # is; otherwise, prepend EXPORTS...
++	    archive_expsym_cmds_CXX='if   test DEF = "`$SED -n     -e '\''s/^[	 ]*//'\''     -e '\''/^\(;.*\)*$/d'\''     -e '\''s/^\(EXPORTS\|LIBRARY\)\([	 ].*\)*$/DEF/p'\''     -e q     $export_symbols`" ; then
++              cp $export_symbols $output_objdir/$soname.def;
++            else
++              echo EXPORTS > $output_objdir/$soname.def;
++              cat $export_symbols >> $output_objdir/$soname.def;
++            fi~
++            $CC -shared -nostdlib $output_objdir/$soname.def $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+ 	  else
+ 	    ld_shlibs_CXX=no
+ 	  fi
+@@ -13377,27 +13938,27 @@ fi
+   hardcode_direct_CXX=no
+   hardcode_automatic_CXX=yes
+   hardcode_shlibpath_var_CXX=unsupported
+-  if test "$lt_cv_ld_force_load" = "yes"; then
+-    whole_archive_flag_spec_CXX='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience ${wl}-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
++  if test yes = "$lt_cv_ld_force_load"; then
++    whole_archive_flag_spec_CXX='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience $wl-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
+ 
+   else
+     whole_archive_flag_spec_CXX=''
+   fi
+   link_all_deplibs_CXX=yes
+-  allow_undefined_flag_CXX="$_lt_dar_allow_undefined"
++  allow_undefined_flag_CXX=$_lt_dar_allow_undefined
+   case $cc_basename in
+-     ifort*) _lt_dar_can_shared=yes ;;
++     ifort*|nagfor*) _lt_dar_can_shared=yes ;;
+      *) _lt_dar_can_shared=$GCC ;;
+   esac
+-  if test "$_lt_dar_can_shared" = "yes"; then
++  if test yes = "$_lt_dar_can_shared"; then
+     output_verbose_link_cmd=func_echo_all
+-    archive_cmds_CXX="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod${_lt_dsymutil}"
+-    module_cmds_CXX="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dsymutil}"
+-    archive_expsym_cmds_CXX="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring ${_lt_dar_single_mod}${_lt_dar_export_syms}${_lt_dsymutil}"
+-    module_expsym_cmds_CXX="sed -e 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dar_export_syms}${_lt_dsymutil}"
+-       if test "$lt_cv_apple_cc_single_mod" != "yes"; then
+-      archive_cmds_CXX="\$CC -r -keep_private_externs -nostdlib -o \${lib}-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \${lib}-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring${_lt_dsymutil}"
+-      archive_expsym_cmds_CXX="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -r -keep_private_externs -nostdlib -o \${lib}-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \${lib}-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring${_lt_dar_export_syms}${_lt_dsymutil}"
++    archive_cmds_CXX="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dsymutil"
++    module_cmds_CXX="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dsymutil"
++    archive_expsym_cmds_CXX="sed 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dar_export_syms$_lt_dsymutil"
++    module_expsym_cmds_CXX="sed -e 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dar_export_syms$_lt_dsymutil"
++       if test yes != "$lt_cv_apple_cc_single_mod"; then
++      archive_cmds_CXX="\$CC -r -keep_private_externs -nostdlib -o \$lib-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$lib-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring$_lt_dsymutil"
++      archive_expsym_cmds_CXX="sed 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -r -keep_private_externs -nostdlib -o \$lib-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$lib-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring$_lt_dar_export_syms$_lt_dsymutil"
+     fi
+ 
+   else
+@@ -13406,6 +13967,35 @@ fi
+ 
+ 	;;
+ 
++      os2*)
++	hardcode_libdir_flag_spec_CXX='-L$libdir'
++	hardcode_minus_L_CXX=yes
++	allow_undefined_flag_CXX=unsupported
++	shrext_cmds=.dll
++	archive_cmds_CXX='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	  $ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	  $ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	  $ECHO EXPORTS >> $output_objdir/$libname.def~
++	  emxexp $libobjs | $SED /"_DLL_InitTerm"/d >> $output_objdir/$libname.def~
++	  $CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	  emximp -o $lib $output_objdir/$libname.def'
++	archive_expsym_cmds_CXX='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	  $ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	  $ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	  $ECHO EXPORTS >> $output_objdir/$libname.def~
++	  prefix_cmds="$SED"~
++	  if test EXPORTS = "`$SED 1q $export_symbols`"; then
++	    prefix_cmds="$prefix_cmds -e 1d";
++	  fi~
++	  prefix_cmds="$prefix_cmds -e \"s/^\(.*\)$/_\1/g\""~
++	  cat $export_symbols | $prefix_cmds >> $output_objdir/$libname.def~
++	  $CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	  emximp -o $lib $output_objdir/$libname.def'
++	old_archive_From_new_cmds_CXX='emximp -o $output_objdir/${libname}_dll.a $output_objdir/$libname.def'
++	enable_shared_with_static_runtimes_CXX=yes
++	file_list_spec_CXX='@'
++	;;
++
+       dgux*)
+         case $cc_basename in
+           ec++*)
+@@ -13440,18 +14030,15 @@ fi
+         ld_shlibs_CXX=yes
+         ;;
+ 
+-      gnu*)
+-        ;;
+-
+       haiku*)
+-        archive_cmds_CXX='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++        archive_cmds_CXX='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+         link_all_deplibs_CXX=yes
+         ;;
+ 
+       hpux9*)
+-        hardcode_libdir_flag_spec_CXX='${wl}+b ${wl}$libdir'
++        hardcode_libdir_flag_spec_CXX='$wl+b $wl$libdir'
+         hardcode_libdir_separator_CXX=:
+-        export_dynamic_flag_spec_CXX='${wl}-E'
++        export_dynamic_flag_spec_CXX='$wl-E'
+         hardcode_direct_CXX=yes
+         hardcode_minus_L_CXX=yes # Not in the search PATH,
+ 				             # but as the default
+@@ -13463,7 +14050,7 @@ fi
+             ld_shlibs_CXX=no
+             ;;
+           aCC*)
+-            archive_cmds_CXX='$RM $output_objdir/$soname~$CC -b ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++            archive_cmds_CXX='$RM $output_objdir/$soname~$CC -b $wl+b $wl$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+             # Commands to make compiler produce verbose output that lists
+             # what "hidden" libraries, object files and flags are used when
+             # linking a shared library.
+@@ -13472,11 +14059,11 @@ fi
+             # explicitly linking system object files so we need to strip them
+             # from the output so that they don't get included in the library
+             # dependencies.
+-            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP "\-L"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP "\-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+             ;;
+           *)
+-            if test "$GXX" = yes; then
+-              archive_cmds_CXX='$RM $output_objdir/$soname~$CC -shared -nostdlib $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++            if test yes = "$GXX"; then
++              archive_cmds_CXX='$RM $output_objdir/$soname~$CC -shared -nostdlib $pic_flag $wl+b $wl$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+             else
+               # FIXME: insert proper C++ library support
+               ld_shlibs_CXX=no
+@@ -13486,15 +14073,15 @@ fi
+         ;;
+ 
+       hpux10*|hpux11*)
+-        if test $with_gnu_ld = no; then
+-	  hardcode_libdir_flag_spec_CXX='${wl}+b ${wl}$libdir'
++        if test no = "$with_gnu_ld"; then
++	  hardcode_libdir_flag_spec_CXX='$wl+b $wl$libdir'
+ 	  hardcode_libdir_separator_CXX=:
+ 
+           case $host_cpu in
+             hppa*64*|ia64*)
+               ;;
+             *)
+-	      export_dynamic_flag_spec_CXX='${wl}-E'
++	      export_dynamic_flag_spec_CXX='$wl-E'
+               ;;
+           esac
+         fi
+@@ -13520,13 +14107,13 @@ fi
+           aCC*)
+ 	    case $host_cpu in
+ 	      hppa*64*)
+-	        archive_cmds_CXX='$CC -b ${wl}+h ${wl}$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        archive_cmds_CXX='$CC -b $wl+h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	        ;;
+ 	      ia64*)
+-	        archive_cmds_CXX='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        archive_cmds_CXX='$CC -b $wl+h $wl$soname $wl+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	        ;;
+ 	      *)
+-	        archive_cmds_CXX='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        archive_cmds_CXX='$CC -b $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	        ;;
+ 	    esac
+ 	    # Commands to make compiler produce verbose output that lists
+@@ -13537,20 +14124,20 @@ fi
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP "\-L"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP "\-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+ 	    ;;
+           *)
+-	    if test "$GXX" = yes; then
+-	      if test $with_gnu_ld = no; then
++	    if test yes = "$GXX"; then
++	      if test no = "$with_gnu_ld"; then
+ 	        case $host_cpu in
+ 	          hppa*64*)
+-	            archive_cmds_CXX='$CC -shared -nostdlib -fPIC ${wl}+h ${wl}$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            archive_cmds_CXX='$CC -shared -nostdlib -fPIC $wl+h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	            ;;
+ 	          ia64*)
+-	            archive_cmds_CXX='$CC -shared -nostdlib $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            archive_cmds_CXX='$CC -shared -nostdlib $pic_flag $wl+h $wl$soname $wl+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	            ;;
+ 	          *)
+-	            archive_cmds_CXX='$CC -shared -nostdlib $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            archive_cmds_CXX='$CC -shared -nostdlib $pic_flag $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	            ;;
+ 	        esac
+ 	      fi
+@@ -13565,22 +14152,22 @@ fi
+       interix[3-9]*)
+ 	hardcode_direct_CXX=no
+ 	hardcode_shlibpath_var_CXX=no
+-	hardcode_libdir_flag_spec_CXX='${wl}-rpath,$libdir'
+-	export_dynamic_flag_spec_CXX='${wl}-E'
++	hardcode_libdir_flag_spec_CXX='$wl-rpath,$libdir'
++	export_dynamic_flag_spec_CXX='$wl-E'
+ 	# Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
+ 	# Instead, shared libraries are loaded at an image base (0x10000000 by
+ 	# default) and relocated if they conflict, which is a slow very memory
+ 	# consuming and fragmenting process.  To avoid this, we pick a random,
+ 	# 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
+ 	# time.  Moving up from 0x10000000 also allows more sbrk(2) space.
+-	archive_cmds_CXX='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+-	archive_expsym_cmds_CXX='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++	archive_cmds_CXX='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++	archive_expsym_cmds_CXX='sed "s|^|_|" $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--retain-symbols-file,$output_objdir/$soname.expsym $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+ 	;;
+       irix5* | irix6*)
+         case $cc_basename in
+           CC*)
+ 	    # SGI C++
+-	    archive_cmds_CXX='$CC -shared -all -multigot $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	    archive_cmds_CXX='$CC -shared -all -multigot $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+ 
+ 	    # Archives containing C++ object files must be created using
+ 	    # "CC -ar", where "CC" is the IRIX C++ compiler.  This is
+@@ -13589,22 +14176,22 @@ fi
+ 	    old_archive_cmds_CXX='$CC -ar -WR,-u -o $oldlib $oldobjs'
+ 	    ;;
+           *)
+-	    if test "$GXX" = yes; then
+-	      if test "$with_gnu_ld" = no; then
+-	        archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	    if test yes = "$GXX"; then
++	      if test no = "$with_gnu_ld"; then
++	        archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 	      else
+-	        archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` -o $lib'
++	        archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` -o $lib'
+ 	      fi
+ 	    fi
+ 	    link_all_deplibs_CXX=yes
+ 	    ;;
+         esac
+-        hardcode_libdir_flag_spec_CXX='${wl}-rpath ${wl}$libdir'
++        hardcode_libdir_flag_spec_CXX='$wl-rpath $wl$libdir'
+         hardcode_libdir_separator_CXX=:
+         inherit_rpath_CXX=yes
+         ;;
+ 
+-      linux* | k*bsd*-gnu | kopensolaris*-gnu)
++      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+         case $cc_basename in
+           KCC*)
+ 	    # Kuck and Associates, Inc. (KAI) C++ Compiler
+@@ -13612,8 +14199,8 @@ fi
+ 	    # KCC will only create a shared library if the output file
+ 	    # ends with ".so" (or ".sl" for HP-UX), so rename the library
+ 	    # to its proper name (with version) after linking.
+-	    archive_cmds_CXX='tempext=`echo $shared_ext | $SED -e '\''s/\([^()0-9A-Za-z{}]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
+-	    archive_expsym_cmds_CXX='tempext=`echo $shared_ext | $SED -e '\''s/\([^()0-9A-Za-z{}]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib ${wl}-retain-symbols-file,$export_symbols; mv \$templib $lib'
++	    archive_cmds_CXX='tempext=`echo $shared_ext | $SED -e '\''s/\([^()0-9A-Za-z{}]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\$tempext\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
++	    archive_expsym_cmds_CXX='tempext=`echo $shared_ext | $SED -e '\''s/\([^()0-9A-Za-z{}]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\$tempext\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib $wl-retain-symbols-file,$export_symbols; mv \$templib $lib'
+ 	    # Commands to make compiler produce verbose output that lists
+ 	    # what "hidden" libraries, object files and flags are used when
+ 	    # linking a shared library.
+@@ -13622,10 +14209,10 @@ fi
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`$CC $CFLAGS -v conftest.$objext -o libconftest$shared_ext 2>&1 | $GREP "ld"`; rm -f libconftest$shared_ext; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    output_verbose_link_cmd='templist=`$CC $CFLAGS -v conftest.$objext -o libconftest$shared_ext 2>&1 | $GREP "ld"`; rm -f libconftest$shared_ext; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+ 
+-	    hardcode_libdir_flag_spec_CXX='${wl}-rpath,$libdir'
+-	    export_dynamic_flag_spec_CXX='${wl}--export-dynamic'
++	    hardcode_libdir_flag_spec_CXX='$wl-rpath,$libdir'
++	    export_dynamic_flag_spec_CXX='$wl--export-dynamic'
+ 
+ 	    # Archives containing C++ object files must be created using
+ 	    # "CC -Bstatic", where "CC" is the KAI C++ compiler.
+@@ -13639,59 +14226,59 @@ fi
+ 	    # earlier do not add the objects themselves.
+ 	    case `$CC -V 2>&1` in
+ 	      *"Version 7."*)
+-	        archive_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-		archive_expsym_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	        archive_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++		archive_expsym_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 		;;
+ 	      *)  # Version 8.0 or newer
+ 	        tmp_idyn=
+ 	        case $host_cpu in
+ 		  ia64*) tmp_idyn=' -i_dynamic';;
+ 		esac
+-	        archive_cmds_CXX='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-		archive_expsym_cmds_CXX='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	        archive_cmds_CXX='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++		archive_expsym_cmds_CXX='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 		;;
+ 	    esac
+ 	    archive_cmds_need_lc_CXX=no
+-	    hardcode_libdir_flag_spec_CXX='${wl}-rpath,$libdir'
+-	    export_dynamic_flag_spec_CXX='${wl}--export-dynamic'
+-	    whole_archive_flag_spec_CXX='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	    hardcode_libdir_flag_spec_CXX='$wl-rpath,$libdir'
++	    export_dynamic_flag_spec_CXX='$wl--export-dynamic'
++	    whole_archive_flag_spec_CXX='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	    ;;
+           pgCC* | pgcpp*)
+             # Portland Group C++ compiler
+ 	    case `$CC -V` in
+ 	    *pgCC\ [1-5].* | *pgcpp\ [1-5].*)
+ 	      prelink_cmds_CXX='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
++               rm -rf $tpldir~
++               $CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
++               compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      old_archive_cmds_CXX='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+-		$RANLIB $oldlib'
++                rm -rf $tpldir~
++                $CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
++                $AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
++                $RANLIB $oldlib'
+ 	      archive_cmds_CXX='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++                rm -rf $tpldir~
++                $CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
++                $CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
+ 	      archive_expsym_cmds_CXX='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++                rm -rf $tpldir~
++                $CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
++                $CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+-	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+-	      archive_expsym_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++	      archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++	      archive_expsym_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	      ;;
+ 	    esac
+ 
+-	    hardcode_libdir_flag_spec_CXX='${wl}--rpath ${wl}$libdir'
+-	    export_dynamic_flag_spec_CXX='${wl}--export-dynamic'
+-	    whole_archive_flag_spec_CXX='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	    hardcode_libdir_flag_spec_CXX='$wl--rpath $wl$libdir'
++	    export_dynamic_flag_spec_CXX='$wl--export-dynamic'
++	    whole_archive_flag_spec_CXX='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+             ;;
+ 	  cxx*)
+ 	    # Compaq C++
+-	    archive_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    archive_expsym_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname  -o $lib ${wl}-retain-symbols-file $wl$export_symbols'
++	    archive_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++	    archive_expsym_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname  -o $lib $wl-retain-symbols-file $wl$export_symbols'
+ 
+ 	    runpath_var=LD_RUN_PATH
+ 	    hardcode_libdir_flag_spec_CXX='-rpath $libdir'
+@@ -13705,18 +14292,18 @@ fi
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld .*$\)/\1/"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "X$list" | $Xsed'
++	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld .*$\)/\1/"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "X$list" | $Xsed'
+ 	    ;;
+ 	  xl* | mpixl* | bgxl*)
+ 	    # IBM XL 8.0 on PPC, with GNU ld
+-	    hardcode_libdir_flag_spec_CXX='${wl}-rpath ${wl}$libdir'
+-	    export_dynamic_flag_spec_CXX='${wl}--export-dynamic'
+-	    archive_cmds_CXX='$CC -qmkshrobj $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    if test "x$supports_anon_versioning" = xyes; then
++	    hardcode_libdir_flag_spec_CXX='$wl-rpath $wl$libdir'
++	    export_dynamic_flag_spec_CXX='$wl--export-dynamic'
++	    archive_cmds_CXX='$CC -qmkshrobj $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	    if test yes = "$supports_anon_versioning"; then
+ 	      archive_expsym_cmds_CXX='echo "{ global:" > $output_objdir/$libname.ver~
+-		cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-		echo "local: *; };" >> $output_objdir/$libname.ver~
+-		$CC -qmkshrobj $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
++                cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++                echo "local: *; };" >> $output_objdir/$libname.ver~
++                $CC -qmkshrobj $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-version-script $wl$output_objdir/$libname.ver -o $lib'
+ 	    fi
+ 	    ;;
+ 	  *)
+@@ -13724,10 +14311,10 @@ fi
+ 	    *Sun\ C*)
+ 	      # Sun C++ 5.9
+ 	      no_undefined_flag_CXX=' -zdefs'
+-	      archive_cmds_CXX='$CC -G${allow_undefined_flag} -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+-	      archive_expsym_cmds_CXX='$CC -G${allow_undefined_flag} -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-retain-symbols-file ${wl}$export_symbols'
++	      archive_cmds_CXX='$CC -G$allow_undefined_flag -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	      archive_expsym_cmds_CXX='$CC -G$allow_undefined_flag -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-retain-symbols-file $wl$export_symbols'
+ 	      hardcode_libdir_flag_spec_CXX='-R$libdir'
+-	      whole_archive_flag_spec_CXX='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	      whole_archive_flag_spec_CXX='$wl--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	      compiler_needs_object_CXX=yes
+ 
+ 	      # Not sure whether something based on
+@@ -13785,22 +14372,17 @@ fi
+         ld_shlibs_CXX=yes
+ 	;;
+ 
+-      openbsd2*)
+-        # C++ shared libraries are fairly broken
+-	ld_shlibs_CXX=no
+-	;;
+-
+-      openbsd*)
++      openbsd* | bitrig*)
+ 	if test -f /usr/libexec/ld.so; then
+ 	  hardcode_direct_CXX=yes
+ 	  hardcode_shlibpath_var_CXX=no
+ 	  hardcode_direct_absolute_CXX=yes
+ 	  archive_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $lib'
+-	  hardcode_libdir_flag_spec_CXX='${wl}-rpath,$libdir'
+-	  if test -z "`echo __ELF__ | $CC -E - | grep __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-	    archive_expsym_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-retain-symbols-file,$export_symbols -o $lib'
+-	    export_dynamic_flag_spec_CXX='${wl}-E'
+-	    whole_archive_flag_spec_CXX="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++	  hardcode_libdir_flag_spec_CXX='$wl-rpath,$libdir'
++	  if test -z "`echo __ELF__ | $CC -E - | grep __ELF__`"; then
++	    archive_expsym_cmds_CXX='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-retain-symbols-file,$export_symbols -o $lib'
++	    export_dynamic_flag_spec_CXX='$wl-E'
++	    whole_archive_flag_spec_CXX=$wlarc'--whole-archive$convenience '$wlarc'--no-whole-archive'
+ 	  fi
+ 	  output_verbose_link_cmd=func_echo_all
+ 	else
+@@ -13816,9 +14398,9 @@ fi
+ 	    # KCC will only create a shared library if the output file
+ 	    # ends with ".so" (or ".sl" for HP-UX), so rename the library
+ 	    # to its proper name (with version) after linking.
+-	    archive_cmds_CXX='tempext=`echo $shared_ext | $SED -e '\''s/\([^()0-9A-Za-z{}]\)/\\\\\1/g'\''`; templib=`echo "$lib" | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
++	    archive_cmds_CXX='tempext=`echo $shared_ext | $SED -e '\''s/\([^()0-9A-Za-z{}]\)/\\\\\1/g'\''`; templib=`echo "$lib" | $SED -e "s/\$tempext\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
+ 
+-	    hardcode_libdir_flag_spec_CXX='${wl}-rpath,$libdir'
++	    hardcode_libdir_flag_spec_CXX='$wl-rpath,$libdir'
+ 	    hardcode_libdir_separator_CXX=:
+ 
+ 	    # Archives containing C++ object files must be created using
+@@ -13836,17 +14418,17 @@ fi
+           cxx*)
+ 	    case $host in
+ 	      osf3*)
+-	        allow_undefined_flag_CXX=' ${wl}-expect_unresolved ${wl}\*'
+-	        archive_cmds_CXX='$CC -shared${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $soname `test -n "$verstring" && func_echo_all "${wl}-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-	        hardcode_libdir_flag_spec_CXX='${wl}-rpath ${wl}$libdir'
++	        allow_undefined_flag_CXX=' $wl-expect_unresolved $wl\*'
++	        archive_cmds_CXX='$CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $soname `test -n "$verstring" && func_echo_all "$wl-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
++	        hardcode_libdir_flag_spec_CXX='$wl-rpath $wl$libdir'
+ 		;;
+ 	      *)
+ 	        allow_undefined_flag_CXX=' -expect_unresolved \*'
+-	        archive_cmds_CXX='$CC -shared${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	        archive_cmds_CXX='$CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+ 	        archive_expsym_cmds_CXX='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done~
+-	          echo "-hidden">> $lib.exp~
+-	          $CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname ${wl}-input ${wl}$lib.exp  `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~
+-	          $RM $lib.exp'
++                  echo "-hidden">> $lib.exp~
++                  $CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname $wl-input $wl$lib.exp  `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib~
++                  $RM $lib.exp'
+ 	        hardcode_libdir_flag_spec_CXX='-rpath $libdir'
+ 		;;
+ 	    esac
+@@ -13861,21 +14443,21 @@ fi
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld" | $GREP -v "ld:"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld.*$\)/\1/"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld" | $GREP -v "ld:"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld.*$\)/\1/"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+ 	    ;;
+ 	  *)
+-	    if test "$GXX" = yes && test "$with_gnu_ld" = no; then
+-	      allow_undefined_flag_CXX=' ${wl}-expect_unresolved ${wl}\*'
++	    if test yes,no = "$GXX,$with_gnu_ld"; then
++	      allow_undefined_flag_CXX=' $wl-expect_unresolved $wl\*'
+ 	      case $host in
+ 	        osf3*)
+-	          archive_cmds_CXX='$CC -shared -nostdlib ${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	          archive_cmds_CXX='$CC -shared -nostdlib $allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 		  ;;
+ 	        *)
+-	          archive_cmds_CXX='$CC -shared $pic_flag -nostdlib ${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	          archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-msym $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 		  ;;
+ 	      esac
+ 
+-	      hardcode_libdir_flag_spec_CXX='${wl}-rpath ${wl}$libdir'
++	      hardcode_libdir_flag_spec_CXX='$wl-rpath $wl$libdir'
+ 	      hardcode_libdir_separator_CXX=:
+ 
+ 	      # Commands to make compiler produce verbose output that lists
+@@ -13921,9 +14503,9 @@ fi
+ 	    # Sun C++ 4.2, 5.x and Centerline C++
+             archive_cmds_need_lc_CXX=yes
+ 	    no_undefined_flag_CXX=' -zdefs'
+-	    archive_cmds_CXX='$CC -G${allow_undefined_flag}  -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	    archive_cmds_CXX='$CC -G$allow_undefined_flag -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	    archive_expsym_cmds_CXX='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	      $CC -G${allow_undefined_flag} ${wl}-M ${wl}$lib.exp -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++              $CC -G$allow_undefined_flag $wl-M $wl$lib.exp -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
+ 
+ 	    hardcode_libdir_flag_spec_CXX='-R$libdir'
+ 	    hardcode_shlibpath_var_CXX=no
+@@ -13931,7 +14513,7 @@ fi
+ 	      solaris2.[0-5] | solaris2.[0-5].*) ;;
+ 	      *)
+ 		# The compiler driver will combine and reorder linker options,
+-		# but understands `-z linker_flag'.
++		# but understands '-z linker_flag'.
+ 	        # Supported since Solaris 2.6 (maybe 2.5.1?)
+ 		whole_archive_flag_spec_CXX='-z allextract$convenience -z defaultextract'
+ 	        ;;
+@@ -13948,30 +14530,30 @@ fi
+ 	    ;;
+           gcx*)
+ 	    # Green Hills C++ Compiler
+-	    archive_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	    archive_cmds_CXX='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-h $wl$soname -o $lib'
+ 
+ 	    # The C++ compiler must be used to create the archive.
+ 	    old_archive_cmds_CXX='$CC $LDFLAGS -archive -o $oldlib $oldobjs'
+ 	    ;;
+           *)
+ 	    # GNU C++ compiler with Solaris linker
+-	    if test "$GXX" = yes && test "$with_gnu_ld" = no; then
+-	      no_undefined_flag_CXX=' ${wl}-z ${wl}defs'
++	    if test yes,no = "$GXX,$with_gnu_ld"; then
++	      no_undefined_flag_CXX=' $wl-z ${wl}defs'
+ 	      if $CC --version | $GREP -v '^2\.7' > /dev/null; then
+-	        archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $LDFLAGS $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	        archive_cmds_CXX='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-h $wl$soname -o $lib'
+ 	        archive_expsym_cmds_CXX='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-		  $CC -shared $pic_flag -nostdlib ${wl}-M $wl$lib.exp -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++                  $CC -shared $pic_flag -nostdlib $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
+ 
+ 	        # Commands to make compiler produce verbose output that lists
+ 	        # what "hidden" libraries, object files and flags are used when
+ 	        # linking a shared library.
+ 	        output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+ 	      else
+-	        # g++ 2.7 appears to require `-G' NOT `-shared' on this
++	        # g++ 2.7 appears to require '-G' NOT '-shared' on this
+ 	        # platform.
+-	        archive_cmds_CXX='$CC -G -nostdlib $LDFLAGS $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	        archive_cmds_CXX='$CC -G -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-h $wl$soname -o $lib'
+ 	        archive_expsym_cmds_CXX='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-		  $CC -G -nostdlib ${wl}-M $wl$lib.exp -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++                  $CC -G -nostdlib $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
+ 
+ 	        # Commands to make compiler produce verbose output that lists
+ 	        # what "hidden" libraries, object files and flags are used when
+@@ -13979,11 +14561,11 @@ fi
+ 	        output_verbose_link_cmd='$CC -G $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+ 	      fi
+ 
+-	      hardcode_libdir_flag_spec_CXX='${wl}-R $wl$libdir'
++	      hardcode_libdir_flag_spec_CXX='$wl-R $wl$libdir'
+ 	      case $host_os in
+ 		solaris2.[0-5] | solaris2.[0-5].*) ;;
+ 		*)
+-		  whole_archive_flag_spec_CXX='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
++		  whole_archive_flag_spec_CXX='$wl-z ${wl}allextract$convenience $wl-z ${wl}defaultextract'
+ 		  ;;
+ 	      esac
+ 	    fi
+@@ -13992,52 +14574,52 @@ fi
+         ;;
+ 
+     sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[01].[10]* | unixware7* | sco3.2v5.0.[024]*)
+-      no_undefined_flag_CXX='${wl}-z,text'
++      no_undefined_flag_CXX='$wl-z,text'
+       archive_cmds_need_lc_CXX=no
+       hardcode_shlibpath_var_CXX=no
+       runpath_var='LD_RUN_PATH'
+ 
+       case $cc_basename in
+         CC*)
+-	  archive_cmds_CXX='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  archive_expsym_cmds_CXX='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds_CXX='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_expsym_cmds_CXX='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	*)
+-	  archive_cmds_CXX='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  archive_expsym_cmds_CXX='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_cmds_CXX='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  archive_expsym_cmds_CXX='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+       esac
+       ;;
+ 
+       sysv5* | sco3.2v5* | sco5v6*)
+-	# Note: We can NOT use -z defs as we might desire, because we do not
++	# Note: We CANNOT use -z defs as we might desire, because we do not
+ 	# link with -lc, and that would cause any symbols used from libc to
+ 	# always be unresolved, which means just about no library would
+ 	# ever link correctly.  If we're not using GNU ld we use -z text
+ 	# though, which does catch some bad symbols but isn't as heavy-handed
+ 	# as -z defs.
+-	no_undefined_flag_CXX='${wl}-z,text'
+-	allow_undefined_flag_CXX='${wl}-z,nodefs'
++	no_undefined_flag_CXX='$wl-z,text'
++	allow_undefined_flag_CXX='$wl-z,nodefs'
+ 	archive_cmds_need_lc_CXX=no
+ 	hardcode_shlibpath_var_CXX=no
+-	hardcode_libdir_flag_spec_CXX='${wl}-R,$libdir'
++	hardcode_libdir_flag_spec_CXX='$wl-R,$libdir'
+ 	hardcode_libdir_separator_CXX=':'
+ 	link_all_deplibs_CXX=yes
+-	export_dynamic_flag_spec_CXX='${wl}-Bexport'
++	export_dynamic_flag_spec_CXX='$wl-Bexport'
+ 	runpath_var='LD_RUN_PATH'
+ 
+ 	case $cc_basename in
+           CC*)
+-	    archive_cmds_CXX='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	    archive_expsym_cmds_CXX='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    archive_cmds_CXX='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    archive_expsym_cmds_CXX='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	    old_archive_cmds_CXX='$CC -Tprelink_objects $oldobjs~
+-	      '"$old_archive_cmds_CXX"
++              '"$old_archive_cmds_CXX"
+ 	    reload_cmds_CXX='$CC -Tprelink_objects $reload_objs~
+-	      '"$reload_cmds_CXX"
++              '"$reload_cmds_CXX"
+ 	    ;;
+ 	  *)
+-	    archive_cmds_CXX='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	    archive_expsym_cmds_CXX='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    archive_cmds_CXX='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    archive_expsym_cmds_CXX='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	    ;;
+ 	esac
+       ;;
+@@ -14069,10 +14651,10 @@ fi
+ 
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ld_shlibs_CXX" >&5
+ $as_echo "$ld_shlibs_CXX" >&6; }
+-    test "$ld_shlibs_CXX" = no && can_build_shared=no
++    test no = "$ld_shlibs_CXX" && can_build_shared=no
+ 
+-    GCC_CXX="$GXX"
+-    LD_CXX="$LD"
++    GCC_CXX=$GXX
++    LD_CXX=$LD
+ 
+     ## CAVEAT EMPTOR:
+     ## There is no encapsulation within the following macros, do not change
+@@ -14116,13 +14698,13 @@ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+   pre_test_object_deps_done=no
+ 
+   for p in `eval "$output_verbose_link_cmd"`; do
+-    case ${prev}${p} in
++    case $prev$p in
+ 
+     -L* | -R* | -l*)
+        # Some compilers place space between "-{L,R}" and the path.
+        # Remove the space.
+-       if test $p = "-L" ||
+-          test $p = "-R"; then
++       if test x-L = "$p" ||
++          test x-R = "$p"; then
+ 	 prev=$p
+ 	 continue
+        fi
+@@ -14138,16 +14720,16 @@ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+        case $p in
+        =*) func_stripname_cnf '=' '' "$p"; p=$lt_sysroot$func_stripname_result ;;
+        esac
+-       if test "$pre_test_object_deps_done" = no; then
+-	 case ${prev} in
++       if test no = "$pre_test_object_deps_done"; then
++	 case $prev in
+ 	 -L | -R)
+ 	   # Internal compiler library paths should come after those
+ 	   # provided the user.  The postdeps already come after the
+ 	   # user supplied libs so there is no need to process them.
+ 	   if test -z "$compiler_lib_search_path_CXX"; then
+-	     compiler_lib_search_path_CXX="${prev}${p}"
++	     compiler_lib_search_path_CXX=$prev$p
+ 	   else
+-	     compiler_lib_search_path_CXX="${compiler_lib_search_path_CXX} ${prev}${p}"
++	     compiler_lib_search_path_CXX="${compiler_lib_search_path_CXX} $prev$p"
+ 	   fi
+ 	   ;;
+ 	 # The "-l" case would never come before the object being
+@@ -14155,9 +14737,9 @@ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+ 	 esac
+        else
+ 	 if test -z "$postdeps_CXX"; then
+-	   postdeps_CXX="${prev}${p}"
++	   postdeps_CXX=$prev$p
+ 	 else
+-	   postdeps_CXX="${postdeps_CXX} ${prev}${p}"
++	   postdeps_CXX="${postdeps_CXX} $prev$p"
+ 	 fi
+        fi
+        prev=
+@@ -14172,15 +14754,15 @@ if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+ 	 continue
+        fi
+ 
+-       if test "$pre_test_object_deps_done" = no; then
++       if test no = "$pre_test_object_deps_done"; then
+ 	 if test -z "$predep_objects_CXX"; then
+-	   predep_objects_CXX="$p"
++	   predep_objects_CXX=$p
+ 	 else
+ 	   predep_objects_CXX="$predep_objects_CXX $p"
+ 	 fi
+        else
+ 	 if test -z "$postdep_objects_CXX"; then
+-	   postdep_objects_CXX="$p"
++	   postdep_objects_CXX=$p
+ 	 else
+ 	   postdep_objects_CXX="$postdep_objects_CXX $p"
+ 	 fi
+@@ -14210,51 +14792,6 @@ interix[3-9]*)
+   postdep_objects_CXX=
+   postdeps_CXX=
+   ;;
+-
+-linux*)
+-  case `$CC -V 2>&1 | sed 5q` in
+-  *Sun\ C*)
+-    # Sun C++ 5.9
+-
+-    # The more standards-conforming stlport4 library is
+-    # incompatible with the Cstd library. Avoid specifying
+-    # it if it's in CXXFLAGS. Ignore libCrun as
+-    # -library=stlport4 depends on it.
+-    case " $CXX $CXXFLAGS " in
+-    *" -library=stlport4 "*)
+-      solaris_use_stlport4=yes
+-      ;;
+-    esac
+-
+-    if test "$solaris_use_stlport4" != yes; then
+-      postdeps_CXX='-library=Cstd -library=Crun'
+-    fi
+-    ;;
+-  esac
+-  ;;
+-
+-solaris*)
+-  case $cc_basename in
+-  CC* | sunCC*)
+-    # The more standards-conforming stlport4 library is
+-    # incompatible with the Cstd library. Avoid specifying
+-    # it if it's in CXXFLAGS. Ignore libCrun as
+-    # -library=stlport4 depends on it.
+-    case " $CXX $CXXFLAGS " in
+-    *" -library=stlport4 "*)
+-      solaris_use_stlport4=yes
+-      ;;
+-    esac
+-
+-    # Adding this requires a known-good setup of shared libraries for
+-    # Sun compiler versions before 5.6, else PIC objects from an old
+-    # archive will be linked into the output, leading to subtle bugs.
+-    if test "$solaris_use_stlport4" != yes; then
+-      postdeps_CXX='-library=Cstd -library=Crun'
+-    fi
+-    ;;
+-  esac
+-  ;;
+ esac
+ 
+ 
+@@ -14263,7 +14800,7 @@ case " $postdeps_CXX " in
+ esac
+  compiler_lib_search_dirs_CXX=
+ if test -n "${compiler_lib_search_path_CXX}"; then
+- compiler_lib_search_dirs_CXX=`echo " ${compiler_lib_search_path_CXX}" | ${SED} -e 's! -L! !g' -e 's!^ !!'`
++ compiler_lib_search_dirs_CXX=`echo " ${compiler_lib_search_path_CXX}" | $SED -e 's! -L! !g' -e 's!^ !!'`
+ fi
+ 
+ 
+@@ -14302,17 +14839,18 @@ lt_prog_compiler_static_CXX=
+ 
+ 
+   # C++ specific cases for pic, static, wl, etc.
+-  if test "$GXX" = yes; then
++  if test yes = "$GXX"; then
+     lt_prog_compiler_wl_CXX='-Wl,'
+     lt_prog_compiler_static_CXX='-static'
+ 
+     case $host_os in
+     aix*)
+       # All AIX code is PIC.
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	lt_prog_compiler_static_CXX='-Bstatic'
+       fi
++      lt_prog_compiler_pic_CXX='-fPIC'
+       ;;
+ 
+     amigaos*)
+@@ -14323,8 +14861,8 @@ lt_prog_compiler_static_CXX=
+         ;;
+       m68k)
+             # FIXME: we need at least 68020 code to build shared libraries, but
+-            # adding the `-m68020' flag to GCC prevents building anything better,
+-            # like `-m68040'.
++            # adding the '-m68020' flag to GCC prevents building anything better,
++            # like '-m68040'.
+             lt_prog_compiler_pic_CXX='-m68020 -resident32 -malways-restore-a4'
+         ;;
+       esac
+@@ -14339,6 +14877,11 @@ lt_prog_compiler_static_CXX=
+       # Although the cygwin gcc ignores -fPIC, still need this for old-style
+       # (--disable-auto-import) libraries
+       lt_prog_compiler_pic_CXX='-DDLL_EXPORT'
++      case $host_os in
++      os2*)
++	lt_prog_compiler_static_CXX='$wl-static'
++	;;
++      esac
+       ;;
+     darwin* | rhapsody*)
+       # PIC is the default on this platform
+@@ -14388,7 +14931,7 @@ lt_prog_compiler_static_CXX=
+     case $host_os in
+       aix[4-9]*)
+ 	# All AIX code is PIC.
+-	if test "$host_cpu" = ia64; then
++	if test ia64 = "$host_cpu"; then
+ 	  # AIX 5 now supports IA64 processor
+ 	  lt_prog_compiler_static_CXX='-Bstatic'
+ 	else
+@@ -14428,14 +14971,14 @@ lt_prog_compiler_static_CXX=
+ 	case $cc_basename in
+ 	  CC*)
+ 	    lt_prog_compiler_wl_CXX='-Wl,'
+-	    lt_prog_compiler_static_CXX='${wl}-a ${wl}archive'
+-	    if test "$host_cpu" != ia64; then
++	    lt_prog_compiler_static_CXX='$wl-a ${wl}archive'
++	    if test ia64 != "$host_cpu"; then
+ 	      lt_prog_compiler_pic_CXX='+Z'
+ 	    fi
+ 	    ;;
+ 	  aCC*)
+ 	    lt_prog_compiler_wl_CXX='-Wl,'
+-	    lt_prog_compiler_static_CXX='${wl}-a ${wl}archive'
++	    lt_prog_compiler_static_CXX='$wl-a ${wl}archive'
+ 	    case $host_cpu in
+ 	    hppa*64*|ia64*)
+ 	      # +Z the default
+@@ -14464,7 +15007,7 @@ lt_prog_compiler_static_CXX=
+ 	    ;;
+ 	esac
+ 	;;
+-      linux* | k*bsd*-gnu | kopensolaris*-gnu)
++      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+ 	case $cc_basename in
+ 	  KCC*)
+ 	    # KAI C++ Compiler
+@@ -14472,7 +15015,7 @@ lt_prog_compiler_static_CXX=
+ 	    lt_prog_compiler_pic_CXX='-fPIC'
+ 	    ;;
+ 	  ecpc* )
+-	    # old Intel C++ for x86_64 which still supported -KPIC.
++	    # old Intel C++ for x86_64, which still supported -KPIC.
+ 	    lt_prog_compiler_wl_CXX='-Wl,'
+ 	    lt_prog_compiler_pic_CXX='-KPIC'
+ 	    lt_prog_compiler_static_CXX='-static'
+@@ -14617,7 +15160,7 @@ lt_prog_compiler_static_CXX=
+   fi
+ 
+ case $host_os in
+-  # For platforms which do not support PIC, -DPIC is meaningless:
++  # For platforms that do not support PIC, -DPIC is meaningless:
+   *djgpp*)
+     lt_prog_compiler_pic_CXX=
+     ;;
+@@ -14649,7 +15192,7 @@ else
+   lt_cv_prog_compiler_pic_works_CXX=no
+    ac_outfile=conftest.$ac_objext
+    echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-   lt_compiler_flag="$lt_prog_compiler_pic_CXX -DPIC"
++   lt_compiler_flag="$lt_prog_compiler_pic_CXX -DPIC"  ## exclude from sc_useless_quotes_in_assignment
+    # Insert the option either (1) after the last *FLAGS variable, or
+    # (2) before a word containing "conftest.", or (3) at the end.
+    # Note that $ac_compile itself does not contain backslashes and begins
+@@ -14679,7 +15222,7 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic_works_CXX" >&5
+ $as_echo "$lt_cv_prog_compiler_pic_works_CXX" >&6; }
+ 
+-if test x"$lt_cv_prog_compiler_pic_works_CXX" = xyes; then
++if test yes = "$lt_cv_prog_compiler_pic_works_CXX"; then
+     case $lt_prog_compiler_pic_CXX in
+      "" | " "*) ;;
+      *) lt_prog_compiler_pic_CXX=" $lt_prog_compiler_pic_CXX" ;;
+@@ -14705,7 +15248,7 @@ if ${lt_cv_prog_compiler_static_works_CXX+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+   lt_cv_prog_compiler_static_works_CXX=no
+-   save_LDFLAGS="$LDFLAGS"
++   save_LDFLAGS=$LDFLAGS
+    LDFLAGS="$LDFLAGS $lt_tmp_static_flag"
+    echo "$lt_simple_link_test_code" > conftest.$ac_ext
+    if (eval $ac_link 2>conftest.err) && test -s conftest$ac_exeext; then
+@@ -14724,13 +15267,13 @@ else
+      fi
+    fi
+    $RM -r conftest*
+-   LDFLAGS="$save_LDFLAGS"
++   LDFLAGS=$save_LDFLAGS
+ 
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_static_works_CXX" >&5
+ $as_echo "$lt_cv_prog_compiler_static_works_CXX" >&6; }
+ 
+-if test x"$lt_cv_prog_compiler_static_works_CXX" = xyes; then
++if test yes = "$lt_cv_prog_compiler_static_works_CXX"; then
+     :
+ else
+     lt_prog_compiler_static_CXX=
+@@ -14844,8 +15387,8 @@ $as_echo "$lt_cv_prog_compiler_c_o_CXX" >&6; }
+ 
+ 
+ 
+-hard_links="nottested"
+-if test "$lt_cv_prog_compiler_c_o_CXX" = no && test "$need_locks" != no; then
++hard_links=nottested
++if test no = "$lt_cv_prog_compiler_c_o_CXX" && test no != "$need_locks"; then
+   # do not overwrite the value of need_locks provided by the user
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can lock with hard links" >&5
+ $as_echo_n "checking if we can lock with hard links... " >&6; }
+@@ -14857,9 +15400,9 @@ $as_echo_n "checking if we can lock with hard links... " >&6; }
+   ln conftest.a conftest.b 2>/dev/null && hard_links=no
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $hard_links" >&5
+ $as_echo "$hard_links" >&6; }
+-  if test "$hard_links" = no; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe" >&5
+-$as_echo "$as_me: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe" >&2;}
++  if test no = "$hard_links"; then
++    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&5
++$as_echo "$as_me: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&2;}
+     need_locks=warn
+   fi
+ else
+@@ -14876,17 +15419,21 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+   case $host_os in
+   aix[4-9]*)
+     # If we're using GNU nm, then we don't want the "-C" option.
+-    # -C means demangle to AIX nm, but means don't demangle with GNU nm
+-    # Also, AIX nm treats weak defined symbols like other global defined
+-    # symbols, whereas GNU nm marks them as "W".
++    # -C means demangle to GNU nm, but means don't demangle to AIX nm.
++    # Without the "-l" option, or with the "-B" option, AIX nm treats
++    # weak defined symbols like other global defined symbols, whereas
++    # GNU nm marks them as "W".
++    # While the 'weak' keyword is ignored in the Export File, we need
++    # it in the Import File for the 'aix-soname' feature, so we have
++    # to replace the "-B" option with "-P" for AIX nm.
+     if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
+-      export_symbols_cmds_CXX='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && (substr(\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++      export_symbols_cmds_CXX='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && (substr(\$ 3,1,1) != ".")) { if (\$ 2 == "W") { print \$ 3 " weak" } else { print \$ 3 } } }'\'' | sort -u > $export_symbols'
+     else
+-      export_symbols_cmds_CXX='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && (substr(\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++      export_symbols_cmds_CXX='`func_echo_all $NM | $SED -e '\''s/B\([^B]*\)$/P\1/'\''` -PCpgl $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "L") || (\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) && (substr(\$ 1,1,1) != ".")) { if ((\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) { print \$ 1 " weak" } else { print \$ 1 } } }'\'' | sort -u > $export_symbols'
+     fi
+     ;;
+   pw32*)
+-    export_symbols_cmds_CXX="$ltdll_cmds"
++    export_symbols_cmds_CXX=$ltdll_cmds
+     ;;
+   cygwin* | mingw* | cegcc*)
+     case $cc_basename in
+@@ -14906,7 +15453,7 @@ $as_echo_n "checking whether the $compiler linker ($LD) supports shared librarie
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ld_shlibs_CXX" >&5
+ $as_echo "$ld_shlibs_CXX" >&6; }
+-test "$ld_shlibs_CXX" = no && can_build_shared=no
++test no = "$ld_shlibs_CXX" && can_build_shared=no
+ 
+ with_gnu_ld_CXX=$with_gnu_ld
+ 
+@@ -14923,7 +15470,7 @@ x|xyes)
+   # Assume -lc should be added
+   archive_cmds_need_lc_CXX=yes
+ 
+-  if test "$enable_shared" = yes && test "$GCC" = yes; then
++  if test yes,yes = "$GCC,$enable_shared"; then
+     case $archive_cmds_CXX in
+     *'~'*)
+       # FIXME: we may have to deal with multi-command sequences.
+@@ -15051,7 +15598,7 @@ $as_echo_n "checking dynamic linker characteristics... " >&6; }
+ library_names_spec=
+ libname_spec='lib$name'
+ soname_spec=
+-shrext_cmds=".so"
++shrext_cmds=.so
+ postinstall_cmds=
+ postuninstall_cmds=
+ finish_cmds=
+@@ -15068,14 +15615,16 @@ hardcode_into_libs=no
+ # flags to be left without arguments
+ need_version=unknown
+ 
++
++
+ case $host_os in
+ aix3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix $libname.a'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname.a'
+   shlibpath_var=LIBPATH
+ 
+   # AIX 3 has no versioning support, so we append a major version to the name.
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  soname_spec='$libname$release$shared_ext$major'
+   ;;
+ 
+ aix[4-9]*)
+@@ -15083,41 +15632,91 @@ aix[4-9]*)
+   need_lib_prefix=no
+   need_version=no
+   hardcode_into_libs=yes
+-  if test "$host_cpu" = ia64; then
++  if test ia64 = "$host_cpu"; then
+     # AIX 5 supports IA64
+-    library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
++    library_names_spec='$libname$release$shared_ext$major $libname$release$shared_ext$versuffix $libname$shared_ext'
+     shlibpath_var=LD_LIBRARY_PATH
+   else
+     # With GCC up to 2.95.x, collect2 would create an import file
+     # for dependence libraries.  The import file would start with
+-    # the line `#! .'.  This would cause the generated library to
+-    # depend on `.', always an invalid library.  This was fixed in
++    # the line '#! .'.  This would cause the generated library to
++    # depend on '.', always an invalid library.  This was fixed in
+     # development snapshots of GCC prior to 3.0.
+     case $host_os in
+       aix4 | aix4.[01] | aix4.[01].*)
+       if { echo '#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 97)'
+ 	   echo ' yes '
+-	   echo '#endif'; } | ${CC} -E - | $GREP yes > /dev/null; then
++	   echo '#endif'; } | $CC -E - | $GREP yes > /dev/null; then
+ 	:
+       else
+ 	can_build_shared=no
+       fi
+       ;;
+     esac
+-    # AIX (on Power*) has no versioning support, so currently we can not hardcode correct
++    # Using Import Files as archive members, it is possible to support
++    # filename-based versioning of shared library archives on AIX. While
++    # this would work for both with and without runtime linking, it will
++    # prevent static linking of such archives. So we do filename-based
++    # shared library versioning with .so extension only, which is used
++    # when both runtime linking and shared linking is enabled.
++    # Unfortunately, runtime linking may impact performance, so we do
++    # not want this to be the default eventually. Also, we use the
++    # versioned .so libs for executables only if there is the -brtl
++    # linker flag in LDFLAGS as well, or --with-aix-soname=svr4 only.
++    # To allow for filename-based versioning support, we need to create
++    # libNAME.so.V as an archive file, containing:
++    # *) an Import File, referring to the versioned filename of the
++    #    archive as well as the shared archive member, telling the
++    #    bitwidth (32 or 64) of that shared object, and providing the
++    #    list of exported symbols of that shared object, eventually
++    #    decorated with the 'weak' keyword
++    # *) the shared object with the F_LOADONLY flag set, to really avoid
++    #    it being seen by the linker.
++    # At run time we better use the real file rather than another symlink,
++    # but for link time we create the symlink libNAME.so -> libNAME.so.V
++
++    case $with_aix_soname,$aix_use_runtimelinking in
++    # AIX (on Power*) has no versioning support, so currently we cannot hardcode correct
+     # soname into executable. Probably we can add versioning support to
+     # collect2, so additional links can be useful in future.
+-    if test "$aix_use_runtimelinking" = yes; then
++    aix,yes) # traditional libtool
++      dynamic_linker='AIX unversionable lib.so'
+       # If using run time linking (on AIX 4.2 or later) use lib<name>.so
+       # instead of lib<name>.a to let people know that these are not
+       # typical AIX shared libraries.
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    else
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++      ;;
++    aix,no) # traditional AIX only
++      dynamic_linker='AIX lib.a(lib.so.V)'
+       # We preserve .a as extension for shared libraries through AIX4.2
+       # and later when we are not doing run time linking.
+-      library_names_spec='${libname}${release}.a $libname.a'
+-      soname_spec='${libname}${release}${shared_ext}$major'
+-    fi
++      library_names_spec='$libname$release.a $libname.a'
++      soname_spec='$libname$release$shared_ext$major'
++      ;;
++    svr4,*) # full svr4 only
++      dynamic_linker="AIX lib.so.V($shared_archive_member_spec.o)"
++      library_names_spec='$libname$release$shared_ext$major $libname$shared_ext'
++      # We do not specify a path in Import Files, so LIBPATH fires.
++      shlibpath_overrides_runpath=yes
++      ;;
++    *,yes) # both, prefer svr4
++      dynamic_linker="AIX lib.so.V($shared_archive_member_spec.o), lib.a(lib.so.V)"
++      library_names_spec='$libname$release$shared_ext$major $libname$shared_ext'
++      # unpreferred sharedlib libNAME.a needs extra handling
++      postinstall_cmds='test -n "$linkname" || linkname="$realname"~func_stripname "" ".so" "$linkname"~$install_shared_prog "$dir/$func_stripname_result.$libext" "$destdir/$func_stripname_result.$libext"~test -z "$tstripme" || test -z "$striplib" || $striplib "$destdir/$func_stripname_result.$libext"'
++      postuninstall_cmds='for n in $library_names $old_library; do :; done~func_stripname "" ".so" "$n"~test "$func_stripname_result" = "$n" || func_append rmfiles " $odir/$func_stripname_result.$libext"'
++      # We do not specify a path in Import Files, so LIBPATH fires.
++      shlibpath_overrides_runpath=yes
++      ;;
++    *,no) # both, prefer aix
++      dynamic_linker="AIX lib.a(lib.so.V), lib.so.V($shared_archive_member_spec.o)"
++      library_names_spec='$libname$release.a $libname.a'
++      soname_spec='$libname$release$shared_ext$major'
++      # unpreferred sharedlib libNAME.so.V and symlink libNAME.so need extra handling
++      postinstall_cmds='test -z "$dlname" || $install_shared_prog $dir/$dlname $destdir/$dlname~test -z "$tstripme" || test -z "$striplib" || $striplib $destdir/$dlname~test -n "$linkname" || linkname=$realname~func_stripname "" ".a" "$linkname"~(cd "$destdir" && $LN_S -f $dlname $func_stripname_result.so)'
++      postuninstall_cmds='test -z "$dlname" || func_append rmfiles " $odir/$dlname"~for n in $old_library $library_names; do :; done~func_stripname "" ".a" "$n"~func_append rmfiles " $odir/$func_stripname_result.so"'
++      ;;
++    esac
+     shlibpath_var=LIBPATH
+   fi
+   ;;
+@@ -15127,18 +15726,18 @@ amigaos*)
+   powerpc)
+     # Since July 2007 AmigaOS4 officially supports .so libraries.
+     # When compiling the executable, add -use-dynld -Lsobjs: to the compileline.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+     ;;
+   m68k)
+     library_names_spec='$libname.ixlibrary $libname.a'
+     # Create ${libname}_ixlibrary.a entries in /sys/libs.
+-    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([^/]*\)\.ixlibrary$%\1%'\''`; test $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
++    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([^/]*\)\.ixlibrary$%\1%'\''`; $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
+     ;;
+   esac
+   ;;
+ 
+ beos*)
+-  library_names_spec='${libname}${shared_ext}'
++  library_names_spec='$libname$shared_ext'
+   dynamic_linker="$host_os ld.so"
+   shlibpath_var=LIBRARY_PATH
+   ;;
+@@ -15146,8 +15745,8 @@ beos*)
+ bsdi[45]*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   sys_lib_search_path_spec="/shlib /usr/lib /usr/X11/lib /usr/contrib/lib /lib /usr/local/lib"
+@@ -15159,7 +15758,7 @@ bsdi[45]*)
+ 
+ cygwin* | mingw* | pw32* | cegcc*)
+   version_type=windows
+-  shrext_cmds=".dll"
++  shrext_cmds=.dll
+   need_version=no
+   need_lib_prefix=no
+ 
+@@ -15168,8 +15767,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+     # gcc
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++    postinstall_cmds='base_file=`basename \$file`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; echo \$dlname'\''`~
+       dldir=$destdir/`dirname \$dlpath`~
+       test -d \$dldir || mkdir -p \$dldir~
+       $install_prog $dir/$dlname \$dldir/$dlname~
+@@ -15185,16 +15784,16 @@ cygwin* | mingw* | pw32* | cegcc*)
+     case $host_os in
+     cygwin*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+ 
+       ;;
+     mingw* | cegcc*)
+       # MinGW DLLs use traditional 'lib' prefix
+-      soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++      soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+       ;;
+     pw32*)
+       # pw32 DLLs use 'pw' prefix rather than 'lib'
+-      library_names_spec='`echo ${libname} | sed -e 's/^lib/pw/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
++      library_names_spec='`echo $libname | sed -e 's/^lib/pw/'``echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
+       ;;
+     esac
+     dynamic_linker='Win32 ld.exe'
+@@ -15203,8 +15802,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+   *,cl*)
+     # Native MSVC
+     libname_spec='$name'
+-    soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+-    library_names_spec='${libname}.dll.lib'
++    soname_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext'
++    library_names_spec='$libname.dll.lib'
+ 
+     case $build_os in
+     mingw*)
+@@ -15231,7 +15830,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+       sys_lib_search_path_spec=`cygpath --path --unix "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
+       ;;
+     *)
+-      sys_lib_search_path_spec="$LIB"
++      sys_lib_search_path_spec=$LIB
+       if $ECHO "$sys_lib_search_path_spec" | $GREP ';[c-zC-Z]:/' >/dev/null; then
+         # It is most probably a Windows format PATH.
+         sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e 's/;/ /g'`
+@@ -15244,8 +15843,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+     esac
+ 
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++    postinstall_cmds='base_file=`basename \$file`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; echo \$dlname'\''`~
+       dldir=$destdir/`dirname \$dlpath`~
+       test -d \$dldir || mkdir -p \$dldir~
+       $install_prog $dir/$dlname \$dldir/$dlname'
+@@ -15258,7 +15857,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+ 
+   *)
+     # Assume MSVC wrapper
+-    library_names_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext} $libname.lib'
++    library_names_spec='$libname`echo $release | $SED -e 's/[.]/-/g'`$versuffix$shared_ext $libname.lib'
+     dynamic_linker='Win32 ld.exe'
+     ;;
+   esac
+@@ -15271,8 +15870,8 @@ darwin* | rhapsody*)
+   version_type=darwin
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${major}$shared_ext ${libname}$shared_ext'
+-  soname_spec='${libname}${release}${major}$shared_ext'
++  library_names_spec='$libname$release$major$shared_ext $libname$shared_ext'
++  soname_spec='$libname$release$major$shared_ext'
+   shlibpath_overrides_runpath=yes
+   shlibpath_var=DYLD_LIBRARY_PATH
+   shrext_cmds='`test .$module = .yes && echo .so || echo .dylib`'
+@@ -15284,8 +15883,8 @@ dgux*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname$shared_ext'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
+@@ -15303,12 +15902,13 @@ freebsd* | dragonfly*)
+   version_type=freebsd-$objformat
+   case $version_type in
+     freebsd-elf*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++      soname_spec='$libname$release$shared_ext$major'
+       need_version=no
+       need_lib_prefix=no
+       ;;
+     freebsd-*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix $libname${shared_ext}$versuffix'
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+       need_version=yes
+       ;;
+   esac
+@@ -15333,26 +15933,15 @@ freebsd* | dragonfly*)
+   esac
+   ;;
+ 
+-gnu*)
+-  version_type=linux # correct to gnu/linux during the next big refactor
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
+-  ;;
+-
+ haiku*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+   dynamic_linker="$host_os runtime_loader"
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
++  shlibpath_overrides_runpath=no
+   sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+   hardcode_into_libs=yes
+   ;;
+@@ -15370,14 +15959,15 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    if test "X$HPUX_IA64_MODE" = X32; then
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
++    if test 32 = "$HPUX_IA64_MODE"; then
+       sys_lib_search_path_spec="/usr/lib/hpux32 /usr/local/lib/hpux32 /usr/local/lib"
++      sys_lib_dlsearch_path_spec=/usr/lib/hpux32
+     else
+       sys_lib_search_path_spec="/usr/lib/hpux64 /usr/local/lib/hpux64"
++      sys_lib_dlsearch_path_spec=/usr/lib/hpux64
+     fi
+-    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+     ;;
+   hppa*64*)
+     shrext_cmds='.sl'
+@@ -15385,8 +15975,8 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     sys_lib_search_path_spec="/usr/lib/pa20_64 /usr/ccs/lib/pa20_64"
+     sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+     ;;
+@@ -15395,8 +15985,8 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=SHLIB_PATH
+     shlibpath_overrides_runpath=no # +s is required to enable SHLIB_PATH
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     ;;
+   esac
+   # HP-UX runs *really* slowly unless shared libraries are mode 555, ...
+@@ -15409,8 +15999,8 @@ interix[3-9]*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+@@ -15421,7 +16011,7 @@ irix5* | irix6* | nonstopux*)
+   case $host_os in
+     nonstopux*) version_type=nonstopux ;;
+     *)
+-	if test "$lt_cv_prog_gnu_ld" = yes; then
++	if test yes = "$lt_cv_prog_gnu_ld"; then
+ 		version_type=linux # correct to gnu/linux during the next big refactor
+ 	else
+ 		version_type=irix
+@@ -15429,8 +16019,8 @@ irix5* | irix6* | nonstopux*)
+   esac
+   need_lib_prefix=no
+   need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext} $libname${shared_ext}'
++  soname_spec='$libname$release$shared_ext$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$release$shared_ext $libname$shared_ext'
+   case $host_os in
+   irix5* | nonstopux*)
+     libsuff= shlibsuff=
+@@ -15449,8 +16039,8 @@ irix5* | irix6* | nonstopux*)
+   esac
+   shlibpath_var=LD_LIBRARY${shlibsuff}_PATH
+   shlibpath_overrides_runpath=no
+-  sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+-  sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
++  sys_lib_search_path_spec="/usr/lib$libsuff /lib$libsuff /usr/local/lib$libsuff"
++  sys_lib_dlsearch_path_spec="/usr/lib$libsuff /lib$libsuff"
+   hardcode_into_libs=yes
+   ;;
+ 
+@@ -15459,13 +16049,33 @@ linux*oldld* | linux*aout* | linux*coff*)
+   dynamic_linker=no
+   ;;
+ 
++linux*android*)
++  version_type=none # Android doesn't support versioned libraries.
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='$libname$release$shared_ext'
++  soname_spec='$libname$release$shared_ext'
++  finish_cmds=
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++
++  # This implies no fast_install, which is unacceptable.
++  # Some rework will be needed to allow for fast_install
++  # before this can be enabled.
++  hardcode_into_libs=yes
++
++  dynamic_linker='Android linker'
++  # Don't embed -rpath directories since the linker doesn't support them.
++  hardcode_libdir_flag_spec_CXX='-L$libdir'
++  ;;
++
+ # This must be glibc/ELF.
+-linux* | k*bsd*-gnu | kopensolaris*-gnu)
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+@@ -15509,14 +16119,15 @@ fi
+   # before this can be enabled.
+   hardcode_into_libs=yes
+ 
+-  # Add ABI-specific directories to the system library path.
+-  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+-
+-  # Append ld.so.conf contents to the search path
++  # Ideally, we could use ldconfig to report *all* directores which are
++  # searched for libraries, however this is still not possible.  Aside from not
++  # being certain /sbin/ldconfig is available, command
++  # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
++  # even though it is searched at run-time.  Try to do the best guess by
++  # appending ld.so.conf contents (and includes) to the search path.
+   if test -f /etc/ld.so.conf; then
+     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
+-    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+-
++    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+   fi
+ 
+   # We used to test for /lib/ld.so.1 and disable shared libraries on
+@@ -15533,12 +16144,12 @@ netbsd*)
+   need_lib_prefix=no
+   need_version=no
+   if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+     finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+     dynamic_linker='NetBSD (a.out) ld.so'
+   else
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     dynamic_linker='NetBSD ld.elf_so'
+   fi
+   shlibpath_var=LD_LIBRARY_PATH
+@@ -15548,7 +16159,7 @@ netbsd*)
+ 
+ newsos6)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   ;;
+@@ -15557,58 +16168,68 @@ newsos6)
+   version_type=qnx
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+   hardcode_into_libs=yes
+   dynamic_linker='ldqnx.so'
+   ;;
+ 
+-openbsd*)
++openbsd* | bitrig*)
+   version_type=sunos
+-  sys_lib_dlsearch_path_spec="/usr/lib"
++  sys_lib_dlsearch_path_spec=/usr/lib
+   need_lib_prefix=no
+-  # Some older versions of OpenBSD (3.3 at least) *do* need versioned libs.
+-  case $host_os in
+-    openbsd3.3 | openbsd3.3.*)	need_version=yes ;;
+-    *)				need_version=no  ;;
+-  esac
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-    case $host_os in
+-      openbsd2.[89] | openbsd2.[89].*)
+-	shlibpath_overrides_runpath=no
+-	;;
+-      *)
+-	shlibpath_overrides_runpath=yes
+-	;;
+-      esac
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
++    need_version=no
+   else
+-    shlibpath_overrides_runpath=yes
++    need_version=yes
+   fi
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
++  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
+   ;;
+ 
+ os2*)
+   libname_spec='$name'
+-  shrext_cmds=".dll"
++  version_type=windows
++  shrext_cmds=.dll
++  need_version=no
+   need_lib_prefix=no
+-  library_names_spec='$libname${shared_ext} $libname.a'
++  # OS/2 can only load a DLL with a base name of 8 characters or less.
++  soname_spec='`test -n "$os2dllname" && libname="$os2dllname";
++    v=$($ECHO $release$versuffix | tr -d .-);
++    n=$($ECHO $libname | cut -b -$((8 - ${#v})) | tr . _);
++    $ECHO $n$v`$shared_ext'
++  library_names_spec='${libname}_dll.$libext'
+   dynamic_linker='OS/2 ld.exe'
+-  shlibpath_var=LIBPATH
++  shlibpath_var=BEGINLIBPATH
++  sys_lib_search_path_spec="/lib /usr/lib /usr/local/lib"
++  sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
++  postinstall_cmds='base_file=`basename \$file`~
++    dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; $ECHO \$dlname'\''`~
++    dldir=$destdir/`dirname \$dlpath`~
++    test -d \$dldir || mkdir -p \$dldir~
++    $install_prog $dir/$dlname \$dldir/$dlname~
++    chmod a+x \$dldir/$dlname~
++    if test -n '\''$stripme'\'' && test -n '\''$striplib'\''; then
++      eval '\''$striplib \$dldir/$dlname'\'' || exit \$?;
++    fi'
++  postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; $ECHO \$dlname'\''`~
++    dlpath=$dir/\$dldll~
++    $RM \$dlpath'
+   ;;
+ 
+ osf3* | osf4* | osf5*)
+   version_type=osf
+   need_lib_prefix=no
+   need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='$libname$release$shared_ext$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   sys_lib_search_path_spec="/usr/shlib /usr/ccs/lib /usr/lib/cmplrs/cc /usr/lib /usr/local/lib /var/shlib"
+-  sys_lib_dlsearch_path_spec="$sys_lib_search_path_spec"
++  sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+   ;;
+ 
+ rdos*)
+@@ -15619,8 +16240,8 @@ solaris*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   hardcode_into_libs=yes
+@@ -15630,11 +16251,11 @@ solaris*)
+ 
+ sunos4*)
+   version_type=sunos
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+   finish_cmds='PATH="\$PATH:/usr/etc" ldconfig $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     need_lib_prefix=no
+   fi
+   need_version=yes
+@@ -15642,8 +16263,8 @@ sunos4*)
+ 
+ sysv4 | sysv4.3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   case $host_vendor in
+     sni)
+@@ -15664,24 +16285,24 @@ sysv4 | sysv4.3*)
+   ;;
+ 
+ sysv4*MP*)
+-  if test -d /usr/nec ;then
++  if test -d /usr/nec; then
+     version_type=linux # correct to gnu/linux during the next big refactor
+-    library_names_spec='$libname${shared_ext}.$versuffix $libname${shared_ext}.$major $libname${shared_ext}'
+-    soname_spec='$libname${shared_ext}.$major'
++    library_names_spec='$libname$shared_ext.$versuffix $libname$shared_ext.$major $libname$shared_ext'
++    soname_spec='$libname$shared_ext.$major'
+     shlibpath_var=LD_LIBRARY_PATH
+   fi
+   ;;
+ 
+ sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
+-  version_type=freebsd-elf
++  version_type=sco
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   hardcode_into_libs=yes
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+     sys_lib_search_path_spec='/usr/ccs/lib /usr/lib'
+@@ -15699,7 +16320,7 @@ tpf*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+   hardcode_into_libs=yes
+@@ -15707,8 +16328,8 @@ tpf*)
+ 
+ uts4*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
+@@ -15718,20 +16339,32 @@ uts4*)
+ esac
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $dynamic_linker" >&5
+ $as_echo "$dynamic_linker" >&6; }
+-test "$dynamic_linker" = no && can_build_shared=no
++test no = "$dynamic_linker" && can_build_shared=no
+ 
+ variables_saved_for_relink="PATH $shlibpath_var $runpath_var"
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   variables_saved_for_relink="$variables_saved_for_relink GCC_EXEC_PREFIX COMPILER_PATH LIBRARY_PATH"
+ fi
+ 
+-if test "${lt_cv_sys_lib_search_path_spec+set}" = set; then
+-  sys_lib_search_path_spec="$lt_cv_sys_lib_search_path_spec"
++if test set = "${lt_cv_sys_lib_search_path_spec+set}"; then
++  sys_lib_search_path_spec=$lt_cv_sys_lib_search_path_spec
+ fi
+-if test "${lt_cv_sys_lib_dlsearch_path_spec+set}" = set; then
+-  sys_lib_dlsearch_path_spec="$lt_cv_sys_lib_dlsearch_path_spec"
++
++if test set = "${lt_cv_sys_lib_dlsearch_path_spec+set}"; then
++  sys_lib_dlsearch_path_spec=$lt_cv_sys_lib_dlsearch_path_spec
+ fi
+ 
++# remember unaugmented sys_lib_dlsearch_path content for libtool script decls...
++configure_time_dlsearch_path=$sys_lib_dlsearch_path_spec
++
++# ... but it needs LT_SYS_LIBRARY_PATH munging for other configure-time code
++func_munge_path_list sys_lib_dlsearch_path_spec "$LT_SYS_LIBRARY_PATH"
++
++# to be used as default LT_SYS_LIBRARY_PATH value in generated libtool
++configure_time_lt_sys_library_path=$LT_SYS_LIBRARY_PATH
++
++
++
+ 
+ 
+ 
+@@ -15774,15 +16407,15 @@ $as_echo_n "checking how to hardcode library paths into programs... " >&6; }
+ hardcode_action_CXX=
+ if test -n "$hardcode_libdir_flag_spec_CXX" ||
+    test -n "$runpath_var_CXX" ||
+-   test "X$hardcode_automatic_CXX" = "Xyes" ; then
++   test yes = "$hardcode_automatic_CXX"; then
+ 
+   # We can hardcode non-existent directories.
+-  if test "$hardcode_direct_CXX" != no &&
++  if test no != "$hardcode_direct_CXX" &&
+      # If the only mechanism to avoid hardcoding is shlibpath_var, we
+      # have to relink, otherwise we might link with an installed library
+      # when we should be linking with a yet-to-be-installed one
+-     ## test "$_LT_TAGVAR(hardcode_shlibpath_var, CXX)" != no &&
+-     test "$hardcode_minus_L_CXX" != no; then
++     ## test no != "$_LT_TAGVAR(hardcode_shlibpath_var, CXX)" &&
++     test no != "$hardcode_minus_L_CXX"; then
+     # Linking always hardcodes the temporary library directory.
+     hardcode_action_CXX=relink
+   else
+@@ -15797,12 +16430,12 @@ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $hardcode_action_CXX" >&5
+ $as_echo "$hardcode_action_CXX" >&6; }
+ 
+-if test "$hardcode_action_CXX" = relink ||
+-   test "$inherit_rpath_CXX" = yes; then
++if test relink = "$hardcode_action_CXX" ||
++   test yes = "$inherit_rpath_CXX"; then
+   # Fast installation is not supported
+   enable_fast_install=no
+-elif test "$shlibpath_overrides_runpath" = yes ||
+-     test "$enable_shared" = no; then
++elif test yes = "$shlibpath_overrides_runpath" ||
++     test no = "$enable_shared"; then
+   # Fast installation is not necessary
+   enable_fast_install=needless
+ fi
+@@ -15825,7 +16458,7 @@ fi
+   lt_cv_path_LD=$lt_save_path_LD
+   lt_cv_prog_gnu_ldcxx=$lt_cv_prog_gnu_ld
+   lt_cv_prog_gnu_ld=$lt_save_with_gnu_ld
+-fi # test "$_lt_caught_CXX_error" != yes
++fi # test yes != "$_lt_caught_CXX_error"
+ 
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+@@ -19679,6 +20312,7 @@ enable_shared='`$ECHO "$enable_shared" | $SED "$delay_single_quote_subst"`'
+ enable_static='`$ECHO "$enable_static" | $SED "$delay_single_quote_subst"`'
+ pic_mode='`$ECHO "$pic_mode" | $SED "$delay_single_quote_subst"`'
+ enable_fast_install='`$ECHO "$enable_fast_install" | $SED "$delay_single_quote_subst"`'
++shared_archive_member_spec='`$ECHO "$shared_archive_member_spec" | $SED "$delay_single_quote_subst"`'
+ SHELL='`$ECHO "$SHELL" | $SED "$delay_single_quote_subst"`'
+ ECHO='`$ECHO "$ECHO" | $SED "$delay_single_quote_subst"`'
+ PATH_SEPARATOR='`$ECHO "$PATH_SEPARATOR" | $SED "$delay_single_quote_subst"`'
+@@ -19714,6 +20348,7 @@ want_nocaseglob='`$ECHO "$want_nocaseglob" | $SED "$delay_single_quote_subst"`'
+ DLLTOOL='`$ECHO "$DLLTOOL" | $SED "$delay_single_quote_subst"`'
+ sharedlib_from_linklib_cmd='`$ECHO "$sharedlib_from_linklib_cmd" | $SED "$delay_single_quote_subst"`'
+ AR='`$ECHO "$AR" | $SED "$delay_single_quote_subst"`'
++lt_ar_flags='`$ECHO "$lt_ar_flags" | $SED "$delay_single_quote_subst"`'
+ AR_FLAGS='`$ECHO "$AR_FLAGS" | $SED "$delay_single_quote_subst"`'
+ archiver_list_spec='`$ECHO "$archiver_list_spec" | $SED "$delay_single_quote_subst"`'
+ STRIP='`$ECHO "$STRIP" | $SED "$delay_single_quote_subst"`'
+@@ -19728,10 +20363,13 @@ compiler='`$ECHO "$compiler" | $SED "$delay_single_quote_subst"`'
+ GCC='`$ECHO "$GCC" | $SED "$delay_single_quote_subst"`'
+ lt_cv_sys_global_symbol_pipe='`$ECHO "$lt_cv_sys_global_symbol_pipe" | $SED "$delay_single_quote_subst"`'
+ lt_cv_sys_global_symbol_to_cdecl='`$ECHO "$lt_cv_sys_global_symbol_to_cdecl" | $SED "$delay_single_quote_subst"`'
++lt_cv_sys_global_symbol_to_import='`$ECHO "$lt_cv_sys_global_symbol_to_import" | $SED "$delay_single_quote_subst"`'
+ lt_cv_sys_global_symbol_to_c_name_address='`$ECHO "$lt_cv_sys_global_symbol_to_c_name_address" | $SED "$delay_single_quote_subst"`'
+ lt_cv_sys_global_symbol_to_c_name_address_lib_prefix='`$ECHO "$lt_cv_sys_global_symbol_to_c_name_address_lib_prefix" | $SED "$delay_single_quote_subst"`'
++lt_cv_nm_interface='`$ECHO "$lt_cv_nm_interface" | $SED "$delay_single_quote_subst"`'
+ nm_file_list_spec='`$ECHO "$nm_file_list_spec" | $SED "$delay_single_quote_subst"`'
+ lt_sysroot='`$ECHO "$lt_sysroot" | $SED "$delay_single_quote_subst"`'
++lt_cv_truncate_bin='`$ECHO "$lt_cv_truncate_bin" | $SED "$delay_single_quote_subst"`'
+ objdir='`$ECHO "$objdir" | $SED "$delay_single_quote_subst"`'
+ MAGIC_CMD='`$ECHO "$MAGIC_CMD" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_no_builtin_flag='`$ECHO "$lt_prog_compiler_no_builtin_flag" | $SED "$delay_single_quote_subst"`'
+@@ -19796,7 +20434,8 @@ finish_cmds='`$ECHO "$finish_cmds" | $SED "$delay_single_quote_subst"`'
+ finish_eval='`$ECHO "$finish_eval" | $SED "$delay_single_quote_subst"`'
+ hardcode_into_libs='`$ECHO "$hardcode_into_libs" | $SED "$delay_single_quote_subst"`'
+ sys_lib_search_path_spec='`$ECHO "$sys_lib_search_path_spec" | $SED "$delay_single_quote_subst"`'
+-sys_lib_dlsearch_path_spec='`$ECHO "$sys_lib_dlsearch_path_spec" | $SED "$delay_single_quote_subst"`'
++configure_time_dlsearch_path='`$ECHO "$configure_time_dlsearch_path" | $SED "$delay_single_quote_subst"`'
++configure_time_lt_sys_library_path='`$ECHO "$configure_time_lt_sys_library_path" | $SED "$delay_single_quote_subst"`'
+ hardcode_action='`$ECHO "$hardcode_action" | $SED "$delay_single_quote_subst"`'
+ enable_dlopen='`$ECHO "$enable_dlopen" | $SED "$delay_single_quote_subst"`'
+ enable_dlopen_self='`$ECHO "$enable_dlopen_self" | $SED "$delay_single_quote_subst"`'
+@@ -19892,7 +20531,6 @@ want_nocaseglob \
+ DLLTOOL \
+ sharedlib_from_linklib_cmd \
+ AR \
+-AR_FLAGS \
+ archiver_list_spec \
+ STRIP \
+ RANLIB \
+@@ -19901,9 +20539,12 @@ CFLAGS \
+ compiler \
+ lt_cv_sys_global_symbol_pipe \
+ lt_cv_sys_global_symbol_to_cdecl \
++lt_cv_sys_global_symbol_to_import \
+ lt_cv_sys_global_symbol_to_c_name_address \
+ lt_cv_sys_global_symbol_to_c_name_address_lib_prefix \
++lt_cv_nm_interface \
+ nm_file_list_spec \
++lt_cv_truncate_bin \
+ lt_prog_compiler_no_builtin_flag \
+ lt_prog_compiler_pic \
+ lt_prog_compiler_wl \
+@@ -19969,7 +20610,7 @@ postdeps_CXX \
+ compiler_lib_search_path_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+-      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\""
++      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\"" ## exclude from sc_prohibit_nested_quotes
+       ;;
+     *)
+       eval "lt_\$var=\\\\\\"\\\$\$var\\\\\\""
+@@ -19996,7 +20637,8 @@ postinstall_cmds \
+ postuninstall_cmds \
+ finish_cmds \
+ sys_lib_search_path_spec \
+-sys_lib_dlsearch_path_spec \
++configure_time_dlsearch_path \
++configure_time_lt_sys_library_path \
+ reload_cmds_CXX \
+ old_archive_cmds_CXX \
+ old_archive_from_new_cmds_CXX \
+@@ -20010,7 +20652,7 @@ prelink_cmds_CXX \
+ postlink_cmds_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+-      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\""
++      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\"" ## exclude from sc_prohibit_nested_quotes
+       ;;
+     *)
+       eval "lt_\$var=\\\\\\"\\\$\$var\\\\\\""
+@@ -20019,19 +20661,16 @@ postlink_cmds_CXX; do
+ done
+ 
+ ac_aux_dir='$ac_aux_dir'
+-xsi_shell='$xsi_shell'
+-lt_shell_append='$lt_shell_append'
+ 
+-# See if we are running on zsh, and set the options which allow our
++# See if we are running on zsh, and set the options that allow our
+ # commands through without removal of \ escapes INIT.
+-if test -n "\${ZSH_VERSION+set}" ; then
++if test -n "\${ZSH_VERSION+set}"; then
+    setopt NO_GLOB_SUBST
+ fi
+ 
+ 
+     PACKAGE='$PACKAGE'
+     VERSION='$VERSION'
+-    TIMESTAMP='$TIMESTAMP'
+     RM='$RM'
+     ofile='$ofile'
+ 
+@@ -20928,55 +21567,53 @@ $as_echo X"$file" |
+  ;;
+     "libtool":C)
+ 
+-    # See if we are running on zsh, and set the options which allow our
++    # See if we are running on zsh, and set the options that allow our
+     # commands through without removal of \ escapes.
+-    if test -n "${ZSH_VERSION+set}" ; then
++    if test -n "${ZSH_VERSION+set}"; then
+       setopt NO_GLOB_SUBST
+     fi
+ 
+-    cfgfile="${ofile}T"
++    cfgfile=${ofile}T
+     trap "$RM \"$cfgfile\"; exit 1" 1 2 15
+     $RM "$cfgfile"
+ 
+     cat <<_LT_EOF >> "$cfgfile"
+ #! $SHELL
+-
+-# `$ECHO "$ofile" | sed 's%^.*/%%'` - Provide generalized library-building support services.
+-# Generated automatically by $as_me ($PACKAGE$TIMESTAMP) $VERSION
++# Generated automatically by $as_me ($PACKAGE) $VERSION
+ # Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
+ # NOTE: Changes made to this file will be lost: look at ltmain.sh.
++
++# Provide generalized library-building support services.
++# Written by Gordon Matzigkeit, 1996
++
++# Copyright (C) 2014 Free Software Foundation, Inc.
++# This is free software; see the source for copying conditions.  There is NO
++# warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++
++# GNU Libtool is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 2 of of the License, or
++# (at your option) any later version.
+ #
+-#   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005,
+-#                 2006, 2007, 2008, 2009, 2010, 2011 Free Software
+-#                 Foundation, Inc.
+-#   Written by Gordon Matzigkeit, 1996
+-#
+-#   This file is part of GNU Libtool.
+-#
+-# GNU Libtool is free software; you can redistribute it and/or
+-# modify it under the terms of the GNU General Public License as
+-# published by the Free Software Foundation; either version 2 of
+-# the License, or (at your option) any later version.
+-#
+-# As a special exception to the GNU General Public License,
+-# if you distribute this file as part of a program or library that
+-# is built using GNU Libtool, you may include this file under the
+-# same distribution terms that you use for the rest of that program.
++# As a special exception to the GNU General Public License, if you
++# distribute this file as part of a program or library that is built
++# using GNU Libtool, you may include this file under the  same
++# distribution terms that you use for the rest of that program.
+ #
+-# GNU Libtool is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# GNU Libtool is distributed in the hope that it will be useful, but
++# WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+-# along with GNU Libtool; see the file COPYING.  If not, a copy
+-# can be downloaded from http://www.gnu.org/licenses/gpl.html, or
+-# obtained by writing to the Free Software Foundation, Inc.,
+-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ 
+ # The names of the tagged configurations supported by this script.
+-available_tags="CXX "
++available_tags='CXX '
++
++# Configured defaults for sys_lib_dlsearch_path munging.
++: \${LT_SYS_LIBRARY_PATH="$configure_time_lt_sys_library_path"}
+ 
+ # ### BEGIN LIBTOOL CONFIG
+ 
+@@ -20996,6 +21633,9 @@ pic_mode=$pic_mode
+ # Whether or not to optimize for fast installation.
+ fast_install=$enable_fast_install
+ 
++# Shared archive member basename,for filename based shared library versioning on AIX.
++shared_archive_member_spec=$shared_archive_member_spec
++
+ # Shell to use when invoking shell scripts.
+ SHELL=$lt_SHELL
+ 
+@@ -21084,8 +21724,11 @@ sharedlib_from_linklib_cmd=$lt_sharedlib_from_linklib_cmd
+ # The archiver.
+ AR=$lt_AR
+ 
++# Flags to create an archive (by configure).
++lt_ar_flags=$lt_ar_flags
++
+ # Flags to create an archive.
+-AR_FLAGS=$lt_AR_FLAGS
++AR_FLAGS=\${ARFLAGS-"\$lt_ar_flags"}
+ 
+ # How to feed a file listing to the archiver.
+ archiver_list_spec=$lt_archiver_list_spec
+@@ -21113,18 +21756,27 @@ global_symbol_pipe=$lt_lt_cv_sys_global_symbol_pipe
+ # Transform the output of nm in a proper C declaration.
+ global_symbol_to_cdecl=$lt_lt_cv_sys_global_symbol_to_cdecl
+ 
++# Transform the output of nm into a list of symbols to manually relocate.
++global_symbol_to_import=$lt_lt_cv_sys_global_symbol_to_import
++
+ # Transform the output of nm in a C name address pair.
+ global_symbol_to_c_name_address=$lt_lt_cv_sys_global_symbol_to_c_name_address
+ 
+ # Transform the output of nm in a C name address pair when lib prefix is needed.
+ global_symbol_to_c_name_address_lib_prefix=$lt_lt_cv_sys_global_symbol_to_c_name_address_lib_prefix
+ 
++# The name lister interface.
++nm_interface=$lt_lt_cv_nm_interface
++
+ # Specify filename containing input files for \$NM.
+ nm_file_list_spec=$lt_nm_file_list_spec
+ 
+-# The root where to search for dependent libraries,and in which our libraries should be installed.
++# The root where to search for dependent libraries,and where our libraries should be installed.
+ lt_sysroot=$lt_sysroot
+ 
++# Command to truncate a binary pipe.
++lt_truncate_bin=$lt_lt_cv_truncate_bin
++
+ # The name of the directory that contains temporary libtool files.
+ objdir=$objdir
+ 
+@@ -21215,8 +21867,11 @@ hardcode_into_libs=$hardcode_into_libs
+ # Compile-time system search path for libraries.
+ sys_lib_search_path_spec=$lt_sys_lib_search_path_spec
+ 
+-# Run-time system search path for libraries.
+-sys_lib_dlsearch_path_spec=$lt_sys_lib_dlsearch_path_spec
++# Detected run-time system search path for libraries.
++sys_lib_dlsearch_path_spec=$lt_configure_time_dlsearch_path
++
++# Explicit LT_SYS_LIBRARY_PATH set during ./configure time.
++configure_time_lt_sys_library_path=$lt_configure_time_lt_sys_library_path
+ 
+ # Whether dlopen is supported.
+ dlopen_support=$enable_dlopen
+@@ -21309,13 +21964,13 @@ hardcode_libdir_flag_spec=$lt_hardcode_libdir_flag_spec
+ # Whether we need a single "-rpath" flag with a separated argument.
+ hardcode_libdir_separator=$lt_hardcode_libdir_separator
+ 
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
++# Set to "yes" if using DIR/libNAME\$shared_ext during linking hardcodes
+ # DIR into the resulting binary.
+ hardcode_direct=$hardcode_direct
+ 
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
++# Set to "yes" if using DIR/libNAME\$shared_ext during linking hardcodes
+ # DIR into the resulting binary and the resulting library dependency is
+-# "absolute",i.e impossible to change by setting \${shlibpath_var} if the
++# "absolute",i.e impossible to change by setting \$shlibpath_var if the
+ # library is relocated.
+ hardcode_direct_absolute=$hardcode_direct_absolute
+ 
+@@ -21381,13 +22036,72 @@ compiler_lib_search_path=$lt_compiler_lib_search_path
+ 
+ _LT_EOF
+ 
++    cat <<'_LT_EOF' >> "$cfgfile"
++
++# ### BEGIN FUNCTIONS SHARED WITH CONFIGURE
++
++# func_munge_path_list VARIABLE PATH
++# -----------------------------------
++# VARIABLE is name of variable containing _space_ separated list of
++# directories to be munged by the contents of PATH, which is string
++# having a format:
++# "DIR[:DIR]:"
++#       string "DIR[ DIR]" will be prepended to VARIABLE
++# ":DIR[:DIR]"
++#       string "DIR[ DIR]" will be appended to VARIABLE
++# "DIRP[:DIRP]::[DIRA:]DIRA"
++#       string "DIRP[ DIRP]" will be prepended to VARIABLE and string
++#       "DIRA[ DIRA]" will be appended to VARIABLE
++# "DIR[:DIR]"
++#       VARIABLE will be replaced by "DIR[ DIR]"
++func_munge_path_list ()
++{
++    case x$2 in
++    x)
++        ;;
++    *:)
++        eval $1=\"`$ECHO $2 | $SED 's/:/ /g'` \$$1\"
++        ;;
++    x:*)
++        eval $1=\"\$$1 `$ECHO $2 | $SED 's/:/ /g'`\"
++        ;;
++    *::*)
++        eval $1=\"\$$1\ `$ECHO $2 | $SED -e 's/.*:://' -e 's/:/ /g'`\"
++        eval $1=\"`$ECHO $2 | $SED -e 's/::.*//' -e 's/:/ /g'`\ \$$1\"
++        ;;
++    *)
++        eval $1=\"`$ECHO $2 | $SED 's/:/ /g'`\"
++        ;;
++    esac
++}
++
++
++# Calculate cc_basename.  Skip known compiler wrappers and cross-prefix.
++func_cc_basename ()
++{
++    for cc_temp in $*""; do
++      case $cc_temp in
++        compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
++        distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
++        \-*) ;;
++        *) break;;
++      esac
++    done
++    func_cc_basename_result=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++}
++
++
++# ### END FUNCTIONS SHARED WITH CONFIGURE
++
++_LT_EOF
++
+   case $host_os in
+   aix3*)
+     cat <<\_LT_EOF >> "$cfgfile"
+ # AIX sometimes has problems with the GCC collect2 program.  For some
+ # reason, if we set the COLLECT_NAMES environment variable, the problems
+ # vanish in a puff of smoke.
+-if test "X${COLLECT_NAMES+set}" != Xset; then
++if test set != "${COLLECT_NAMES+set}"; then
+   COLLECT_NAMES=
+   export COLLECT_NAMES
+ fi
+@@ -21396,7 +22110,7 @@ _LT_EOF
+   esac
+ 
+ 
+-ltmain="$ac_aux_dir/ltmain.sh"
++ltmain=$ac_aux_dir/ltmain.sh
+ 
+ 
+   # We use sed instead of cat because bash on DJGPP gets confused if
+@@ -21406,165 +22120,6 @@ ltmain="$ac_aux_dir/ltmain.sh"
+   sed '$q' "$ltmain" >> "$cfgfile" \
+      || (rm -f "$cfgfile"; exit 1)
+ 
+-  if test x"$xsi_shell" = xyes; then
+-  sed -e '/^func_dirname ()$/,/^} # func_dirname /c\
+-func_dirname ()\
+-{\
+-\    case ${1} in\
+-\      */*) func_dirname_result="${1%/*}${2}" ;;\
+-\      *  ) func_dirname_result="${3}" ;;\
+-\    esac\
+-} # Extended-shell func_dirname implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_basename ()$/,/^} # func_basename /c\
+-func_basename ()\
+-{\
+-\    func_basename_result="${1##*/}"\
+-} # Extended-shell func_basename implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_dirname_and_basename ()$/,/^} # func_dirname_and_basename /c\
+-func_dirname_and_basename ()\
+-{\
+-\    case ${1} in\
+-\      */*) func_dirname_result="${1%/*}${2}" ;;\
+-\      *  ) func_dirname_result="${3}" ;;\
+-\    esac\
+-\    func_basename_result="${1##*/}"\
+-} # Extended-shell func_dirname_and_basename implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_stripname ()$/,/^} # func_stripname /c\
+-func_stripname ()\
+-{\
+-\    # pdksh 5.2.14 does not do ${X%$Y} correctly if both X and Y are\
+-\    # positional parameters, so assign one to ordinary parameter first.\
+-\    func_stripname_result=${3}\
+-\    func_stripname_result=${func_stripname_result#"${1}"}\
+-\    func_stripname_result=${func_stripname_result%"${2}"}\
+-} # Extended-shell func_stripname implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_split_long_opt ()$/,/^} # func_split_long_opt /c\
+-func_split_long_opt ()\
+-{\
+-\    func_split_long_opt_name=${1%%=*}\
+-\    func_split_long_opt_arg=${1#*=}\
+-} # Extended-shell func_split_long_opt implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_split_short_opt ()$/,/^} # func_split_short_opt /c\
+-func_split_short_opt ()\
+-{\
+-\    func_split_short_opt_arg=${1#??}\
+-\    func_split_short_opt_name=${1%"$func_split_short_opt_arg"}\
+-} # Extended-shell func_split_short_opt implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_lo2o ()$/,/^} # func_lo2o /c\
+-func_lo2o ()\
+-{\
+-\    case ${1} in\
+-\      *.lo) func_lo2o_result=${1%.lo}.${objext} ;;\
+-\      *)    func_lo2o_result=${1} ;;\
+-\    esac\
+-} # Extended-shell func_lo2o implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_xform ()$/,/^} # func_xform /c\
+-func_xform ()\
+-{\
+-    func_xform_result=${1%.*}.lo\
+-} # Extended-shell func_xform implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_arith ()$/,/^} # func_arith /c\
+-func_arith ()\
+-{\
+-    func_arith_result=$(( $* ))\
+-} # Extended-shell func_arith implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_len ()$/,/^} # func_len /c\
+-func_len ()\
+-{\
+-    func_len_result=${#1}\
+-} # Extended-shell func_len implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-fi
+-
+-if test x"$lt_shell_append" = xyes; then
+-  sed -e '/^func_append ()$/,/^} # func_append /c\
+-func_append ()\
+-{\
+-    eval "${1}+=\\${2}"\
+-} # Extended-shell func_append implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  sed -e '/^func_append_quoted ()$/,/^} # func_append_quoted /c\
+-func_append_quoted ()\
+-{\
+-\    func_quote_for_eval "${2}"\
+-\    eval "${1}+=\\\\ \\$func_quote_for_eval_result"\
+-} # Extended-shell func_append_quoted implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-
+-
+-  # Save a `func_append' function call where possible by direct use of '+='
+-  sed -e 's%func_append \([a-zA-Z_]\{1,\}\) "%\1+="%g' $cfgfile > $cfgfile.tmp \
+-    && mv -f "$cfgfile.tmp" "$cfgfile" \
+-      || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-  test 0 -eq $? || _lt_function_replace_fail=:
+-else
+-  # Save a `func_append' function call even when '+=' is not available
+-  sed -e 's%func_append \([a-zA-Z_]\{1,\}\) "%\1="$\1%g' $cfgfile > $cfgfile.tmp \
+-    && mv -f "$cfgfile.tmp" "$cfgfile" \
+-      || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-  test 0 -eq $? || _lt_function_replace_fail=:
+-fi
+-
+-if test x"$_lt_function_replace_fail" = x":"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to substitute extended shell functions in $ofile" >&5
+-$as_echo "$as_me: WARNING: Unable to substitute extended shell functions in $ofile" >&2;}
+-fi
+-
+-
+    mv -f "$cfgfile" "$ofile" ||
+     (rm -f "$ofile" && cp "$cfgfile" "$ofile" && rm -f "$cfgfile")
+   chmod +x "$ofile"
+@@ -21651,13 +22206,13 @@ hardcode_libdir_flag_spec=$lt_hardcode_libdir_flag_spec_CXX
+ # Whether we need a single "-rpath" flag with a separated argument.
+ hardcode_libdir_separator=$lt_hardcode_libdir_separator_CXX
+ 
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
++# Set to "yes" if using DIR/libNAME\$shared_ext during linking hardcodes
+ # DIR into the resulting binary.
+ hardcode_direct=$hardcode_direct_CXX
+ 
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
++# Set to "yes" if using DIR/libNAME\$shared_ext during linking hardcodes
+ # DIR into the resulting binary and the resulting library dependency is
+-# "absolute",i.e impossible to change by setting \${shlibpath_var} if the
++# "absolute",i.e impossible to change by setting \$shlibpath_var if the
+ # library is relocated.
+ hardcode_direct_absolute=$hardcode_direct_absolute_CXX
+ 
+diff --git a/fficonfig.h.in b/fficonfig.h.in
+index 8aec513..26fcbf2 100644
+--- a/fficonfig.h.in
++++ b/fficonfig.h.in
+@@ -124,8 +124,7 @@
+ /* Define to 1 if you have the <unistd.h> header file. */
+ #undef HAVE_UNISTD_H
+ 
+-/* Define to the sub-directory in which libtool stores uninstalled libraries.
+-   */
++/* Define to the sub-directory where libtool stores uninstalled libraries. */
+ #undef LT_OBJDIR
+ 
+ /* Define to 1 if your C compiler doesn't accept -c and -o together. */
+diff --git a/include/Makefile.in b/include/Makefile.in
+index 9d747e8..f137729 100644
+--- a/include/Makefile.in
++++ b/include/Makefile.in
+@@ -223,6 +223,7 @@ LIBTOOL = @LIBTOOL@
+ LIPO = @LIPO@
+ LN_S = @LN_S@
+ LTLIBOBJS = @LTLIBOBJS@
++LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
+ MAINT = @MAINT@
+ MAKEINFO = @MAKEINFO@
+ MANIFEST_TOOL = @MANIFEST_TOOL@
+diff --git a/ltmain.sh b/ltmain.sh
+index 63ae69d..f34febc 100644
+--- a/ltmain.sh
++++ b/ltmain.sh
+@@ -1,9 +1,12 @@
++#! /bin/sh
++## DO NOT EDIT - This file generated from ./build-aux/ltmain.in
++##               by inline-source v2016-02-21.11
+ 
+-# libtool (GNU libtool) 2.4.2
++# libtool (GNU libtool) 2.4.6.34-08c5
++# Provide generalized library-building support services.
+ # Written by Gordon Matzigkeit <gord@gnu.ai.mit.edu>, 1996
+ 
+-# Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005, 2006,
+-# 2007, 2008, 2009, 2010, 2011 Free Software Foundation, Inc.
++# Copyright (C) 1996-2016 Free Software Foundation, Inc.
+ # This is free software; see the source for copying conditions.  There is NO
+ # warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ 
+@@ -23,881 +26,2311 @@
+ # General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+-# along with GNU Libtool; see the file COPYING.  If not, a copy
+-# can be downloaded from http://www.gnu.org/licenses/gpl.html,
+-# or obtained by writing to the Free Software Foundation, Inc.,
+-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+-# Usage: $progname [OPTION]... [MODE-ARG]...
+-#
+-# Provide generalized library-building support services.
+-#
+-#       --config             show all configuration variables
+-#       --debug              enable verbose shell tracing
+-#   -n, --dry-run            display commands without modifying any files
+-#       --features           display basic configuration information and exit
+-#       --mode=MODE          use operation mode MODE
+-#       --preserve-dup-deps  don't remove duplicate dependency libraries
+-#       --quiet, --silent    don't print informational messages
+-#       --no-quiet, --no-silent
+-#                            print informational messages (default)
+-#       --no-warn            don't display warning messages
+-#       --tag=TAG            use configuration variables from tag TAG
+-#   -v, --verbose            print more informational messages than default
+-#       --no-verbose         don't print the extra informational messages
+-#       --version            print version information
+-#   -h, --help, --help-all   print short, long, or detailed help message
+-#
+-# MODE must be one of the following:
+-#
+-#         clean              remove files from the build directory
+-#         compile            compile a source file into a libtool object
+-#         execute            automatically set library path, then run a program
+-#         finish             complete the installation of libtool libraries
+-#         install            install libraries or executables
+-#         link               create a library or an executable
+-#         uninstall          remove libraries from an installed directory
++
++PROGRAM=libtool
++PACKAGE=libtool
++VERSION=2.4.6.34-08c5
++package_revision=2.4.6.34
++
++
++## ------ ##
++## Usage. ##
++## ------ ##
++
++# Run './libtool --help' for help with using this script from the
++# command line.
++
++
++## ------------------------------- ##
++## User overridable command paths. ##
++## ------------------------------- ##
++
++# After configure completes, it has a better idea of some of the
++# shell tools we need than the defaults used by the functions shared
++# with bootstrap, so set those here where they can still be over-
++# ridden by the user, but otherwise take precedence.
++
++: ${AUTOCONF="autoconf"}
++: ${AUTOMAKE="automake"}
++
++
++## -------------------------- ##
++## Source external libraries. ##
++## -------------------------- ##
++
++# Much of our low-level functionality needs to be sourced from external
++# libraries, which are installed to $pkgauxdir.
++
++# Set a version string for this script.
++scriptversion=2016-02-28.16; # UTC
++
++# General shell script boiler plate, and helper functions.
++# Written by Gary V. Vaughan, 2004
++
++# This is free software.  There is NO warranty; not even for
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ #
+-# MODE-ARGS vary depending on the MODE.  When passed as first option,
+-# `--mode=MODE' may be abbreviated as `MODE' or a unique abbreviation of that.
+-# Try `$progname --help --mode=MODE' for a more detailed description of MODE.
++# Copyright (C) 2004-2016 Bootstrap Authors
+ #
+-# When reporting a bug, please describe a test case to reproduce it and
+-# include the following information:
++# This file is dual licensed under the terms of the MIT license
++# <https://opensource.org/license/MIT>, and GPL version 3 or later
++# <http://www.gnu.org/licenses/gpl-2.0.html>.  You must apply one of
++# these licenses when using or redistributing this software or any of
++# the files within it.  See the URLs above, or the file `LICENSE`
++# included in the Bootstrap distribution for the full license texts.
++
++# Please report bugs or propose patches to:
++# <https://github.com/gnulib-modules/bootstrap/issues>
++
++
++## ------ ##
++## Usage. ##
++## ------ ##
++
++# Evaluate this file near the top of your script to gain access to
++# the functions and variables defined here:
+ #
+-#         host-triplet:	$host
+-#         shell:		$SHELL
+-#         compiler:		$LTCC
+-#         compiler flags:		$LTCFLAGS
+-#         linker:		$LD (gnu? $with_gnu_ld)
+-#         $progname:	(GNU libtool) 2.4.2
+-#         automake:	$automake_version
+-#         autoconf:	$autoconf_version
++#   . `echo "$0" | ${SED-sed} 's|[^/]*$||'`/build-aux/funclib.sh
+ #
+-# Report bugs to <bug-libtool@gnu.org>.
+-# GNU libtool home page: <http://www.gnu.org/software/libtool/>.
+-# General help using GNU software: <http://www.gnu.org/gethelp/>.
++# If you need to override any of the default environment variable
++# settings, do that before evaluating this file.
+ 
+-PROGRAM=libtool
+-PACKAGE=libtool
+-VERSION=2.4.2
+-TIMESTAMP=""
+-package_revision=1.3337
+ 
+-# Be Bourne compatible
+-if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then
++## -------------------- ##
++## Shell normalisation. ##
++## -------------------- ##
++
++# Some shells need a little help to be as Bourne compatible as possible.
++# Before doing anything else, make sure all that help has been provided!
++
++DUALCASE=1; export DUALCASE # for MKS sh
++if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
+   emulate sh
+   NULLCMD=:
+-  # Zsh 3.x and 4.x performs word splitting on ${1+"$@"}, which
++  # Pre-4.2 versions of Zsh do word splitting on ${1+"$@"}, which
+   # is contrary to our usage.  Disable this feature.
+   alias -g '${1+"$@"}'='"$@"'
+   setopt NO_GLOB_SUBST
+ else
+-  case `(set -o) 2>/dev/null` in *posix*) set -o posix;; esac
++  case `(set -o) 2>/dev/null` in *posix*) set -o posix ;; esac
+ fi
+-BIN_SH=xpg4; export BIN_SH # for Tru64
+-DUALCASE=1; export DUALCASE # for MKS sh
+-
+-# A function that is used when there is no print builtin or printf.
+-func_fallback_echo ()
+-{
+-  eval 'cat <<_LTECHO_EOF
+-$1
+-_LTECHO_EOF'
+-}
+ 
+-# NLS nuisances: We save the old values to restore during execute mode.
+-lt_user_locale=
+-lt_safe_locale=
+-for lt_var in LANG LANGUAGE LC_ALL LC_CTYPE LC_COLLATE LC_MESSAGES
++# NLS nuisances: We save the old values in case they are required later.
++_G_user_locale=
++_G_safe_locale=
++for _G_var in LANG LANGUAGE LC_ALL LC_CTYPE LC_COLLATE LC_MESSAGES
+ do
+-  eval "if test \"\${$lt_var+set}\" = set; then
+-          save_$lt_var=\$$lt_var
+-          $lt_var=C
+-	  export $lt_var
+-	  lt_user_locale=\"$lt_var=\\\$save_\$lt_var; \$lt_user_locale\"
+-	  lt_safe_locale=\"$lt_var=C; \$lt_safe_locale\"
++  eval "if test set = \"\${$_G_var+set}\"; then
++          save_$_G_var=\$$_G_var
++          $_G_var=C
++	  export $_G_var
++	  _G_user_locale=\"$_G_var=\\\$save_\$_G_var; \$_G_user_locale\"
++	  _G_safe_locale=\"$_G_var=C; \$_G_safe_locale\"
+ 	fi"
+ done
+-LC_ALL=C
+-LANGUAGE=C
+-export LANGUAGE LC_ALL
+-
+-$lt_unset CDPATH
+ 
++# Make sure IFS has a sensible default
++sp=' '
++nl='
++'
++IFS="$sp	$nl"
++
++# There are apparently some retarded systems that use ';' as a PATH separator!
++if test "${PATH_SEPARATOR+set}" != set; then
++  PATH_SEPARATOR=:
++  (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
++    (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 ||
++      PATH_SEPARATOR=';'
++  }
++fi
+ 
+-# Work around backward compatibility issue on IRIX 6.5. On IRIX 6.4+, sh
+-# is ksh but when the shell is invoked as "sh" and the current value of
+-# the _XPG environment variable is not equal to 1 (one), the special
+-# positional parameter $0, within a function call, is the name of the
+-# function.
+-progpath="$0"
+ 
++# func_unset VAR
++# --------------
++# Portably unset VAR.
++# In some shells, an 'unset VAR' statement leaves a non-zero return
++# status if VAR is already unset, which might be problematic if the
++# statement is used at the end of a function (thus poisoning its return
++# value) or when 'set -e' is active (causing even a spurious abort of
++# the script in this case).
++func_unset ()
++{
++    { eval $1=; (eval unset $1) >/dev/null 2>&1 && eval unset $1 || : ; }
++}
+ 
+ 
+-: ${CP="cp -f"}
+-test "${ECHO+set}" = set || ECHO=${as_echo-'printf %s\n'}
+-: ${MAKE="make"}
+-: ${MKDIR="mkdir"}
+-: ${MV="mv -f"}
+-: ${RM="rm -f"}
+-: ${SHELL="${CONFIG_SHELL-/bin/sh}"}
+-: ${Xsed="$SED -e 1s/^X//"}
++# Make sure CDPATH doesn't cause `cd` commands to output the target dir.
++func_unset CDPATH
+ 
+-# Global variables:
+-EXIT_SUCCESS=0
+-EXIT_FAILURE=1
+-EXIT_MISMATCH=63  # $? = 63 is used to indicate version mismatch to missing.
+-EXIT_SKIP=77	  # $? = 77 is used to indicate a skipped test to automake.
++# Make sure ${,E,F}GREP behave sanely.
++func_unset GREP_OPTIONS
+ 
+-exit_status=$EXIT_SUCCESS
+ 
+-# Make sure IFS has a sensible default
+-lt_nl='
+-'
+-IFS=" 	$lt_nl"
++## ------------------------- ##
++## Locate command utilities. ##
++## ------------------------- ##
+ 
+-dirname="s,/[^/]*$,,"
+-basename="s,^.*/,,"
+ 
+-# func_dirname file append nondir_replacement
+-# Compute the dirname of FILE.  If nonempty, add APPEND to the result,
+-# otherwise set result to NONDIR_REPLACEMENT.
+-func_dirname ()
++# func_executable_p FILE
++# ----------------------
++# Check that FILE is an executable regular file.
++func_executable_p ()
+ {
+-    func_dirname_result=`$ECHO "${1}" | $SED "$dirname"`
+-    if test "X$func_dirname_result" = "X${1}"; then
+-      func_dirname_result="${3}"
+-    else
+-      func_dirname_result="$func_dirname_result${2}"
+-    fi
+-} # func_dirname may be replaced by extended shell implementation
++    test -f "$1" && test -x "$1"
++}
+ 
+ 
+-# func_basename file
+-func_basename ()
++# func_path_progs PROGS_LIST CHECK_FUNC [PATH]
++# --------------------------------------------
++# Search for either a program that responds to --version with output
++# containing "GNU", or else returned by CHECK_FUNC otherwise, by
++# trying all the directories in PATH with each of the elements of
++# PROGS_LIST.
++#
++# CHECK_FUNC should accept the path to a candidate program, and
++# set $func_check_prog_result if it truncates its output less than
++# $_G_path_prog_max characters.
++func_path_progs ()
+ {
+-    func_basename_result=`$ECHO "${1}" | $SED "$basename"`
+-} # func_basename may be replaced by extended shell implementation
++    _G_progs_list=$1
++    _G_check_func=$2
++    _G_PATH=${3-"$PATH"}
++
++    _G_path_prog_max=0
++    _G_path_prog_found=false
++    _G_save_IFS=$IFS; IFS=${PATH_SEPARATOR-:}
++    for _G_dir in $_G_PATH; do
++      IFS=$_G_save_IFS
++      test -z "$_G_dir" && _G_dir=.
++      for _G_prog_name in $_G_progs_list; do
++        for _exeext in '' .EXE; do
++          _G_path_prog=$_G_dir/$_G_prog_name$_exeext
++          func_executable_p "$_G_path_prog" || continue
++          case `"$_G_path_prog" --version 2>&1` in
++            *GNU*) func_path_progs_result=$_G_path_prog _G_path_prog_found=: ;;
++            *)     $_G_check_func $_G_path_prog
++		   func_path_progs_result=$func_check_prog_result
++		   ;;
++          esac
++          $_G_path_prog_found && break 3
++        done
++      done
++    done
++    IFS=$_G_save_IFS
++    test -z "$func_path_progs_result" && {
++      echo "no acceptable sed could be found in \$PATH" >&2
++      exit 1
++    }
++}
+ 
+ 
+-# func_dirname_and_basename file append nondir_replacement
+-# perform func_basename and func_dirname in a single function
+-# call:
+-#   dirname:  Compute the dirname of FILE.  If nonempty,
+-#             add APPEND to the result, otherwise set result
+-#             to NONDIR_REPLACEMENT.
+-#             value returned in "$func_dirname_result"
+-#   basename: Compute filename of FILE.
+-#             value retuned in "$func_basename_result"
+-# Implementation must be kept synchronized with func_dirname
+-# and func_basename. For efficiency, we do not delegate to
+-# those functions but instead duplicate the functionality here.
+-func_dirname_and_basename ()
+-{
+-    # Extract subdirectory from the argument.
+-    func_dirname_result=`$ECHO "${1}" | $SED -e "$dirname"`
+-    if test "X$func_dirname_result" = "X${1}"; then
+-      func_dirname_result="${3}"
+-    else
+-      func_dirname_result="$func_dirname_result${2}"
+-    fi
+-    func_basename_result=`$ECHO "${1}" | $SED -e "$basename"`
+-} # func_dirname_and_basename may be replaced by extended shell implementation
++# We want to be able to use the functions in this file before configure
++# has figured out where the best binaries are kept, which means we have
++# to search for them ourselves - except when the results are already set
++# where we skip the searches.
+ 
++# Unless the user overrides by setting SED, search the path for either GNU
++# sed, or the sed that truncates its output the least.
++test -z "$SED" && {
++  _G_sed_script=s/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/
++  for _G_i in 1 2 3 4 5 6 7; do
++    _G_sed_script=$_G_sed_script$nl$_G_sed_script
++  done
++  echo "$_G_sed_script" 2>/dev/null | sed 99q >conftest.sed
++  _G_sed_script=
+ 
+-# func_stripname prefix suffix name
+-# strip PREFIX and SUFFIX off of NAME.
+-# PREFIX and SUFFIX must not contain globbing or regex special
+-# characters, hashes, percent signs, but SUFFIX may contain a leading
+-# dot (in which case that matches only a dot).
+-# func_strip_suffix prefix name
+-func_stripname ()
+-{
+-    case ${2} in
+-      .*) func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%\\\\${2}\$%%"`;;
+-      *)  func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%${2}\$%%"`;;
+-    esac
+-} # func_stripname may be replaced by extended shell implementation
++  func_check_prog_sed ()
++  {
++    _G_path_prog=$1
+ 
++    _G_count=0
++    printf 0123456789 >conftest.in
++    while :
++    do
++      cat conftest.in conftest.in >conftest.tmp
++      mv conftest.tmp conftest.in
++      cp conftest.in conftest.nl
++      echo '' >> conftest.nl
++      "$_G_path_prog" -f conftest.sed <conftest.nl >conftest.out 2>/dev/null || break
++      diff conftest.out conftest.nl >/dev/null 2>&1 || break
++      _G_count=`expr $_G_count + 1`
++      if test "$_G_count" -gt "$_G_path_prog_max"; then
++        # Best one so far, save it but keep looking for a better one
++        func_check_prog_result=$_G_path_prog
++        _G_path_prog_max=$_G_count
++      fi
++      # 10*(2^10) chars as input seems more than enough
++      test 10 -lt "$_G_count" && break
++    done
++    rm -f conftest.in conftest.tmp conftest.nl conftest.out
++  }
+ 
+-# These SED scripts presuppose an absolute path with a trailing slash.
+-pathcar='s,^/\([^/]*\).*$,\1,'
+-pathcdr='s,^/[^/]*,,'
+-removedotparts=':dotsl
+-		s@/\./@/@g
+-		t dotsl
+-		s,/\.$,/,'
+-collapseslashes='s@/\{1,\}@/@g'
+-finalslash='s,/*$,/,'
++  func_path_progs "sed gsed" func_check_prog_sed $PATH:/usr/xpg4/bin
++  rm -f conftest.sed
++  SED=$func_path_progs_result
++}
+ 
+-# func_normal_abspath PATH
+-# Remove doubled-up and trailing slashes, "." path components,
+-# and cancel out any ".." path components in PATH after making
+-# it an absolute path.
+-#             value returned in "$func_normal_abspath_result"
+-func_normal_abspath ()
+-{
+-  # Start from root dir and reassemble the path.
+-  func_normal_abspath_result=
+-  func_normal_abspath_tpath=$1
+-  func_normal_abspath_altnamespace=
+-  case $func_normal_abspath_tpath in
+-    "")
+-      # Empty path, that just means $cwd.
+-      func_stripname '' '/' "`pwd`"
+-      func_normal_abspath_result=$func_stripname_result
+-      return
+-    ;;
+-    # The next three entries are used to spot a run of precisely
+-    # two leading slashes without using negated character classes;
+-    # we take advantage of case's first-match behaviour.
+-    ///*)
+-      # Unusual form of absolute path, do nothing.
+-    ;;
+-    //*)
+-      # Not necessarily an ordinary path; POSIX reserves leading '//'
+-      # and for example Cygwin uses it to access remote file shares
+-      # over CIFS/SMB, so we conserve a leading double slash if found.
+-      func_normal_abspath_altnamespace=/
+-    ;;
+-    /*)
+-      # Absolute path, do nothing.
+-    ;;
+-    *)
+-      # Relative path, prepend $cwd.
+-      func_normal_abspath_tpath=`pwd`/$func_normal_abspath_tpath
+-    ;;
+-  esac
+-  # Cancel out all the simple stuff to save iterations.  We also want
+-  # the path to end with a slash for ease of parsing, so make sure
+-  # there is one (and only one) here.
+-  func_normal_abspath_tpath=`$ECHO "$func_normal_abspath_tpath" | $SED \
+-        -e "$removedotparts" -e "$collapseslashes" -e "$finalslash"`
+-  while :; do
+-    # Processed it all yet?
+-    if test "$func_normal_abspath_tpath" = / ; then
+-      # If we ascended to the root using ".." the result may be empty now.
+-      if test -z "$func_normal_abspath_result" ; then
+-        func_normal_abspath_result=/
++
++# Unless the user overrides by setting GREP, search the path for either GNU
++# grep, or the grep that truncates its output the least.
++test -z "$GREP" && {
++  func_check_prog_grep ()
++  {
++    _G_path_prog=$1
++
++    _G_count=0
++    _G_path_prog_max=0
++    printf 0123456789 >conftest.in
++    while :
++    do
++      cat conftest.in conftest.in >conftest.tmp
++      mv conftest.tmp conftest.in
++      cp conftest.in conftest.nl
++      echo 'GREP' >> conftest.nl
++      "$_G_path_prog" -e 'GREP$' -e '-(cannot match)-' <conftest.nl >conftest.out 2>/dev/null || break
++      diff conftest.out conftest.nl >/dev/null 2>&1 || break
++      _G_count=`expr $_G_count + 1`
++      if test "$_G_count" -gt "$_G_path_prog_max"; then
++        # Best one so far, save it but keep looking for a better one
++        func_check_prog_result=$_G_path_prog
++        _G_path_prog_max=$_G_count
+       fi
+-      break
+-    fi
+-    func_normal_abspath_tcomponent=`$ECHO "$func_normal_abspath_tpath" | $SED \
+-        -e "$pathcar"`
+-    func_normal_abspath_tpath=`$ECHO "$func_normal_abspath_tpath" | $SED \
+-        -e "$pathcdr"`
+-    # Figure out what to do with it
+-    case $func_normal_abspath_tcomponent in
+-      "")
+-        # Trailing empty path component, ignore it.
+-      ;;
+-      ..)
+-        # Parent dir; strip last assembled component from result.
+-        func_dirname "$func_normal_abspath_result"
+-        func_normal_abspath_result=$func_dirname_result
+-      ;;
+-      *)
+-        # Actual path component, append it.
+-        func_normal_abspath_result=$func_normal_abspath_result/$func_normal_abspath_tcomponent
+-      ;;
+-    esac
+-  done
+-  # Restore leading double-slash if one was found on entry.
+-  func_normal_abspath_result=$func_normal_abspath_altnamespace$func_normal_abspath_result
++      # 10*(2^10) chars as input seems more than enough
++      test 10 -lt "$_G_count" && break
++    done
++    rm -f conftest.in conftest.tmp conftest.nl conftest.out
++  }
++
++  func_path_progs "grep ggrep" func_check_prog_grep $PATH:/usr/xpg4/bin
++  GREP=$func_path_progs_result
+ }
+ 
+-# func_relative_path SRCDIR DSTDIR
+-# generates a relative path from SRCDIR to DSTDIR, with a trailing
+-# slash if non-empty, suitable for immediately appending a filename
+-# without needing to append a separator.
+-#             value returned in "$func_relative_path_result"
+-func_relative_path ()
+-{
+-  func_relative_path_result=
+-  func_normal_abspath "$1"
+-  func_relative_path_tlibdir=$func_normal_abspath_result
+-  func_normal_abspath "$2"
+-  func_relative_path_tbindir=$func_normal_abspath_result
+-
+-  # Ascend the tree starting from libdir
+-  while :; do
+-    # check if we have found a prefix of bindir
+-    case $func_relative_path_tbindir in
+-      $func_relative_path_tlibdir)
+-        # found an exact match
+-        func_relative_path_tcancelled=
+-        break
+-        ;;
+-      $func_relative_path_tlibdir*)
+-        # found a matching prefix
+-        func_stripname "$func_relative_path_tlibdir" '' "$func_relative_path_tbindir"
+-        func_relative_path_tcancelled=$func_stripname_result
+-        if test -z "$func_relative_path_result"; then
+-          func_relative_path_result=.
+-        fi
+-        break
+-        ;;
+-      *)
+-        func_dirname $func_relative_path_tlibdir
+-        func_relative_path_tlibdir=${func_dirname_result}
+-        if test "x$func_relative_path_tlibdir" = x ; then
+-          # Have to descend all the way to the root!
+-          func_relative_path_result=../$func_relative_path_result
+-          func_relative_path_tcancelled=$func_relative_path_tbindir
+-          break
+-        fi
+-        func_relative_path_result=../$func_relative_path_result
+-        ;;
+-    esac
+-  done
+ 
+-  # Now calculate path; take care to avoid doubling-up slashes.
+-  func_stripname '' '/' "$func_relative_path_result"
+-  func_relative_path_result=$func_stripname_result
+-  func_stripname '/' '/' "$func_relative_path_tcancelled"
+-  if test "x$func_stripname_result" != x ; then
+-    func_relative_path_result=${func_relative_path_result}/${func_stripname_result}
+-  fi
++## ------------------------------- ##
++## User overridable command paths. ##
++## ------------------------------- ##
+ 
+-  # Normalisation. If bindir is libdir, return empty string,
+-  # else relative path ending with a slash; either way, target
+-  # file name can be directly appended.
+-  if test ! -z "$func_relative_path_result"; then
+-    func_stripname './' '' "$func_relative_path_result/"
+-    func_relative_path_result=$func_stripname_result
+-  fi
+-}
++# All uppercase variable names are used for environment variables.  These
++# variables can be overridden by the user before calling a script that
++# uses them if a suitable command of that name is not already available
++# in the command search PATH.
++
++: ${CP="cp -f"}
++: ${ECHO="printf %s\n"}
++: ${EGREP="$GREP -E"}
++: ${FGREP="$GREP -F"}
++: ${LN_S="ln -s"}
++: ${MAKE="make"}
++: ${MKDIR="mkdir"}
++: ${MV="mv -f"}
++: ${RM="rm -f"}
++: ${SHELL="${CONFIG_SHELL-/bin/sh}"}
++
++
++## -------------------- ##
++## Useful sed snippets. ##
++## -------------------- ##
++
++sed_dirname='s|/[^/]*$||'
++sed_basename='s|^.*/||'
++
++# Sed substitution that helps us do robust quoting.  It backslashifies
++# metacharacters that are still active within double-quoted strings.
++sed_quote_subst='s|\([`"$\\]\)|\\\1|g'
++
++# Same as above, but do not quote variable references.
++sed_double_quote_subst='s/\(["`\\]\)/\\\1/g'
++
++# Sed substitution that turns a string into a regex matching for the
++# string literally.
++sed_make_literal_regex='s|[].[^$\\*\/]|\\&|g'
++
++# Sed substitution that converts a w32 file name or path
++# that contains forward slashes, into one that contains
++# (escaped) backslashes.  A very naive implementation.
++sed_naive_backslashify='s|\\\\*|\\|g;s|/|\\|g;s|\\|\\\\|g'
++
++# Re-'\' parameter expansions in output of sed_double_quote_subst that
++# were '\'-ed in input to the same.  If an odd number of '\' preceded a
++# '$' in input to sed_double_quote_subst, that '$' was protected from
++# expansion.  Since each input '\' is now two '\'s, look for any number
++# of runs of four '\'s followed by two '\'s and then a '$'.  '\' that '$'.
++_G_bs='\\'
++_G_bs2='\\\\'
++_G_bs4='\\\\\\\\'
++_G_dollar='\$'
++sed_double_backslash="\
++  s/$_G_bs4/&\\
++/g
++  s/^$_G_bs2$_G_dollar/$_G_bs&/
++  s/\\([^$_G_bs]\\)$_G_bs2$_G_dollar/\\1$_G_bs2$_G_bs$_G_dollar/g
++  s/\n//g"
++
++
++## ----------------- ##
++## Global variables. ##
++## ----------------- ##
++
++# Except for the global variables explicitly listed below, the following
++# functions in the '^func_' namespace, and the '^require_' namespace
++# variables initialised in the 'Resource management' section, sourcing
++# this file will not pollute your global namespace with anything
++# else. There's no portable way to scope variables in Bourne shell
++# though, so actually running these functions will sometimes place
++# results into a variable named after the function, and often use
++# temporary variables in the '^_G_' namespace. If you are careful to
++# avoid using those namespaces casually in your sourcing script, things
++# should continue to work as you expect. And, of course, you can freely
++# overwrite any of the functions or variables defined here before
++# calling anything to customize them.
++
++EXIT_SUCCESS=0
++EXIT_FAILURE=1
++EXIT_MISMATCH=63  # $? = 63 is used to indicate version mismatch to missing.
++EXIT_SKIP=77	  # $? = 77 is used to indicate a skipped test to automake.
++
++# Allow overriding, eg assuming that you follow the convention of
++# putting '$debug_cmd' at the start of all your functions, you can get
++# bash to show function call trace with:
++#
++#    debug_cmd='eval echo "${FUNCNAME[0]} $*" >&2' bash your-script-name
++debug_cmd=${debug_cmd-":"}
++exit_cmd=:
++
++# By convention, finish your script with:
++#
++#    exit $exit_status
++#
++# so that you can set exit_status to non-zero if you want to indicate
++# something went wrong during execution without actually bailing out at
++# the point of failure.
++exit_status=$EXIT_SUCCESS
+ 
+-# The name of this program:
+-func_dirname_and_basename "$progpath"
+-progname=$func_basename_result
++# Work around backward compatibility issue on IRIX 6.5. On IRIX 6.4+, sh
++# is ksh but when the shell is invoked as "sh" and the current value of
++# the _XPG environment variable is not equal to 1 (one), the special
++# positional parameter $0, within a function call, is the name of the
++# function.
++progpath=$0
++
++# The name of this program.
++progname=`$ECHO "$progpath" |$SED "$sed_basename"`
+ 
+-# Make sure we have an absolute path for reexecution:
++# Make sure we have an absolute progpath for reexecution:
+ case $progpath in
+   [\\/]*|[A-Za-z]:\\*) ;;
+   *[\\/]*)
+-     progdir=$func_dirname_result
++     progdir=`$ECHO "$progpath" |$SED "$sed_dirname"`
+      progdir=`cd "$progdir" && pwd`
+-     progpath="$progdir/$progname"
++     progpath=$progdir/$progname
+      ;;
+   *)
+-     save_IFS="$IFS"
++     _G_IFS=$IFS
+      IFS=${PATH_SEPARATOR-:}
+      for progdir in $PATH; do
+-       IFS="$save_IFS"
++       IFS=$_G_IFS
+        test -x "$progdir/$progname" && break
+      done
+-     IFS="$save_IFS"
++     IFS=$_G_IFS
+      test -n "$progdir" || progdir=`pwd`
+-     progpath="$progdir/$progname"
++     progpath=$progdir/$progname
+      ;;
+ esac
+ 
+-# Sed substitution that helps us do robust quoting.  It backslashifies
+-# metacharacters that are still active within double-quoted strings.
+-Xsed="${SED}"' -e 1s/^X//'
+-sed_quote_subst='s/\([`"$\\]\)/\\\1/g'
+-
+-# Same as above, but do not quote variable references.
+-double_quote_subst='s/\(["`\\]\)/\\\1/g'
+ 
+-# Sed substitution that turns a string into a regex matching for the
+-# string literally.
+-sed_make_literal_regex='s,[].[^$\\*\/],\\&,g'
++## ----------------- ##
++## Standard options. ##
++## ----------------- ##
+ 
+-# Sed substitution that converts a w32 file name or path
+-# which contains forward slashes, into one that contains
+-# (escaped) backslashes.  A very naive implementation.
+-lt_sed_naive_backslashify='s|\\\\*|\\|g;s|/|\\|g;s|\\|\\\\|g'
+-
+-# Re-`\' parameter expansions in output of double_quote_subst that were
+-# `\'-ed in input to the same.  If an odd number of `\' preceded a '$'
+-# in input to double_quote_subst, that '$' was protected from expansion.
+-# Since each input `\' is now two `\'s, look for any number of runs of
+-# four `\'s followed by two `\'s and then a '$'.  `\' that '$'.
+-bs='\\'
+-bs2='\\\\'
+-bs4='\\\\\\\\'
+-dollar='\$'
+-sed_double_backslash="\
+-  s/$bs4/&\\
+-/g
+-  s/^$bs2$dollar/$bs&/
+-  s/\\([^$bs]\\)$bs2$dollar/\\1$bs2$bs$dollar/g
+-  s/\n//g"
++# The following options affect the operation of the functions defined
++# below, and should be set appropriately depending on run-time para-
++# meters passed on the command line.
+ 
+-# Standard options:
+ opt_dry_run=false
+-opt_help=false
+ opt_quiet=false
+ opt_verbose=false
+-opt_warning=:
+ 
+-# func_echo arg...
+-# Echo program name prefixed message, along with the current mode
+-# name if it has been set yet.
+-func_echo ()
+-{
+-    $ECHO "$progname: ${opt_mode+$opt_mode: }$*"
+-}
++# Categories 'all' and 'none' are always available.  Append any others
++# you will pass as the first argument to func_warning from your own
++# code.
++warning_categories=
+ 
+-# func_verbose arg...
+-# Echo program name prefixed message in verbose mode only.
+-func_verbose ()
+-{
+-    $opt_verbose && func_echo ${1+"$@"}
++# By default, display warnings according to 'opt_warning_types'.  Set
++# 'warning_func'  to ':' to elide all warnings, or func_fatal_error to
++# treat the next displayed warning as a fatal error.
++warning_func=func_warn_and_continue
+ 
+-    # A bug in bash halts the script if the last line of a function
+-    # fails when set -e is in force, so we need another command to
+-    # work around that:
+-    :
+-}
++# Set to 'all' to display all warnings, 'none' to suppress all
++# warnings, or a space delimited list of some subset of
++# 'warning_categories' to display only the listed warnings.
++opt_warning_types=all
+ 
+-# func_echo_all arg...
+-# Invoke $ECHO with all args, space-separated.
+-func_echo_all ()
+-{
+-    $ECHO "$*"
+-}
+ 
+-# func_error arg...
+-# Echo program name prefixed message to standard error.
+-func_error ()
+-{
+-    $ECHO "$progname: ${opt_mode+$opt_mode: }"${1+"$@"} 1>&2
+-}
++## -------------------- ##
++## Resource management. ##
++## -------------------- ##
+ 
+-# func_warning arg...
+-# Echo program name prefixed warning message to standard error.
+-func_warning ()
+-{
+-    $opt_warning && $ECHO "$progname: ${opt_mode+$opt_mode: }warning: "${1+"$@"} 1>&2
++# This section contains definitions for functions that each ensure a
++# particular resource (a file, or a non-empty configuration variable for
++# example) is available, and if appropriate to extract default values
++# from pertinent package files. Call them using their associated
++# 'require_*' variable to ensure that they are executed, at most, once.
++#
++# It's entirely deliberate that calling these functions can set
++# variables that don't obey the namespace limitations obeyed by the rest
++# of this file, in order that that they be as useful as possible to
++# callers.
+ 
+-    # bash bug again:
+-    :
+-}
+ 
+-# func_fatal_error arg...
+-# Echo program name prefixed message to standard error, and exit.
+-func_fatal_error ()
++# require_term_colors
++# -------------------
++# Allow display of bold text on terminals that support it.
++require_term_colors=func_require_term_colors
++func_require_term_colors ()
+ {
+-    func_error ${1+"$@"}
+-    exit $EXIT_FAILURE
+-}
++    $debug_cmd
++
++    test -t 1 && {
++      # COLORTERM and USE_ANSI_COLORS environment variables take
++      # precedence, because most terminfo databases neglect to describe
++      # whether color sequences are supported.
++      test -n "${COLORTERM+set}" && : ${USE_ANSI_COLORS="1"}
++
++      if test 1 = "$USE_ANSI_COLORS"; then
++        # Standard ANSI escape sequences
++        tc_reset='[0m'
++        tc_bold='[1m';   tc_standout='[7m'
++        tc_red='[31m';   tc_green='[32m'
++        tc_blue='[34m';  tc_cyan='[36m'
++      else
++        # Otherwise trust the terminfo database after all.
++        test -n "`tput sgr0 2>/dev/null`" && {
++          tc_reset=`tput sgr0`
++          test -n "`tput bold 2>/dev/null`" && tc_bold=`tput bold`
++          tc_standout=$tc_bold
++          test -n "`tput smso 2>/dev/null`" && tc_standout=`tput smso`
++          test -n "`tput setaf 1 2>/dev/null`" && tc_red=`tput setaf 1`
++          test -n "`tput setaf 2 2>/dev/null`" && tc_green=`tput setaf 2`
++          test -n "`tput setaf 4 2>/dev/null`" && tc_blue=`tput setaf 4`
++          test -n "`tput setaf 5 2>/dev/null`" && tc_cyan=`tput setaf 5`
++        }
++      fi
++    }
+ 
+-# func_fatal_help arg...
+-# Echo program name prefixed message to standard error, followed by
+-# a help hint, and exit.
+-func_fatal_help ()
+-{
+-    func_error ${1+"$@"}
+-    func_fatal_error "$help"
++    require_term_colors=:
+ }
+-help="Try \`$progname --help' for more information."  ## default
+ 
+ 
+-# func_grep expression filename
+-# Check whether EXPRESSION matches any line of FILENAME, without output.
+-func_grep ()
+-{
+-    $GREP "$1" "$2" >/dev/null 2>&1
+-}
++## ----------------- ##
++## Function library. ##
++## ----------------- ##
+ 
++# This section contains a variety of useful functions to call in your
++# scripts. Take note of the portable wrappers for features provided by
++# some modern shells, which will fall back to slower equivalents on
++# less featureful shells.
+ 
+-# func_mkdir_p directory-path
+-# Make sure the entire path to DIRECTORY-PATH is available.
+-func_mkdir_p ()
++
++# func_append VAR VALUE
++# ---------------------
++# Append VALUE onto the existing contents of VAR.
++
++  # We should try to minimise forks, especially on Windows where they are
++  # unreasonably slow, so skip the feature probes when bash or zsh are
++  # being used:
++  if test set = "${BASH_VERSION+set}${ZSH_VERSION+set}"; then
++    : ${_G_HAVE_ARITH_OP="yes"}
++    : ${_G_HAVE_XSI_OPS="yes"}
++    # The += operator was introduced in bash 3.1
++    case $BASH_VERSION in
++      [12].* | 3.0 | 3.0*) ;;
++      *)
++        : ${_G_HAVE_PLUSEQ_OP="yes"}
++        ;;
++    esac
++  fi
++
++  # _G_HAVE_PLUSEQ_OP
++  # Can be empty, in which case the shell is probed, "yes" if += is
++  # useable or anything else if it does not work.
++  test -z "$_G_HAVE_PLUSEQ_OP" \
++    && (eval 'x=a; x+=" b"; test "a b" = "$x"') 2>/dev/null \
++    && _G_HAVE_PLUSEQ_OP=yes
++
++if test yes = "$_G_HAVE_PLUSEQ_OP"
++then
++  # This is an XSI compatible shell, allowing a faster implementation...
++  eval 'func_append ()
++  {
++    $debug_cmd
++
++    eval "$1+=\$2"
++  }'
++else
++  # ...otherwise fall back to using expr, which is often a shell builtin.
++  func_append ()
++  {
++    $debug_cmd
++
++    eval "$1=\$$1\$2"
++  }
++fi
++
++
++# func_append_quoted VAR VALUE
++# ----------------------------
++# Quote VALUE and append to the end of shell variable VAR, separated
++# by a space.
++if test yes = "$_G_HAVE_PLUSEQ_OP"; then
++  eval 'func_append_quoted ()
++  {
++    $debug_cmd
++
++    func_quote_arg pretty "$2"
++    eval "$1+=\\ \$func_quote_arg_result"
++  }'
++else
++  func_append_quoted ()
++  {
++    $debug_cmd
++
++    func_quote_arg pretty "$2"
++    eval "$1=\$$1\\ \$func_quote_arg_result"
++  }
++fi
++
++
++# func_append_uniq VAR VALUE
++# --------------------------
++# Append unique VALUE onto the existing contents of VAR, assuming
++# entries are delimited by the first character of VALUE.  For example:
++#
++#   func_append_uniq options " --another-option option-argument"
++#
++# will only append to $options if " --another-option option-argument "
++# is not already present somewhere in $options already (note spaces at
++# each end implied by leading space in second argument).
++func_append_uniq ()
++{
++    $debug_cmd
++
++    eval _G_current_value='`$ECHO $'$1'`'
++    _G_delim=`expr "$2" : '\(.\)'`
++
++    case $_G_delim$_G_current_value$_G_delim in
++      *"$2$_G_delim"*) ;;
++      *) func_append "$@" ;;
++    esac
++}
++
++
++# func_arith TERM...
++# ------------------
++# Set func_arith_result to the result of evaluating TERMs.
++  test -z "$_G_HAVE_ARITH_OP" \
++    && (eval 'test 2 = $(( 1 + 1 ))') 2>/dev/null \
++    && _G_HAVE_ARITH_OP=yes
++
++if test yes = "$_G_HAVE_ARITH_OP"; then
++  eval 'func_arith ()
++  {
++    $debug_cmd
++
++    func_arith_result=$(( $* ))
++  }'
++else
++  func_arith ()
++  {
++    $debug_cmd
++
++    func_arith_result=`expr "$@"`
++  }
++fi
++
++
++# func_basename FILE
++# ------------------
++# Set func_basename_result to FILE with everything up to and including
++# the last / stripped.
++if test yes = "$_G_HAVE_XSI_OPS"; then
++  # If this shell supports suffix pattern removal, then use it to avoid
++  # forking. Hide the definitions single quotes in case the shell chokes
++  # on unsupported syntax...
++  _b='func_basename_result=${1##*/}'
++  _d='case $1 in
++        */*) func_dirname_result=${1%/*}$2 ;;
++        *  ) func_dirname_result=$3        ;;
++      esac'
++
++else
++  # ...otherwise fall back to using sed.
++  _b='func_basename_result=`$ECHO "$1" |$SED "$sed_basename"`'
++  _d='func_dirname_result=`$ECHO "$1"  |$SED "$sed_dirname"`
++      if test "X$func_dirname_result" = "X$1"; then
++        func_dirname_result=$3
++      else
++        func_append func_dirname_result "$2"
++      fi'
++fi
++
++eval 'func_basename ()
++{
++    $debug_cmd
++
++    '"$_b"'
++}'
++
++
++# func_dirname FILE APPEND NONDIR_REPLACEMENT
++# -------------------------------------------
++# Compute the dirname of FILE.  If nonempty, add APPEND to the result,
++# otherwise set result to NONDIR_REPLACEMENT.
++eval 'func_dirname ()
++{
++    $debug_cmd
++
++    '"$_d"'
++}'
++
++
++# func_dirname_and_basename FILE APPEND NONDIR_REPLACEMENT
++# --------------------------------------------------------
++# Perform func_basename and func_dirname in a single function
++# call:
++#   dirname:  Compute the dirname of FILE.  If nonempty,
++#             add APPEND to the result, otherwise set result
++#             to NONDIR_REPLACEMENT.
++#             value returned in "$func_dirname_result"
++#   basename: Compute filename of FILE.
++#             value retuned in "$func_basename_result"
++# For efficiency, we do not delegate to the functions above but instead
++# duplicate the functionality here.
++eval 'func_dirname_and_basename ()
++{
++    $debug_cmd
++
++    '"$_b"'
++    '"$_d"'
++}'
++
++
++# func_echo ARG...
++# ----------------
++# Echo program name prefixed message.
++func_echo ()
++{
++    $debug_cmd
++
++    _G_message=$*
++
++    func_echo_IFS=$IFS
++    IFS=$nl
++    for _G_line in $_G_message; do
++      IFS=$func_echo_IFS
++      $ECHO "$progname: $_G_line"
++    done
++    IFS=$func_echo_IFS
++}
++
++
++# func_echo_all ARG...
++# --------------------
++# Invoke $ECHO with all args, space-separated.
++func_echo_all ()
++{
++    $ECHO "$*"
++}
++
++
++# func_echo_infix_1 INFIX ARG...
++# ------------------------------
++# Echo program name, followed by INFIX on the first line, with any
++# additional lines not showing INFIX.
++func_echo_infix_1 ()
++{
++    $debug_cmd
++
++    $require_term_colors
++
++    _G_infix=$1; shift
++    _G_indent=$_G_infix
++    _G_prefix="$progname: $_G_infix: "
++    _G_message=$*
++
++    # Strip color escape sequences before counting printable length
++    for _G_tc in "$tc_reset" "$tc_bold" "$tc_standout" "$tc_red" "$tc_green" "$tc_blue" "$tc_cyan"
++    do
++      test -n "$_G_tc" && {
++        _G_esc_tc=`$ECHO "$_G_tc" | $SED "$sed_make_literal_regex"`
++        _G_indent=`$ECHO "$_G_indent" | $SED "s|$_G_esc_tc||g"`
++      }
++    done
++    _G_indent="$progname: "`echo "$_G_indent" | $SED 's|.| |g'`"  " ## exclude from sc_prohibit_nested_quotes
++
++    func_echo_infix_1_IFS=$IFS
++    IFS=$nl
++    for _G_line in $_G_message; do
++      IFS=$func_echo_infix_1_IFS
++      $ECHO "$_G_prefix$tc_bold$_G_line$tc_reset" >&2
++      _G_prefix=$_G_indent
++    done
++    IFS=$func_echo_infix_1_IFS
++}
++
++
++# func_error ARG...
++# -----------------
++# Echo program name prefixed message to standard error.
++func_error ()
++{
++    $debug_cmd
++
++    $require_term_colors
++
++    func_echo_infix_1 "  $tc_standout${tc_red}error$tc_reset" "$*" >&2
++}
++
++
++# func_fatal_error ARG...
++# -----------------------
++# Echo program name prefixed message to standard error, and exit.
++func_fatal_error ()
++{
++    $debug_cmd
++
++    func_error "$*"
++    exit $EXIT_FAILURE
++}
++
++
++# func_grep EXPRESSION FILENAME
++# -----------------------------
++# Check whether EXPRESSION matches any line of FILENAME, without output.
++func_grep ()
+ {
+-    my_directory_path="$1"
+-    my_dir_list=
++    $debug_cmd
++
++    $GREP "$1" "$2" >/dev/null 2>&1
++}
+ 
+-    if test -n "$my_directory_path" && test "$opt_dry_run" != ":"; then
+ 
+-      # Protect directory names starting with `-'
+-      case $my_directory_path in
+-        -*) my_directory_path="./$my_directory_path" ;;
++# func_len STRING
++# ---------------
++# Set func_len_result to the length of STRING. STRING may not
++# start with a hyphen.
++  test -z "$_G_HAVE_XSI_OPS" \
++    && (eval 'x=a/b/c;
++      test 5aa/bb/cc = "${#x}${x%%/*}${x%/*}${x#*/}${x##*/}"') 2>/dev/null \
++    && _G_HAVE_XSI_OPS=yes
++
++if test yes = "$_G_HAVE_XSI_OPS"; then
++  eval 'func_len ()
++  {
++    $debug_cmd
++
++    func_len_result=${#1}
++  }'
++else
++  func_len ()
++  {
++    $debug_cmd
++
++    func_len_result=`expr "$1" : ".*" 2>/dev/null || echo $max_cmd_len`
++  }
++fi
++
++
++# func_mkdir_p DIRECTORY-PATH
++# ---------------------------
++# Make sure the entire path to DIRECTORY-PATH is available.
++func_mkdir_p ()
++{
++    $debug_cmd
++
++    _G_directory_path=$1
++    _G_dir_list=
++
++    if test -n "$_G_directory_path" && test : != "$opt_dry_run"; then
++
++      # Protect directory names starting with '-'
++      case $_G_directory_path in
++        -*) _G_directory_path=./$_G_directory_path ;;
+       esac
+ 
+       # While some portion of DIR does not yet exist...
+-      while test ! -d "$my_directory_path"; do
++      while test ! -d "$_G_directory_path"; do
+         # ...make a list in topmost first order.  Use a colon delimited
+ 	# list incase some portion of path contains whitespace.
+-        my_dir_list="$my_directory_path:$my_dir_list"
++        _G_dir_list=$_G_directory_path:$_G_dir_list
+ 
+         # If the last portion added has no slash in it, the list is done
+-        case $my_directory_path in */*) ;; *) break ;; esac
++        case $_G_directory_path in */*) ;; *) break ;; esac
+ 
+         # ...otherwise throw away the child directory and loop
+-        my_directory_path=`$ECHO "$my_directory_path" | $SED -e "$dirname"`
++        _G_directory_path=`$ECHO "$_G_directory_path" | $SED -e "$sed_dirname"`
+       done
+-      my_dir_list=`$ECHO "$my_dir_list" | $SED 's,:*$,,'`
++      _G_dir_list=`$ECHO "$_G_dir_list" | $SED 's|:*$||'`
+ 
+-      save_mkdir_p_IFS="$IFS"; IFS=':'
+-      for my_dir in $my_dir_list; do
+-	IFS="$save_mkdir_p_IFS"
+-        # mkdir can fail with a `File exist' error if two processes
++      func_mkdir_p_IFS=$IFS; IFS=:
++      for _G_dir in $_G_dir_list; do
++	IFS=$func_mkdir_p_IFS
++        # mkdir can fail with a 'File exist' error if two processes
+         # try to create one of the directories concurrently.  Don't
+         # stop in that case!
+-        $MKDIR "$my_dir" 2>/dev/null || :
++        $MKDIR "$_G_dir" 2>/dev/null || :
+       done
+-      IFS="$save_mkdir_p_IFS"
++      IFS=$func_mkdir_p_IFS
+ 
+       # Bail out if we (or some other process) failed to create a directory.
+-      test -d "$my_directory_path" || \
+-        func_fatal_error "Failed to create \`$1'"
++      test -d "$_G_directory_path" || \
++        func_fatal_error "Failed to create '$1'"
+     fi
+ }
+ 
+ 
+-# func_mktempdir [string]
++# func_mktempdir [BASENAME]
++# -------------------------
+ # Make a temporary directory that won't clash with other running
+ # libtool processes, and avoids race conditions if possible.  If
+-# given, STRING is the basename for that directory.
++# given, BASENAME is the basename for that directory.
+ func_mktempdir ()
+ {
+-    my_template="${TMPDIR-/tmp}/${1-$progname}"
++    $debug_cmd
++
++    _G_template=${TMPDIR-/tmp}/${1-$progname}
+ 
+-    if test "$opt_dry_run" = ":"; then
++    if test : = "$opt_dry_run"; then
+       # Return a directory name, but don't create it in dry-run mode
+-      my_tmpdir="${my_template}-$$"
++      _G_tmpdir=$_G_template-$$
+     else
+ 
+       # If mktemp works, use that first and foremost
+-      my_tmpdir=`mktemp -d "${my_template}-XXXXXXXX" 2>/dev/null`
++      _G_tmpdir=`mktemp -d "$_G_template-XXXXXXXX" 2>/dev/null`
+ 
+-      if test ! -d "$my_tmpdir"; then
++      if test ! -d "$_G_tmpdir"; then
+         # Failing that, at least try and use $RANDOM to avoid a race
+-        my_tmpdir="${my_template}-${RANDOM-0}$$"
++        _G_tmpdir=$_G_template-${RANDOM-0}$$
+ 
+-        save_mktempdir_umask=`umask`
++        func_mktempdir_umask=`umask`
+         umask 0077
+-        $MKDIR "$my_tmpdir"
+-        umask $save_mktempdir_umask
++        $MKDIR "$_G_tmpdir"
++        umask $func_mktempdir_umask
++      fi
++
++      # If we're not in dry-run mode, bomb out on failure
++      test -d "$_G_tmpdir" || \
++        func_fatal_error "cannot create temporary directory '$_G_tmpdir'"
++    fi
++
++    $ECHO "$_G_tmpdir"
++}
++
++
++# func_normal_abspath PATH
++# ------------------------
++# Remove doubled-up and trailing slashes, "." path components,
++# and cancel out any ".." path components in PATH after making
++# it an absolute path.
++func_normal_abspath ()
++{
++    $debug_cmd
++
++    # These SED scripts presuppose an absolute path with a trailing slash.
++    _G_pathcar='s|^/\([^/]*\).*$|\1|'
++    _G_pathcdr='s|^/[^/]*||'
++    _G_removedotparts=':dotsl
++		s|/\./|/|g
++		t dotsl
++		s|/\.$|/|'
++    _G_collapseslashes='s|/\{1,\}|/|g'
++    _G_finalslash='s|/*$|/|'
++
++    # Start from root dir and reassemble the path.
++    func_normal_abspath_result=
++    func_normal_abspath_tpath=$1
++    func_normal_abspath_altnamespace=
++    case $func_normal_abspath_tpath in
++      "")
++        # Empty path, that just means $cwd.
++        func_stripname '' '/' "`pwd`"
++        func_normal_abspath_result=$func_stripname_result
++        return
++        ;;
++      # The next three entries are used to spot a run of precisely
++      # two leading slashes without using negated character classes;
++      # we take advantage of case's first-match behaviour.
++      ///*)
++        # Unusual form of absolute path, do nothing.
++        ;;
++      //*)
++        # Not necessarily an ordinary path; POSIX reserves leading '//'
++        # and for example Cygwin uses it to access remote file shares
++        # over CIFS/SMB, so we conserve a leading double slash if found.
++        func_normal_abspath_altnamespace=/
++        ;;
++      /*)
++        # Absolute path, do nothing.
++        ;;
++      *)
++        # Relative path, prepend $cwd.
++        func_normal_abspath_tpath=`pwd`/$func_normal_abspath_tpath
++        ;;
++    esac
++
++    # Cancel out all the simple stuff to save iterations.  We also want
++    # the path to end with a slash for ease of parsing, so make sure
++    # there is one (and only one) here.
++    func_normal_abspath_tpath=`$ECHO "$func_normal_abspath_tpath" | $SED \
++          -e "$_G_removedotparts" -e "$_G_collapseslashes" -e "$_G_finalslash"`
++    while :; do
++      # Processed it all yet?
++      if test / = "$func_normal_abspath_tpath"; then
++        # If we ascended to the root using ".." the result may be empty now.
++        if test -z "$func_normal_abspath_result"; then
++          func_normal_abspath_result=/
++        fi
++        break
++      fi
++      func_normal_abspath_tcomponent=`$ECHO "$func_normal_abspath_tpath" | $SED \
++          -e "$_G_pathcar"`
++      func_normal_abspath_tpath=`$ECHO "$func_normal_abspath_tpath" | $SED \
++          -e "$_G_pathcdr"`
++      # Figure out what to do with it
++      case $func_normal_abspath_tcomponent in
++        "")
++          # Trailing empty path component, ignore it.
++          ;;
++        ..)
++          # Parent dir; strip last assembled component from result.
++          func_dirname "$func_normal_abspath_result"
++          func_normal_abspath_result=$func_dirname_result
++          ;;
++        *)
++          # Actual path component, append it.
++          func_append func_normal_abspath_result "/$func_normal_abspath_tcomponent"
++          ;;
++      esac
++    done
++    # Restore leading double-slash if one was found on entry.
++    func_normal_abspath_result=$func_normal_abspath_altnamespace$func_normal_abspath_result
++}
++
++
++# func_notquiet ARG...
++# --------------------
++# Echo program name prefixed message only when not in quiet mode.
++func_notquiet ()
++{
++    $debug_cmd
++
++    $opt_quiet || func_echo ${1+"$@"}
++
++    # A bug in bash halts the script if the last line of a function
++    # fails when set -e is in force, so we need another command to
++    # work around that:
++    :
++}
++
++
++# func_relative_path SRCDIR DSTDIR
++# --------------------------------
++# Set func_relative_path_result to the relative path from SRCDIR to DSTDIR.
++func_relative_path ()
++{
++    $debug_cmd
++
++    func_relative_path_result=
++    func_normal_abspath "$1"
++    func_relative_path_tlibdir=$func_normal_abspath_result
++    func_normal_abspath "$2"
++    func_relative_path_tbindir=$func_normal_abspath_result
++
++    # Ascend the tree starting from libdir
++    while :; do
++      # check if we have found a prefix of bindir
++      case $func_relative_path_tbindir in
++        $func_relative_path_tlibdir)
++          # found an exact match
++          func_relative_path_tcancelled=
++          break
++          ;;
++        $func_relative_path_tlibdir*)
++          # found a matching prefix
++          func_stripname "$func_relative_path_tlibdir" '' "$func_relative_path_tbindir"
++          func_relative_path_tcancelled=$func_stripname_result
++          if test -z "$func_relative_path_result"; then
++            func_relative_path_result=.
++          fi
++          break
++          ;;
++        *)
++          func_dirname $func_relative_path_tlibdir
++          func_relative_path_tlibdir=$func_dirname_result
++          if test -z "$func_relative_path_tlibdir"; then
++            # Have to descend all the way to the root!
++            func_relative_path_result=../$func_relative_path_result
++            func_relative_path_tcancelled=$func_relative_path_tbindir
++            break
++          fi
++          func_relative_path_result=../$func_relative_path_result
++          ;;
++      esac
++    done
++
++    # Now calculate path; take care to avoid doubling-up slashes.
++    func_stripname '' '/' "$func_relative_path_result"
++    func_relative_path_result=$func_stripname_result
++    func_stripname '/' '/' "$func_relative_path_tcancelled"
++    if test -n "$func_stripname_result"; then
++      func_append func_relative_path_result "/$func_stripname_result"
++    fi
++
++    # Normalisation. If bindir is libdir, return '.' else relative path.
++    if test -n "$func_relative_path_result"; then
++      func_stripname './' '' "$func_relative_path_result"
++      func_relative_path_result=$func_stripname_result
++    fi
++
++    test -n "$func_relative_path_result" || func_relative_path_result=.
++
++    :
++}
++
++
++# func_quote_portable EVAL ARG
++# ----------------------------
++# Internal function to portably implement func_quote_arg.  Note that we still
++# keep attention to performance here so we as much as possible try to avoid
++# calling sed binary (so far O(N) complexity as long as func_append is O(1)).
++func_quote_portable ()
++{
++    $debug_cmd
++
++    func_quote_portable_result=$2
++
++    # one-time-loop (easy break)
++    while true
++    do
++      if $1; then
++        func_quote_portable_result=`$ECHO "$2" | $SED \
++          -e "$sed_double_quote_subst" -e "$sed_double_backslash"`
++        break
++      fi
++
++      # Quote for eval.
++      case $func_quote_portable_result in
++        *[\\\`\"\$]*)
++          case $func_quote_portable_result in
++            *[\[\*\?]*)
++              func_quote_portable_result=`$ECHO "$func_quote_portable_result" \
++                  | $SED "$sed_quote_subst"`
++              break
++              ;;
++          esac
++
++          func_quote_portable_old_IFS=$IFS
++          for _G_char in '\' '`' '"' '$'
++          do
++            # STATE($1) PREV($2) SEPARATOR($3)
++            set start "" ""
++            func_quote_portable_result=dummy"$_G_char$func_quote_portable_result$_G_char"dummy
++            IFS=$_G_char
++            for _G_part in $func_quote_portable_result
++            do
++              case $1 in
++              quote)
++                func_append func_quote_portable_result "$3$2"
++                set quote "$_G_part" "\\$_G_char"
++                ;;
++              start)
++                set first "" ""
++                func_quote_portable_result=
++                ;;
++              first)
++                set quote "$_G_part" ""
++                ;;
++              esac
++            done
++          done
++          IFS=$func_quote_portable_old_IFS
++          ;;
++        *) ;;
++      esac
++      break
++    done
++
++    func_quote_portable_unquoted_result=$func_quote_portable_result
++    case $func_quote_portable_result in
++      # double-quote args containing shell metacharacters to delay
++      # word splitting, command substitution and variable expansion
++      # for a subsequent eval.
++      # many bourne shells cannot handle close brackets correctly
++      # in scan sets, so we specify it separately.
++      *[\[\~\#\^\&\*\(\)\{\}\|\;\<\>\?\'\ \	]*|*]*|"")
++        func_quote_portable_result=\"$func_quote_portable_result\"
++        ;;
++    esac
++}
++
++
++# func_quotefast_eval ARG
++# -----------------------
++# Quote one ARG (internal).  This is equivalent to 'func_quote_arg eval ARG',
++# but optimized for speed.  Result is stored in $func_quotefast_eval.
++if test xyes = `(x=; printf -v x %q yes; echo x"$x") 2>/dev/null`; then
++  printf -v _GL_test_printf_tilde %q '~'
++  if test '\~' = "$_GL_test_printf_tilde"; then
++    func_quotefast_eval ()
++    {
++      printf -v func_quotefast_eval_result %q "$1"
++    }
++  else
++    # Broken older Bash implementations.  Make those faster too if possible.
++    func_quotefast_eval ()
++    {
++      case $1 in
++        '~'*)
++          func_quote_portable false "$1"
++          func_quotefast_eval_result=$func_quote_portable_result
++          ;;
++        *)
++          printf -v func_quotefast_eval_result %q "$1"
++          ;;
++      esac
++    }
++  fi
++else
++  func_quotefast_eval ()
++  {
++    func_quote_portable false "$1"
++    func_quotefast_eval_result=$func_quote_portable_result
++  }
++fi
++
++
++# func_quote_arg MODEs ARG
++# ------------------------
++# Quote one ARG to be evaled later.  MODEs argument may contain zero or more
++# specifiers listed below separated by ',' character.  This function returns two
++# values:
++#   i) func_quote_arg_result
++#      double-quoted (when needed), suitable for a subsequent eval
++#  ii) func_quote_arg_unquoted_result
++#      has all characters that are still active within double
++#      quotes backslashified.  Available only if 'unquoted' is specified.
++#
++# Available modes:
++# ----------------
++# 'eval' (default)
++#       - escape shell special characters
++# 'expand'
++#       - the same as 'eval';  but do not quote variable references
++# 'pretty'
++#       - request aesthetic output, i.e. '"a b"' instead of 'a\ b'.  This might
++#         be used later in func_quote to get output like: 'echo "a b"' instead
++#         of 'echo a\ b'.  This is slower than default on some shells.
++# 'unquoted'
++#       - produce also $func_quote_arg_unquoted_result which does not contain
++#         wrapping double-quotes.
++#
++# Examples for 'func_quote_arg pretty,unquoted string':
++#
++#   string      | *_result              | *_unquoted_result
++#   ------------+-----------------------+-------------------
++#   "           | \"                    | \"
++#   a b         | "a b"                 | a b
++#   "a b"       | "\"a b\""             | \"a b\"
++#   *           | "*"                   | *
++#   z="${x-$y}" | "z=\"\${x-\$y}\""     | z=\"\${x-\$y}\"
++#
++# Examples for 'func_quote_arg pretty,unquoted,expand string':
++#
++#   string        |   *_result          |  *_unquoted_result
++#   --------------+---------------------+--------------------
++#   z="${x-$y}"   | "z=\"${x-$y}\""     | z=\"${x-$y}\"
++func_quote_arg ()
++{
++    _G_quote_expand=false
++    case ,$1, in
++      *,expand,*)
++        _G_quote_expand=:
++        ;;
++    esac
++
++    case ,$1, in
++      *,pretty,*|*,expand,*|*,unquoted,*)
++        func_quote_portable $_G_quote_expand "$2"
++        func_quote_arg_result=$func_quote_portable_result
++        func_quote_arg_unquoted_result=$func_quote_portable_unquoted_result
++        ;;
++      *)
++        # Faster quote-for-eval for some shells.
++        func_quotefast_eval "$2"
++        func_quote_arg_result=$func_quotefast_eval_result
++        ;;
++    esac
++}
++
++
++# func_quote MODEs ARGs...
++# ------------------------
++# Quote all ARGs to be evaled later and join them into single command.  See
++# func_quote_arg's description for more info.
++func_quote ()
++{
++    $debug_cmd
++    _G_func_quote_mode=$1 ; shift
++    func_quote_result=
++    while test 0 -lt $#; do
++      func_quote_arg "$_G_func_quote_mode" "$1"
++      if test -n "$func_quote_result"; then
++        func_append func_quote_result " $func_quote_arg_result"
++      else
++        func_append func_quote_result "$func_quote_arg_result"
++      fi
++      shift
++    done
++}
++
++
++# func_stripname PREFIX SUFFIX NAME
++# ---------------------------------
++# strip PREFIX and SUFFIX from NAME, and store in func_stripname_result.
++# PREFIX and SUFFIX must not contain globbing or regex special
++# characters, hashes, percent signs, but SUFFIX may contain a leading
++# dot (in which case that matches only a dot).
++if test yes = "$_G_HAVE_XSI_OPS"; then
++  eval 'func_stripname ()
++  {
++    $debug_cmd
++
++    # pdksh 5.2.14 does not do ${X%$Y} correctly if both X and Y are
++    # positional parameters, so assign one to ordinary variable first.
++    func_stripname_result=$3
++    func_stripname_result=${func_stripname_result#"$1"}
++    func_stripname_result=${func_stripname_result%"$2"}
++  }'
++else
++  func_stripname ()
++  {
++    $debug_cmd
++
++    case $2 in
++      .*) func_stripname_result=`$ECHO "$3" | $SED -e "s%^$1%%" -e "s%\\\\$2\$%%"`;;
++      *)  func_stripname_result=`$ECHO "$3" | $SED -e "s%^$1%%" -e "s%$2\$%%"`;;
++    esac
++  }
++fi
++
++
++# func_show_eval CMD [FAIL_EXP]
++# -----------------------------
++# Unless opt_quiet is true, then output CMD.  Then, if opt_dryrun is
++# not true, evaluate CMD.  If the evaluation of CMD fails, and FAIL_EXP
++# is given, then evaluate it.
++func_show_eval ()
++{
++    $debug_cmd
++
++    _G_cmd=$1
++    _G_fail_exp=${2-':'}
++
++    func_quote_arg pretty,expand "$_G_cmd"
++    eval "func_notquiet $func_quote_arg_result"
++
++    $opt_dry_run || {
++      eval "$_G_cmd"
++      _G_status=$?
++      if test 0 -ne "$_G_status"; then
++	eval "(exit $_G_status); $_G_fail_exp"
++      fi
++    }
++}
++
++
++# func_show_eval_locale CMD [FAIL_EXP]
++# ------------------------------------
++# Unless opt_quiet is true, then output CMD.  Then, if opt_dryrun is
++# not true, evaluate CMD.  If the evaluation of CMD fails, and FAIL_EXP
++# is given, then evaluate it.  Use the saved locale for evaluation.
++func_show_eval_locale ()
++{
++    $debug_cmd
++
++    _G_cmd=$1
++    _G_fail_exp=${2-':'}
++
++    $opt_quiet || {
++      func_quote_arg expand,pretty "$_G_cmd"
++      eval "func_echo $func_quote_arg_result"
++    }
++
++    $opt_dry_run || {
++      eval "$_G_user_locale
++	    $_G_cmd"
++      _G_status=$?
++      eval "$_G_safe_locale"
++      if test 0 -ne "$_G_status"; then
++	eval "(exit $_G_status); $_G_fail_exp"
++      fi
++    }
++}
++
++
++# func_tr_sh
++# ----------
++# Turn $1 into a string suitable for a shell variable name.
++# Result is stored in $func_tr_sh_result.  All characters
++# not in the set a-zA-Z0-9_ are replaced with '_'. Further,
++# if $1 begins with a digit, a '_' is prepended as well.
++func_tr_sh ()
++{
++    $debug_cmd
++
++    case $1 in
++    [0-9]* | *[!a-zA-Z0-9_]*)
++      func_tr_sh_result=`$ECHO "$1" | $SED -e 's/^\([0-9]\)/_\1/' -e 's/[^a-zA-Z0-9_]/_/g'`
++      ;;
++    * )
++      func_tr_sh_result=$1
++      ;;
++    esac
++}
++
++
++# func_verbose ARG...
++# -------------------
++# Echo program name prefixed message in verbose mode only.
++func_verbose ()
++{
++    $debug_cmd
++
++    $opt_verbose && func_echo "$*"
++
++    :
++}
++
++
++# func_warn_and_continue ARG...
++# -----------------------------
++# Echo program name prefixed warning message to standard error.
++func_warn_and_continue ()
++{
++    $debug_cmd
++
++    $require_term_colors
++
++    func_echo_infix_1 "${tc_red}warning$tc_reset" "$*" >&2
++}
++
++
++# func_warning CATEGORY ARG...
++# ----------------------------
++# Echo program name prefixed warning message to standard error. Warning
++# messages can be filtered according to CATEGORY, where this function
++# elides messages where CATEGORY is not listed in the global variable
++# 'opt_warning_types'.
++func_warning ()
++{
++    $debug_cmd
++
++    # CATEGORY must be in the warning_categories list!
++    case " $warning_categories " in
++      *" $1 "*) ;;
++      *) func_internal_error "invalid warning category '$1'" ;;
++    esac
++
++    _G_category=$1
++    shift
++
++    case " $opt_warning_types " in
++      *" $_G_category "*) $warning_func ${1+"$@"} ;;
++    esac
++}
++
++
++# func_sort_ver VER1 VER2
++# -----------------------
++# 'sort -V' is not generally available.
++# Note this deviates from the version comparison in automake
++# in that it treats 1.5 < 1.5.0, and treats 1.4.4a < 1.4-p3a
++# but this should suffice as we won't be specifying old
++# version formats or redundant trailing .0 in bootstrap.conf.
++# If we did want full compatibility then we should probably
++# use m4_version_compare from autoconf.
++func_sort_ver ()
++{
++    $debug_cmd
++
++    printf '%s\n%s\n' "$1" "$2" \
++      | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n -k 5,5n -k 6,6n -k 7,7n -k 8,8n -k 9,9n
++}
++
++# func_lt_ver PREV CURR
++# ---------------------
++# Return true if PREV and CURR are in the correct order according to
++# func_sort_ver, otherwise false.  Use it like this:
++#
++#  func_lt_ver "$prev_ver" "$proposed_ver" || func_fatal_error "..."
++func_lt_ver ()
++{
++    $debug_cmd
++
++    test "x$1" = x`func_sort_ver "$1" "$2" | $SED 1q`
++}
++
++
++# Local variables:
++# mode: shell-script
++# sh-indentation: 2
++# eval: (add-hook 'before-save-hook 'time-stamp)
++# time-stamp-pattern: "10/scriptversion=%:y-%02m-%02d.%02H; # UTC"
++# time-stamp-time-zone: "UTC"
++# End:
++#! /bin/sh
++
++# A portable, pluggable option parser for Bourne shell.
++# Written by Gary V. Vaughan, 2010
++
++# This is free software.  There is NO warranty; not even for
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++#
++# Copyright (C) 2010-2016 Bootstrap Authors
++#
++# This file is dual licensed under the terms of the MIT license
++# <https://opensource.org/license/MIT>, and GPL version 3 or later
++# <http://www.gnu.org/licenses/gpl-2.0.html>.  You must apply one of
++# these licenses when using or redistributing this software or any of
++# the files within it.  See the URLs above, or the file `LICENSE`
++# included in the Bootstrap distribution for the full license texts.
++
++# Please report bugs or propose patches to:
++# <https://github.com/gnulib-modules/bootstrap/issues>
++
++# Set a version string for this script.
++scriptversion=2016-03-06.01; # UTC
++
++
++## ------ ##
++## Usage. ##
++## ------ ##
++
++# This file is a library for parsing options in your shell scripts along
++# with assorted other useful supporting features that you can make use
++# of too.
++#
++# For the simplest scripts you might need only:
++#
++#   #!/bin/sh
++#   . relative/path/to/funclib.sh
++#   . relative/path/to/options-parser
++#   scriptversion=1.0
++#   func_options ${1+"$@"}
++#   eval set dummy "$func_options_result"; shift
++#   ...rest of your script...
++#
++# In order for the '--version' option to work, you will need to have a
++# suitably formatted comment like the one at the top of this file
++# starting with '# Written by ' and ending with '# Copyright'.
++#
++# For '-h' and '--help' to work, you will also need a one line
++# description of your script's purpose in a comment directly above the
++# '# Written by ' line, like the one at the top of this file.
++#
++# The default options also support '--debug', which will turn on shell
++# execution tracing (see the comment above debug_cmd below for another
++# use), and '--verbose' and the func_verbose function to allow your script
++# to display verbose messages only when your user has specified
++# '--verbose'.
++#
++# After sourcing this file, you can plug in processing for additional
++# options by amending the variables from the 'Configuration' section
++# below, and following the instructions in the 'Option parsing'
++# section further down.
++
++## -------------- ##
++## Configuration. ##
++## -------------- ##
++
++# You should override these variables in your script after sourcing this
++# file so that they reflect the customisations you have added to the
++# option parser.
++
++# The usage line for option parsing errors and the start of '-h' and
++# '--help' output messages. You can embed shell variables for delayed
++# expansion at the time the message is displayed, but you will need to
++# quote other shell meta-characters carefully to prevent them being
++# expanded when the contents are evaled.
++usage='$progpath [OPTION]...'
++
++# Short help message in response to '-h' and '--help'.  Add to this or
++# override it after sourcing this library to reflect the full set of
++# options your script accepts.
++usage_message="\
++       --debug        enable verbose shell tracing
++   -W, --warnings=CATEGORY
++                      report the warnings falling in CATEGORY [all]
++   -v, --verbose      verbosely report processing
++       --version      print version information and exit
++   -h, --help         print short or long help message and exit
++"
++
++# Additional text appended to 'usage_message' in response to '--help'.
++long_help_message="
++Warning categories include:
++       'all'          show all warnings
++       'none'         turn off all the warnings
++       'error'        warnings are treated as fatal errors"
++
++# Help message printed before fatal option parsing errors.
++fatal_help="Try '\$progname --help' for more information."
++
++
++
++## ------------------------- ##
++## Hook function management. ##
++## ------------------------- ##
++
++# This section contains functions for adding, removing, and running hooks
++# in the main code.  A hook is just a list of function names that can be
++# run in order later on.
++
++# func_hookable FUNC_NAME
++# -----------------------
++# Declare that FUNC_NAME will run hooks added with
++# 'func_add_hook FUNC_NAME ...'.
++func_hookable ()
++{
++    $debug_cmd
++
++    func_append hookable_fns " $1"
++}
++
++
++# func_add_hook FUNC_NAME HOOK_FUNC
++# ---------------------------------
++# Request that FUNC_NAME call HOOK_FUNC before it returns.  FUNC_NAME must
++# first have been declared "hookable" by a call to 'func_hookable'.
++func_add_hook ()
++{
++    $debug_cmd
++
++    case " $hookable_fns " in
++      *" $1 "*) ;;
++      *) func_fatal_error "'$1' does not accept hook functions." ;;
++    esac
++
++    eval func_append ${1}_hooks '" $2"'
++}
++
++
++# func_remove_hook FUNC_NAME HOOK_FUNC
++# ------------------------------------
++# Remove HOOK_FUNC from the list of hook functions to be called by
++# FUNC_NAME.
++func_remove_hook ()
++{
++    $debug_cmd
++
++    eval ${1}_hooks='`$ECHO "\$'$1'_hooks" |$SED "s| '$2'||"`'
++}
++
++
++# func_propagate_result FUNC_NAME_A FUNC_NAME_B
++# ---------------------------------------------
++# If the *_result variable of FUNC_NAME_A _is set_, assign its value to
++# *_result variable of FUNC_NAME_B.
++func_propagate_result ()
++{
++    $debug_cmd
++
++    func_propagate_result_result=:
++    if eval "test \"\${${1}_result+set}\" = set"
++    then
++      eval "${2}_result=\$${1}_result"
++    else
++      func_propagate_result_result=false
++    fi
++}
++
++
++# func_run_hooks FUNC_NAME [ARG]...
++# ---------------------------------
++# Run all hook functions registered to FUNC_NAME.
++# It's assumed that the list of hook functions contains nothing more
++# than a whitespace-delimited list of legal shell function names, and
++# no effort is wasted trying to catch shell meta-characters or preserve
++# whitespace.
++func_run_hooks ()
++{
++    $debug_cmd
++
++    case " $hookable_fns " in
++      *" $1 "*) ;;
++      *) func_fatal_error "'$1' does not support hook functions." ;;
++    esac
++
++    eval _G_hook_fns=\$$1_hooks; shift
++
++    for _G_hook in $_G_hook_fns; do
++      func_unset "${_G_hook}_result"
++      eval $_G_hook '${1+"$@"}'
++      func_propagate_result $_G_hook func_run_hooks
++      if $func_propagate_result_result; then
++        eval set dummy "$func_run_hooks_result"; shift
+       fi
++    done
++}
++
++
++
++## --------------- ##
++## Option parsing. ##
++## --------------- ##
++
++# In order to add your own option parsing hooks, you must accept the
++# full positional parameter list from your hook function.  You may remove
++# or edit any options that you action, and then pass back the remaining
++# unprocessed options in '<hooked_function_name>_result', escaped
++# suitably for 'eval'.
++#
++# The '<hooked_function_name>_result' variable is automatically unset
++# before your hook gets called; for best performance, only set the
++# *_result variable when necessary (i.e. don't call the 'func_quote'
++# function unnecessarily because it can be an expensive operation on some
++# machines).
++#
++# Like this:
++#
++#    my_options_prep ()
++#    {
++#        $debug_cmd
++#
++#        # Extend the existing usage message.
++#        usage_message=$usage_message'
++#      -s, --silent       don'\''t print informational messages
++#    '
++#        # No change in '$@' (ignored completely by this hook).  Leave
++#        # my_options_prep_result variable intact.
++#    }
++#    func_add_hook func_options_prep my_options_prep
++#
++#
++#    my_silent_option ()
++#    {
++#        $debug_cmd
++#
++#        args_changed=false
++#
++#        # Note that, for efficiency, we parse as many options as we can
++#        # recognise in a loop before passing the remainder back to the
++#        # caller on the first unrecognised argument we encounter.
++#        while test $# -gt 0; do
++#          opt=$1; shift
++#          case $opt in
++#            --silent|-s) opt_silent=:
++#                         args_changed=:
++#                         ;;
++#            # Separate non-argument short options:
++#            -s*)         func_split_short_opt "$_G_opt"
++#                         set dummy "$func_split_short_opt_name" \
++#                             "-$func_split_short_opt_arg" ${1+"$@"}
++#                         shift
++#                         args_changed=:
++#                         ;;
++#            *)           # Make sure the first unrecognised option "$_G_opt"
++#                         # is added back to "$@" in case we need it later,
++#                         # if $args_changed was set to 'true'.
++#                         set dummy "$_G_opt" ${1+"$@"}; shift; break ;;
++#          esac
++#        done
++#
++#        # Only call 'func_quote' here if we processed at least one argument.
++#        if $args_changed; then
++#          func_quote eval ${1+"$@"}
++#          my_silent_option_result=$func_quote_result
++#        fi
++#    }
++#    func_add_hook func_parse_options my_silent_option
++#
++#
++#    my_option_validation ()
++#    {
++#        $debug_cmd
++#
++#        $opt_silent && $opt_verbose && func_fatal_help "\
++#    '--silent' and '--verbose' options are mutually exclusive."
++#    }
++#    func_add_hook func_validate_options my_option_validation
++#
++# You'll also need to manually amend $usage_message to reflect the extra
++# options you parse.  It's preferable to append if you can, so that
++# multiple option parsing hooks can be added safely.
++
+ 
+-      # If we're not in dry-run mode, bomb out on failure
+-      test -d "$my_tmpdir" || \
+-        func_fatal_error "cannot create temporary directory \`$my_tmpdir'"
+-    fi
++# func_options_finish [ARG]...
++# ----------------------------
++# Finishing the option parse loop (call 'func_options' hooks ATM).
++func_options_finish ()
++{
++    $debug_cmd
+ 
+-    $ECHO "$my_tmpdir"
++    func_run_hooks func_options ${1+"$@"}
++    func_propagate_result func_run_hooks func_options_finish
+ }
+ 
+ 
+-# func_quote_for_eval arg
+-# Aesthetically quote ARG to be evaled later.
+-# This function returns two values: FUNC_QUOTE_FOR_EVAL_RESULT
+-# is double-quoted, suitable for a subsequent eval, whereas
+-# FUNC_QUOTE_FOR_EVAL_UNQUOTED_RESULT has merely all characters
+-# which are still active within double quotes backslashified.
+-func_quote_for_eval ()
++# func_options [ARG]...
++# ---------------------
++# All the functions called inside func_options are hookable. See the
++# individual implementations for details.
++func_hookable func_options
++func_options ()
+ {
+-    case $1 in
+-      *[\\\`\"\$]*)
+-	func_quote_for_eval_unquoted_result=`$ECHO "$1" | $SED "$sed_quote_subst"` ;;
+-      *)
+-        func_quote_for_eval_unquoted_result="$1" ;;
+-    esac
++    $debug_cmd
+ 
+-    case $func_quote_for_eval_unquoted_result in
+-      # Double-quote args containing shell metacharacters to delay
+-      # word splitting, command substitution and and variable
+-      # expansion for a subsequent eval.
+-      # Many Bourne shells cannot handle close brackets correctly
+-      # in scan sets, so we specify it separately.
+-      *[\[\~\#\^\&\*\(\)\{\}\|\;\<\>\?\'\ \	]*|*]*|"")
+-        func_quote_for_eval_result="\"$func_quote_for_eval_unquoted_result\""
+-        ;;
+-      *)
+-        func_quote_for_eval_result="$func_quote_for_eval_unquoted_result"
+-    esac
++    _G_options_quoted=false
++
++    for my_func in options_prep parse_options validate_options options_finish
++    do
++      func_unset func_${my_func}_result
++      func_unset func_run_hooks_result
++      eval func_$my_func '${1+"$@"}'
++      func_propagate_result func_$my_func func_options
++      if $func_propagate_result_result; then
++        eval set dummy "$func_options_result"; shift
++        _G_options_quoted=:
++      fi
++    done
++
++    $_G_options_quoted || {
++      # As we (func_options) are top-level options-parser function and
++      # nobody quoted "$@" for us yet, we need to do it explicitly for
++      # caller.
++      func_quote eval ${1+"$@"}
++      func_options_result=$func_quote_result
++    }
+ }
+ 
+ 
+-# func_quote_for_expand arg
+-# Aesthetically quote ARG to be evaled later; same as above,
+-# but do not quote variable references.
+-func_quote_for_expand ()
++# func_options_prep [ARG]...
++# --------------------------
++# All initialisations required before starting the option parse loop.
++# Note that when calling hook functions, we pass through the list of
++# positional parameters.  If a hook function modifies that list, and
++# needs to propagate that back to rest of this script, then the complete
++# modified list must be put in 'func_run_hooks_result' before returning.
++func_hookable func_options_prep
++func_options_prep ()
+ {
+-    case $1 in
+-      *[\\\`\"]*)
+-	my_arg=`$ECHO "$1" | $SED \
+-	    -e "$double_quote_subst" -e "$sed_double_backslash"` ;;
+-      *)
+-        my_arg="$1" ;;
+-    esac
++    $debug_cmd
+ 
+-    case $my_arg in
+-      # Double-quote args containing shell metacharacters to delay
+-      # word splitting and command substitution for a subsequent eval.
+-      # Many Bourne shells cannot handle close brackets correctly
+-      # in scan sets, so we specify it separately.
+-      *[\[\~\#\^\&\*\(\)\{\}\|\;\<\>\?\'\ \	]*|*]*|"")
+-        my_arg="\"$my_arg\""
+-        ;;
+-    esac
++    # Option defaults:
++    opt_verbose=false
++    opt_warning_types=
+ 
+-    func_quote_for_expand_result="$my_arg"
++    func_run_hooks func_options_prep ${1+"$@"}
++    func_propagate_result func_run_hooks func_options_prep
+ }
+ 
+ 
+-# func_show_eval cmd [fail_exp]
+-# Unless opt_silent is true, then output CMD.  Then, if opt_dryrun is
+-# not true, evaluate CMD.  If the evaluation of CMD fails, and FAIL_EXP
+-# is given, then evaluate it.
+-func_show_eval ()
++# func_parse_options [ARG]...
++# ---------------------------
++# The main option parsing loop.
++func_hookable func_parse_options
++func_parse_options ()
+ {
+-    my_cmd="$1"
+-    my_fail_exp="${2-:}"
++    $debug_cmd
++
++    _G_parse_options_requote=false
++    # this just eases exit handling
++    while test $# -gt 0; do
++      # Defer to hook functions for initial option parsing, so they
++      # get priority in the event of reusing an option name.
++      func_run_hooks func_parse_options ${1+"$@"}
++      func_propagate_result func_run_hooks func_parse_options
++      if $func_propagate_result_result; then
++        eval set dummy "$func_parse_options_result"; shift
++        # Even though we may have changed "$@", we passed the "$@" array
++        # down into the hook and it quoted it for us (because we are in
++        # this if-branch).  No need to quote it again.
++        _G_parse_options_requote=false
++      fi
+ 
+-    ${opt_silent-false} || {
+-      func_quote_for_expand "$my_cmd"
+-      eval "func_echo $func_quote_for_expand_result"
+-    }
++      # Break out of the loop if we already parsed every option.
++      test $# -gt 0 || break
++
++      # We expect that one of the options parsed in this function matches
++      # and thus we remove _G_opt from "$@" and need to re-quote.
++      _G_match_parse_options=:
++      _G_opt=$1
++      shift
++      case $_G_opt in
++        --debug|-x)   debug_cmd='set -x'
++                      func_echo "enabling shell trace mode" >&2
++                      $debug_cmd
++                      ;;
++
++        --no-warnings|--no-warning|--no-warn)
++                      set dummy --warnings none ${1+"$@"}
++                      shift
++		      ;;
+ 
+-    if ${opt_dry_run-false}; then :; else
+-      eval "$my_cmd"
+-      my_status=$?
+-      if test "$my_status" -eq 0; then :; else
+-	eval "(exit $my_status); $my_fail_exp"
++        --warnings|--warning|-W)
++                      if test $# = 0 && func_missing_arg $_G_opt; then
++                        _G_parse_options_requote=:
++                        break
++                      fi
++                      case " $warning_categories $1" in
++                        *" $1 "*)
++                          # trailing space prevents matching last $1 above
++                          func_append_uniq opt_warning_types " $1"
++                          ;;
++                        *all)
++                          opt_warning_types=$warning_categories
++                          ;;
++                        *none)
++                          opt_warning_types=none
++                          warning_func=:
++                          ;;
++                        *error)
++                          opt_warning_types=$warning_categories
++                          warning_func=func_fatal_error
++                          ;;
++                        *)
++                          func_fatal_error \
++                             "unsupported warning category: '$1'"
++                          ;;
++                      esac
++                      shift
++                      ;;
++
++        --verbose|-v) opt_verbose=: ;;
++        --version)    func_version ;;
++        -\?|-h)       func_usage ;;
++        --help)       func_help ;;
++
++	# Separate optargs to long options (plugins may need this):
++	--*=*)        func_split_equals "$_G_opt"
++	              set dummy "$func_split_equals_lhs" \
++                          "$func_split_equals_rhs" ${1+"$@"}
++                      shift
++                      ;;
++
++       # Separate optargs to short options:
++        -W*)
++                      func_split_short_opt "$_G_opt"
++                      set dummy "$func_split_short_opt_name" \
++                          "$func_split_short_opt_arg" ${1+"$@"}
++                      shift
++                      ;;
++
++        # Separate non-argument short options:
++        -\?*|-h*|-v*|-x*)
++                      func_split_short_opt "$_G_opt"
++                      set dummy "$func_split_short_opt_name" \
++                          "-$func_split_short_opt_arg" ${1+"$@"}
++                      shift
++                      ;;
++
++        --)           _G_parse_options_requote=: ; break ;;
++        -*)           func_fatal_help "unrecognised option: '$_G_opt'" ;;
++        *)            set dummy "$_G_opt" ${1+"$@"}; shift
++                      _G_match_parse_options=false
++                      break
++                      ;;
++      esac
++
++      if $_G_match_parse_options; then
++        _G_parse_options_requote=:
+       fi
++    done
++
++    if $_G_parse_options_requote; then
++      # save modified positional parameters for caller
++      func_quote eval ${1+"$@"}
++      func_parse_options_result=$func_quote_result
+     fi
+ }
+ 
+ 
+-# func_show_eval_locale cmd [fail_exp]
+-# Unless opt_silent is true, then output CMD.  Then, if opt_dryrun is
+-# not true, evaluate CMD.  If the evaluation of CMD fails, and FAIL_EXP
+-# is given, then evaluate it.  Use the saved locale for evaluation.
+-func_show_eval_locale ()
++# func_validate_options [ARG]...
++# ------------------------------
++# Perform any sanity checks on option settings and/or unconsumed
++# arguments.
++func_hookable func_validate_options
++func_validate_options ()
+ {
+-    my_cmd="$1"
+-    my_fail_exp="${2-:}"
++    $debug_cmd
+ 
+-    ${opt_silent-false} || {
+-      func_quote_for_expand "$my_cmd"
+-      eval "func_echo $func_quote_for_expand_result"
+-    }
++    # Display all warnings if -W was not given.
++    test -n "$opt_warning_types" || opt_warning_types=" $warning_categories"
+ 
+-    if ${opt_dry_run-false}; then :; else
+-      eval "$lt_user_locale
+-	    $my_cmd"
+-      my_status=$?
+-      eval "$lt_safe_locale"
+-      if test "$my_status" -eq 0; then :; else
+-	eval "(exit $my_status); $my_fail_exp"
+-      fi
+-    fi
+-}
++    func_run_hooks func_validate_options ${1+"$@"}
++    func_propagate_result func_run_hooks func_validate_options
+ 
+-# func_tr_sh
+-# Turn $1 into a string suitable for a shell variable name.
+-# Result is stored in $func_tr_sh_result.  All characters
+-# not in the set a-zA-Z0-9_ are replaced with '_'. Further,
+-# if $1 begins with a digit, a '_' is prepended as well.
+-func_tr_sh ()
+-{
+-  case $1 in
+-  [0-9]* | *[!a-zA-Z0-9_]*)
+-    func_tr_sh_result=`$ECHO "$1" | $SED 's/^\([0-9]\)/_\1/; s/[^a-zA-Z0-9_]/_/g'`
+-    ;;
+-  * )
+-    func_tr_sh_result=$1
+-    ;;
+-  esac
++    # Bail if the options were screwed!
++    $exit_cmd $EXIT_FAILURE
+ }
+ 
+ 
+-# func_version
+-# Echo version message to standard output and exit.
+-func_version ()
+-{
+-    $opt_debug
+ 
+-    $SED -n '/(C)/!b go
+-	:more
+-	/\./!{
+-	  N
+-	  s/\n# / /
+-	  b more
+-	}
+-	:go
+-	/^# '$PROGRAM' (GNU /,/# warranty; / {
+-        s/^# //
+-	s/^# *$//
+-        s/\((C)\)[ 0-9,-]*\( [1-9][0-9]*\)/\1\2/
+-        p
+-     }' < "$progpath"
+-     exit $?
+-}
++## ----------------- ##
++## Helper functions. ##
++## ----------------- ##
+ 
+-# func_usage
+-# Echo short help message to standard output and exit.
+-func_usage ()
++# This section contains the helper functions used by the rest of the
++# hookable option parser framework in ascii-betical order.
++
++
++# func_fatal_help ARG...
++# ----------------------
++# Echo program name prefixed message to standard error, followed by
++# a help hint, and exit.
++func_fatal_help ()
+ {
+-    $opt_debug
++    $debug_cmd
+ 
+-    $SED -n '/^# Usage:/,/^#  *.*--help/ {
+-        s/^# //
+-	s/^# *$//
+-	s/\$progname/'$progname'/
+-	p
+-    }' < "$progpath"
+-    echo
+-    $ECHO "run \`$progname --help | more' for full usage"
+-    exit $?
++    eval \$ECHO \""Usage: $usage"\"
++    eval \$ECHO \""$fatal_help"\"
++    func_error ${1+"$@"}
++    exit $EXIT_FAILURE
+ }
+ 
+-# func_help [NOEXIT]
+-# Echo long help message to standard output and exit,
+-# unless 'noexit' is passed as argument.
++
++# func_help
++# ---------
++# Echo long help message to standard output and exit.
+ func_help ()
+ {
+-    $opt_debug
+-
+-    $SED -n '/^# Usage:/,/# Report bugs to/ {
+-	:print
+-        s/^# //
+-	s/^# *$//
+-	s*\$progname*'$progname'*
+-	s*\$host*'"$host"'*
+-	s*\$SHELL*'"$SHELL"'*
+-	s*\$LTCC*'"$LTCC"'*
+-	s*\$LTCFLAGS*'"$LTCFLAGS"'*
+-	s*\$LD*'"$LD"'*
+-	s/\$with_gnu_ld/'"$with_gnu_ld"'/
+-	s/\$automake_version/'"`(${AUTOMAKE-automake} --version) 2>/dev/null |$SED 1q`"'/
+-	s/\$autoconf_version/'"`(${AUTOCONF-autoconf} --version) 2>/dev/null |$SED 1q`"'/
+-	p
+-	d
+-     }
+-     /^# .* home page:/b print
+-     /^# General help using/b print
+-     ' < "$progpath"
+-    ret=$?
+-    if test -z "$1"; then
+-      exit $ret
+-    fi
++    $debug_cmd
++
++    func_usage_message
++    $ECHO "$long_help_message"
++    exit 0
+ }
+ 
+-# func_missing_arg argname
++
++# func_missing_arg ARGNAME
++# ------------------------
+ # Echo program name prefixed message to standard error and set global
+ # exit_cmd.
+ func_missing_arg ()
+ {
+-    $opt_debug
++    $debug_cmd
+ 
+-    func_error "missing argument for $1."
++    func_error "Missing argument for '$1'."
+     exit_cmd=exit
+ }
+ 
+ 
+-# func_split_short_opt shortopt
++# func_split_equals STRING
++# ------------------------
++# Set func_split_equals_lhs and func_split_equals_rhs shell variables
++# after splitting STRING at the '=' sign.
++test -z "$_G_HAVE_XSI_OPS" \
++    && (eval 'x=a/b/c;
++      test 5aa/bb/cc = "${#x}${x%%/*}${x%/*}${x#*/}${x##*/}"') 2>/dev/null \
++    && _G_HAVE_XSI_OPS=yes
++
++if test yes = "$_G_HAVE_XSI_OPS"
++then
++  # This is an XSI compatible shell, allowing a faster implementation...
++  eval 'func_split_equals ()
++  {
++      $debug_cmd
++
++      func_split_equals_lhs=${1%%=*}
++      func_split_equals_rhs=${1#*=}
++      if test "x$func_split_equals_lhs" = "x$1"; then
++        func_split_equals_rhs=
++      fi
++  }'
++else
++  # ...otherwise fall back to using expr, which is often a shell builtin.
++  func_split_equals ()
++  {
++      $debug_cmd
++
++      func_split_equals_lhs=`expr "x$1" : 'x\([^=]*\)'`
++      func_split_equals_rhs=
++      test "x$func_split_equals_lhs" = "x$1" \
++        || func_split_equals_rhs=`expr "x$1" : 'x[^=]*=\(.*\)$'`
++  }
++fi #func_split_equals
++
++
++# func_split_short_opt SHORTOPT
++# -----------------------------
+ # Set func_split_short_opt_name and func_split_short_opt_arg shell
+ # variables after splitting SHORTOPT after the 2nd character.
+-func_split_short_opt ()
++if test yes = "$_G_HAVE_XSI_OPS"
++then
++  # This is an XSI compatible shell, allowing a faster implementation...
++  eval 'func_split_short_opt ()
++  {
++      $debug_cmd
++
++      func_split_short_opt_arg=${1#??}
++      func_split_short_opt_name=${1%"$func_split_short_opt_arg"}
++  }'
++else
++  # ...otherwise fall back to using expr, which is often a shell builtin.
++  func_split_short_opt ()
++  {
++      $debug_cmd
++
++      func_split_short_opt_name=`expr "x$1" : 'x-\(.\)'`
++      func_split_short_opt_arg=`expr "x$1" : 'x-.\(.*\)$'`
++  }
++fi #func_split_short_opt
++
++
++# func_usage
++# ----------
++# Echo short help message to standard output and exit.
++func_usage ()
+ {
+-    my_sed_short_opt='1s/^\(..\).*$/\1/;q'
+-    my_sed_short_rest='1s/^..\(.*\)$/\1/;q'
++    $debug_cmd
+ 
+-    func_split_short_opt_name=`$ECHO "$1" | $SED "$my_sed_short_opt"`
+-    func_split_short_opt_arg=`$ECHO "$1" | $SED "$my_sed_short_rest"`
+-} # func_split_short_opt may be replaced by extended shell implementation
++    func_usage_message
++    $ECHO "Run '$progname --help |${PAGER-more}' for full usage"
++    exit 0
++}
+ 
+ 
+-# func_split_long_opt longopt
+-# Set func_split_long_opt_name and func_split_long_opt_arg shell
+-# variables after splitting LONGOPT at the `=' sign.
+-func_split_long_opt ()
++# func_usage_message
++# ------------------
++# Echo short help message to standard output.
++func_usage_message ()
+ {
+-    my_sed_long_opt='1s/^\(--[^=]*\)=.*/\1/;q'
+-    my_sed_long_arg='1s/^--[^=]*=//'
++    $debug_cmd
+ 
+-    func_split_long_opt_name=`$ECHO "$1" | $SED "$my_sed_long_opt"`
+-    func_split_long_opt_arg=`$ECHO "$1" | $SED "$my_sed_long_arg"`
+-} # func_split_long_opt may be replaced by extended shell implementation
++    eval \$ECHO \""Usage: $usage"\"
++    echo
++    $SED -n 's|^# ||
++        /^Written by/{
++          x;p;x
++        }
++	h
++	/^Written by/q' < "$progpath"
++    echo
++    eval \$ECHO \""$usage_message"\"
++}
+ 
+-exit_cmd=:
+ 
++# func_version
++# ------------
++# Echo version message to standard output and exit.
++# The version message is extracted from the calling file's header
++# comments, with leading '# ' stripped:
++#   1. First display the progname and version
++#   2. Followed by the header comment line matching  /^# Written by /
++#   3. Then a blank line followed by the first following line matching
++#      /^# Copyright /
++#   4. Immediately followed by any lines between the previous matches,
++#      except lines preceding the intervening completely blank line.
++# For example, see the header comments of this file.
++func_version ()
++{
++    $debug_cmd
+ 
++    printf '%s\n' "$progname $scriptversion"
++    $SED -n '
++        /^# Written by /!b
++        s|^# ||; p; n
++
++        :fwd2blank
++        /./ {
++          n
++          b fwd2blank
++        }
++        p; n
++
++        :holdwarranty
++        s|^# ||
++        s|^# *$||
++        /^Copyright /! {
++          /./H
++          n
++          b holdwarranty
++        }
+ 
++        s|\((C)\)[ 0-9,-]*[ ,-]\([1-9][0-9]* \)|\1 \2|
++        G
++        s|\(\n\)\n*|\1|g
++        p; q' < "$progpath"
+ 
++    exit $?
++}
+ 
+-magic="%%%MAGIC variable%%%"
+-magic_exe="%%%MAGIC EXE variable%%%"
+ 
+-# Global variables.
+-nonopt=
+-preserve_args=
+-lo2o="s/\\.lo\$/.${objext}/"
+-o2lo="s/\\.${objext}\$/.lo/"
+-extracted_archives=
+-extracted_serial=0
++# Local variables:
++# mode: shell-script
++# sh-indentation: 2
++# eval: (add-hook 'before-save-hook 'time-stamp)
++# time-stamp-pattern: "10/scriptversion=%:y-%02m-%02d.%02H; # UTC"
++# time-stamp-time-zone: "UTC"
++# End:
+ 
+-# If this variable is set in any of the actions, the command in it
+-# will be execed at the end.  This prevents here-documents from being
+-# left over by shells.
+-exec_cmd=
++# Set a version string.
++scriptversion='(GNU libtool) 2.4.6.34-08c5'
+ 
+-# func_append var value
+-# Append VALUE to the end of shell variable VAR.
+-func_append ()
+-{
+-    eval "${1}=\$${1}\${2}"
+-} # func_append may be replaced by extended shell implementation
+ 
+-# func_append_quoted var value
+-# Quote VALUE and append to the end of shell variable VAR, separated
+-# by a space.
+-func_append_quoted ()
++# func_echo ARG...
++# ----------------
++# Libtool also displays the current mode in messages, so override
++# funclib.sh func_echo with this custom definition.
++func_echo ()
+ {
+-    func_quote_for_eval "${2}"
+-    eval "${1}=\$${1}\\ \$func_quote_for_eval_result"
+-} # func_append_quoted may be replaced by extended shell implementation
++    $debug_cmd
+ 
++    _G_message=$*
+ 
+-# func_arith arithmetic-term...
+-func_arith ()
+-{
+-    func_arith_result=`expr "${@}"`
+-} # func_arith may be replaced by extended shell implementation
++    func_echo_IFS=$IFS
++    IFS=$nl
++    for _G_line in $_G_message; do
++      IFS=$func_echo_IFS
++      $ECHO "$progname${opt_mode+: $opt_mode}: $_G_line"
++    done
++    IFS=$func_echo_IFS
++}
+ 
+ 
+-# func_len string
+-# STRING may not start with a hyphen.
+-func_len ()
++# func_warning ARG...
++# -------------------
++# Libtool warnings are not categorized, so override funclib.sh
++# func_warning with this simpler definition.
++func_warning ()
+ {
+-    func_len_result=`expr "${1}" : ".*" 2>/dev/null || echo $max_cmd_len`
+-} # func_len may be replaced by extended shell implementation
++    $debug_cmd
+ 
++    $warning_func ${1+"$@"}
++}
+ 
+-# func_lo2o object
+-func_lo2o ()
+-{
+-    func_lo2o_result=`$ECHO "${1}" | $SED "$lo2o"`
+-} # func_lo2o may be replaced by extended shell implementation
+ 
++## ---------------- ##
++## Options parsing. ##
++## ---------------- ##
++
++# Hook in the functions to make sure our own options are parsed during
++# the option parsing loop.
++
++usage='$progpath [OPTION]... [MODE-ARG]...'
++
++# Short help message in response to '-h'.
++usage_message="Options:
++       --config             show all configuration variables
++       --debug              enable verbose shell tracing
++   -n, --dry-run            display commands without modifying any files
++       --features           display basic configuration information and exit
++       --mode=MODE          use operation mode MODE
++       --no-warnings        equivalent to '-Wnone'
++       --preserve-dup-deps  don't remove duplicate dependency libraries
++       --quiet, --silent    don't print informational messages
++       --tag=TAG            use configuration variables from tag TAG
++   -v, --verbose            print more informational messages than default
++       --version            print version information
++   -W, --warnings=CATEGORY  report the warnings falling in CATEGORY [all]
++   -h, --help, --help-all   print short, long, or detailed help message
++"
+ 
+-# func_xform libobj-or-source
+-func_xform ()
++# Additional text appended to 'usage_message' in response to '--help'.
++func_help ()
+ {
+-    func_xform_result=`$ECHO "${1}" | $SED 's/\.[^.]*$/.lo/'`
+-} # func_xform may be replaced by extended shell implementation
++    $debug_cmd
++
++    func_usage_message
++    $ECHO "$long_help_message
++
++MODE must be one of the following:
++
++       clean           remove files from the build directory
++       compile         compile a source file into a libtool object
++       execute         automatically set library path, then run a program
++       finish          complete the installation of libtool libraries
++       install         install libraries or executables
++       link            create a library or an executable
++       uninstall       remove libraries from an installed directory
++
++MODE-ARGS vary depending on the MODE.  When passed as first option,
++'--mode=MODE' may be abbreviated as 'MODE' or a unique abbreviation of that.
++Try '$progname --help --mode=MODE' for a more detailed description of MODE.
++
++When reporting a bug, please describe a test case to reproduce it and
++include the following information:
++
++       host-triplet:   $host
++       shell:          $SHELL
++       compiler:       $LTCC
++       compiler flags: $LTCFLAGS
++       linker:         $LD (gnu? $with_gnu_ld)
++       version:        $progname (GNU libtool) 2.4.6.34-08c5
++       automake:       `($AUTOMAKE --version) 2>/dev/null |$SED 1q`
++       autoconf:       `($AUTOCONF --version) 2>/dev/null |$SED 1q`
++
++Report bugs to <bug-libtool@gnu.org>.
++GNU libtool home page: <http://www.gnu.org/s/libtool/>.
++General help using GNU software: <http://www.gnu.org/gethelp/>."
++    exit 0
++}
++
++
++# func_lo2o OBJECT-NAME
++# ---------------------
++# Transform OBJECT-NAME from a '.lo' suffix to the platform specific
++# object suffix.
++
++lo2o=s/\\.lo\$/.$objext/
++o2lo=s/\\.$objext\$/.lo/
++
++if test yes = "$_G_HAVE_XSI_OPS"; then
++  eval 'func_lo2o ()
++  {
++    case $1 in
++      *.lo) func_lo2o_result=${1%.lo}.$objext ;;
++      *   ) func_lo2o_result=$1               ;;
++    esac
++  }'
++
++  # func_xform LIBOBJ-OR-SOURCE
++  # ---------------------------
++  # Transform LIBOBJ-OR-SOURCE from a '.o' or '.c' (or otherwise)
++  # suffix to a '.lo' libtool-object suffix.
++  eval 'func_xform ()
++  {
++    func_xform_result=${1%.*}.lo
++  }'
++else
++  # ...otherwise fall back to using sed.
++  func_lo2o ()
++  {
++    func_lo2o_result=`$ECHO "$1" | $SED "$lo2o"`
++  }
++
++  func_xform ()
++  {
++    func_xform_result=`$ECHO "$1" | $SED 's|\.[^.]*$|.lo|'`
++  }
++fi
+ 
+ 
+-# func_fatal_configuration arg...
++# func_fatal_configuration ARG...
++# -------------------------------
+ # Echo program name prefixed message to standard error, followed by
+ # a configuration failure hint, and exit.
+ func_fatal_configuration ()
+ {
+-    func_error ${1+"$@"}
+-    func_error "See the $PACKAGE documentation for more information."
+-    func_fatal_error "Fatal configuration error."
++    func__fatal_error ${1+"$@"} \
++      "See the $PACKAGE documentation for more information." \
++      "Fatal configuration error."
+ }
+ 
+ 
+ # func_config
++# -----------
+ # Display the configuration for all the tags in this script.
+ func_config ()
+ {
+@@ -915,17 +2348,19 @@ func_config ()
+     exit $?
+ }
+ 
++
+ # func_features
++# -------------
+ # Display the features supported by this script.
+ func_features ()
+ {
+     echo "host: $host"
+-    if test "$build_libtool_libs" = yes; then
++    if test yes = "$build_libtool_libs"; then
+       echo "enable shared libraries"
+     else
+       echo "disable shared libraries"
+     fi
+-    if test "$build_old_libs" = yes; then
++    if test yes = "$build_old_libs"; then
+       echo "enable static libraries"
+     else
+       echo "disable static libraries"
+@@ -934,314 +2369,365 @@ func_features ()
+     exit $?
+ }
+ 
+-# func_enable_tag tagname
++
++# func_enable_tag TAGNAME
++# -----------------------
+ # Verify that TAGNAME is valid, and either flag an error and exit, or
+ # enable the TAGNAME tag.  We also add TAGNAME to the global $taglist
+ # variable here.
+ func_enable_tag ()
+ {
+-  # Global variable:
+-  tagname="$1"
++    # Global variable:
++    tagname=$1
+ 
+-  re_begincf="^# ### BEGIN LIBTOOL TAG CONFIG: $tagname\$"
+-  re_endcf="^# ### END LIBTOOL TAG CONFIG: $tagname\$"
+-  sed_extractcf="/$re_begincf/,/$re_endcf/p"
++    re_begincf="^# ### BEGIN LIBTOOL TAG CONFIG: $tagname\$"
++    re_endcf="^# ### END LIBTOOL TAG CONFIG: $tagname\$"
++    sed_extractcf=/$re_begincf/,/$re_endcf/p
+ 
+-  # Validate tagname.
+-  case $tagname in
+-    *[!-_A-Za-z0-9,/]*)
+-      func_fatal_error "invalid tag name: $tagname"
+-      ;;
+-  esac
++    # Validate tagname.
++    case $tagname in
++      *[!-_A-Za-z0-9,/]*)
++        func_fatal_error "invalid tag name: $tagname"
++        ;;
++    esac
+ 
+-  # Don't test for the "default" C tag, as we know it's
+-  # there but not specially marked.
+-  case $tagname in
+-    CC) ;;
++    # Don't test for the "default" C tag, as we know it's
++    # there but not specially marked.
++    case $tagname in
++        CC) ;;
+     *)
+-      if $GREP "$re_begincf" "$progpath" >/dev/null 2>&1; then
+-	taglist="$taglist $tagname"
+-
+-	# Evaluate the configuration.  Be careful to quote the path
+-	# and the sed script, to avoid splitting on whitespace, but
+-	# also don't use non-portable quotes within backquotes within
+-	# quotes we have to do it in 2 steps:
+-	extractedcf=`$SED -n -e "$sed_extractcf" < "$progpath"`
+-	eval "$extractedcf"
+-      else
+-	func_error "ignoring unknown tag $tagname"
+-      fi
+-      ;;
+-  esac
++        if $GREP "$re_begincf" "$progpath" >/dev/null 2>&1; then
++	  taglist="$taglist $tagname"
++
++	  # Evaluate the configuration.  Be careful to quote the path
++	  # and the sed script, to avoid splitting on whitespace, but
++	  # also don't use non-portable quotes within backquotes within
++	  # quotes we have to do it in 2 steps:
++	  extractedcf=`$SED -n -e "$sed_extractcf" < "$progpath"`
++	  eval "$extractedcf"
++        else
++	  func_error "ignoring unknown tag $tagname"
++        fi
++        ;;
++    esac
+ }
+ 
++
+ # func_check_version_match
++# ------------------------
+ # Ensure that we are using m4 macros, and libtool script from the same
+ # release of libtool.
+ func_check_version_match ()
+ {
+-  if test "$package_revision" != "$macro_revision"; then
+-    if test "$VERSION" != "$macro_version"; then
+-      if test -z "$macro_version"; then
+-        cat >&2 <<_LT_EOF
++    if test "$package_revision" != "$macro_revision"; then
++      if test "$VERSION" != "$macro_version"; then
++        if test -z "$macro_version"; then
++          cat >&2 <<_LT_EOF
+ $progname: Version mismatch error.  This is $PACKAGE $VERSION, but the
+ $progname: definition of this LT_INIT comes from an older release.
+ $progname: You should recreate aclocal.m4 with macros from $PACKAGE $VERSION
+ $progname: and run autoconf again.
+ _LT_EOF
+-      else
+-        cat >&2 <<_LT_EOF
++        else
++          cat >&2 <<_LT_EOF
+ $progname: Version mismatch error.  This is $PACKAGE $VERSION, but the
+ $progname: definition of this LT_INIT comes from $PACKAGE $macro_version.
+ $progname: You should recreate aclocal.m4 with macros from $PACKAGE $VERSION
+ $progname: and run autoconf again.
+ _LT_EOF
+-      fi
+-    else
+-      cat >&2 <<_LT_EOF
++        fi
++      else
++        cat >&2 <<_LT_EOF
+ $progname: Version mismatch error.  This is $PACKAGE $VERSION, revision $package_revision,
+ $progname: but the definition of this LT_INIT comes from revision $macro_revision.
+ $progname: You should recreate aclocal.m4 with macros from revision $package_revision
+ $progname: of $PACKAGE $VERSION and run autoconf again.
+ _LT_EOF
+-    fi
++      fi
+ 
+-    exit $EXIT_MISMATCH
+-  fi
++      exit $EXIT_MISMATCH
++    fi
+ }
+ 
+ 
+-# Shorthand for --mode=foo, only valid as the first argument
+-case $1 in
+-clean|clea|cle|cl)
+-  shift; set dummy --mode clean ${1+"$@"}; shift
+-  ;;
+-compile|compil|compi|comp|com|co|c)
+-  shift; set dummy --mode compile ${1+"$@"}; shift
+-  ;;
+-execute|execut|execu|exec|exe|ex|e)
+-  shift; set dummy --mode execute ${1+"$@"}; shift
+-  ;;
+-finish|finis|fini|fin|fi|f)
+-  shift; set dummy --mode finish ${1+"$@"}; shift
+-  ;;
+-install|instal|insta|inst|ins|in|i)
+-  shift; set dummy --mode install ${1+"$@"}; shift
+-  ;;
+-link|lin|li|l)
+-  shift; set dummy --mode link ${1+"$@"}; shift
+-  ;;
+-uninstall|uninstal|uninsta|uninst|unins|unin|uni|un|u)
+-  shift; set dummy --mode uninstall ${1+"$@"}; shift
+-  ;;
+-esac
+-
++# libtool_options_prep [ARG]...
++# -----------------------------
++# Preparation for options parsed by libtool.
++libtool_options_prep ()
++{
++    $debug_mode
+ 
++    # Option defaults:
++    opt_config=false
++    opt_dlopen=
++    opt_dry_run=false
++    opt_help=false
++    opt_mode=
++    opt_preserve_dup_deps=false
++    opt_quiet=false
+ 
+-# Option defaults:
+-opt_debug=:
+-opt_dry_run=false
+-opt_config=false
+-opt_preserve_dup_deps=false
+-opt_features=false
+-opt_finish=false
+-opt_help=false
+-opt_help_all=false
+-opt_silent=:
+-opt_warning=:
+-opt_verbose=:
+-opt_silent=false
+-opt_verbose=false
++    nonopt=
++    preserve_args=
+ 
++    _G_rc_lt_options_prep=:
+ 
+-# Parse options once, thoroughly.  This comes as soon as possible in the
+-# script to make things like `--version' happen as quickly as we can.
+-{
+-  # this just eases exit handling
+-  while test $# -gt 0; do
+-    opt="$1"
+-    shift
+-    case $opt in
+-      --debug|-x)	opt_debug='set -x'
+-			func_echo "enabling shell trace mode"
+-			$opt_debug
+-			;;
+-      --dry-run|--dryrun|-n)
+-			opt_dry_run=:
+-			;;
+-      --config)
+-			opt_config=:
+-func_config
+-			;;
+-      --dlopen|-dlopen)
+-			optarg="$1"
+-			opt_dlopen="${opt_dlopen+$opt_dlopen
+-}$optarg"
+-			shift
+-			;;
+-      --preserve-dup-deps)
+-			opt_preserve_dup_deps=:
+-			;;
+-      --features)
+-			opt_features=:
+-func_features
+-			;;
+-      --finish)
+-			opt_finish=:
+-set dummy --mode finish ${1+"$@"}; shift
+-			;;
+-      --help)
+-			opt_help=:
+-			;;
+-      --help-all)
+-			opt_help_all=:
+-opt_help=': help-all'
+-			;;
+-      --mode)
+-			test $# = 0 && func_missing_arg $opt && break
+-			optarg="$1"
+-			opt_mode="$optarg"
+-case $optarg in
+-  # Valid mode arguments:
+-  clean|compile|execute|finish|install|link|relink|uninstall) ;;
+-
+-  # Catch anything else as an error
+-  *) func_error "invalid argument for $opt"
+-     exit_cmd=exit
+-     break
+-     ;;
+-esac
+-			shift
+-			;;
+-      --no-silent|--no-quiet)
+-			opt_silent=false
+-func_append preserve_args " $opt"
+-			;;
+-      --no-warning|--no-warn)
+-			opt_warning=false
+-func_append preserve_args " $opt"
+-			;;
+-      --no-verbose)
+-			opt_verbose=false
+-func_append preserve_args " $opt"
+-			;;
+-      --silent|--quiet)
+-			opt_silent=:
+-func_append preserve_args " $opt"
+-        opt_verbose=false
+-			;;
+-      --verbose|-v)
+-			opt_verbose=:
+-func_append preserve_args " $opt"
+-opt_silent=false
+-			;;
+-      --tag)
+-			test $# = 0 && func_missing_arg $opt && break
+-			optarg="$1"
+-			opt_tag="$optarg"
+-func_append preserve_args " $opt $optarg"
+-func_enable_tag "$optarg"
+-			shift
+-			;;
+-
+-      -\?|-h)		func_usage				;;
+-      --help)		func_help				;;
+-      --version)	func_version				;;
+-
+-      # Separate optargs to long options:
+-      --*=*)
+-			func_split_long_opt "$opt"
+-			set dummy "$func_split_long_opt_name" "$func_split_long_opt_arg" ${1+"$@"}
+-			shift
+-			;;
+-
+-      # Separate non-argument short options:
+-      -\?*|-h*|-n*|-v*)
+-			func_split_short_opt "$opt"
+-			set dummy "$func_split_short_opt_name" "-$func_split_short_opt_arg" ${1+"$@"}
+-			shift
+-			;;
+-
+-      --)		break					;;
+-      -*)		func_fatal_help "unrecognized option \`$opt'" ;;
+-      *)		set dummy "$opt" ${1+"$@"};	shift; break  ;;
++    # Shorthand for --mode=foo, only valid as the first argument
++    case $1 in
++    clean|clea|cle|cl)
++      shift; set dummy --mode clean ${1+"$@"}; shift
++      ;;
++    compile|compil|compi|comp|com|co|c)
++      shift; set dummy --mode compile ${1+"$@"}; shift
++      ;;
++    execute|execut|execu|exec|exe|ex|e)
++      shift; set dummy --mode execute ${1+"$@"}; shift
++      ;;
++    finish|finis|fini|fin|fi|f)
++      shift; set dummy --mode finish ${1+"$@"}; shift
++      ;;
++    install|instal|insta|inst|ins|in|i)
++      shift; set dummy --mode install ${1+"$@"}; shift
++      ;;
++    link|lin|li|l)
++      shift; set dummy --mode link ${1+"$@"}; shift
++      ;;
++    uninstall|uninstal|uninsta|uninst|unins|unin|uni|un|u)
++      shift; set dummy --mode uninstall ${1+"$@"}; shift
++      ;;
++    *)
++      _G_rc_lt_options_prep=false
++      ;;
+     esac
+-  done
+ 
+-  # Validate options:
++    if $_G_rc_lt_options_prep; then
++      # Pass back the list of options.
++      func_quote eval ${1+"$@"}
++      libtool_options_prep_result=$func_quote_result
++    fi
++}
++func_add_hook func_options_prep libtool_options_prep
+ 
+-  # save first non-option argument
+-  if test "$#" -gt 0; then
+-    nonopt="$opt"
+-    shift
+-  fi
+ 
+-  # preserve --debug
+-  test "$opt_debug" = : || func_append preserve_args " --debug"
++# libtool_parse_options [ARG]...
++# ---------------------------------
++# Provide handling for libtool specific options.
++libtool_parse_options ()
++{
++    $debug_cmd
+ 
+-  case $host in
+-    *cygwin* | *mingw* | *pw32* | *cegcc*)
+-      # don't eliminate duplications in $postdeps and $predeps
+-      opt_duplicate_compiler_generated_deps=:
+-      ;;
+-    *)
+-      opt_duplicate_compiler_generated_deps=$opt_preserve_dup_deps
+-      ;;
+-  esac
++    _G_rc_lt_parse_options=false
+ 
+-  $opt_help || {
+-    # Sanity checks first:
+-    func_check_version_match
++    # Perform our own loop to consume as many options as possible in
++    # each iteration.
++    while test $# -gt 0; do
++      _G_match_lt_parse_options=:
++      _G_opt=$1
++      shift
++      case $_G_opt in
++        --dry-run|--dryrun|-n)
++                        opt_dry_run=:
++                        ;;
++
++        --config)       func_config ;;
++
++        --dlopen|-dlopen)
++                        opt_dlopen="${opt_dlopen+$opt_dlopen
++}$1"
++                        shift
++                        ;;
++
++        --preserve-dup-deps)
++                        opt_preserve_dup_deps=: ;;
++
++        --features)     func_features ;;
++
++        --finish)       set dummy --mode finish ${1+"$@"}; shift ;;
++
++        --help)         opt_help=: ;;
++
++        --help-all)     opt_help=': help-all' ;;
++
++        --mode)         test $# = 0 && func_missing_arg $_G_opt && break
++                        opt_mode=$1
++                        case $1 in
++                          # Valid mode arguments:
++                          clean|compile|execute|finish|install|link|relink|uninstall) ;;
++
++                          # Catch anything else as an error
++                          *) func_error "invalid argument for $_G_opt"
++                             exit_cmd=exit
++                             break
++                             ;;
++                        esac
++                        shift
++                        ;;
++
++        --no-silent|--no-quiet)
++                        opt_quiet=false
++                        func_append preserve_args " $_G_opt"
++                        ;;
++
++        --no-warnings|--no-warning|--no-warn)
++                        opt_warning=false
++                        func_append preserve_args " $_G_opt"
++                        ;;
++
++        --no-verbose)
++                        opt_verbose=false
++                        func_append preserve_args " $_G_opt"
++                        ;;
++
++        --silent|--quiet)
++                        opt_quiet=:
++                        opt_verbose=false
++                        func_append preserve_args " $_G_opt"
++                        ;;
++
++        --tag)          test $# = 0 && func_missing_arg $_G_opt && break
++                        opt_tag=$1
++                        func_append preserve_args " $_G_opt $1"
++                        func_enable_tag "$1"
++                        shift
++                        ;;
++
++        --verbose|-v)   opt_quiet=false
++                        opt_verbose=:
++                        func_append preserve_args " $_G_opt"
++                        ;;
++
++        # An option not handled by this hook function:
++        *)              set dummy "$_G_opt" ${1+"$@"} ; shift
++                        _G_match_lt_parse_options=false
++                        break
++                        ;;
++      esac
++      $_G_match_lt_parse_options && _G_rc_lt_parse_options=:
++    done
+ 
+-    if test "$build_libtool_libs" != yes && test "$build_old_libs" != yes; then
+-      func_fatal_configuration "not configured to build any kind of library"
++    if $_G_rc_lt_parse_options; then
++      # save modified positional parameters for caller
++      func_quote eval ${1+"$@"}
++      libtool_parse_options_result=$func_quote_result
+     fi
++}
++func_add_hook func_parse_options libtool_parse_options
+ 
+-    # Darwin sucks
+-    eval std_shrext=\"$shrext_cmds\"
+ 
+-    # Only execute mode is allowed to have -dlopen flags.
+-    if test -n "$opt_dlopen" && test "$opt_mode" != execute; then
+-      func_error "unrecognized option \`-dlopen'"
+-      $ECHO "$help" 1>&2
+-      exit $EXIT_FAILURE
++
++# libtool_validate_options [ARG]...
++# ---------------------------------
++# Perform any sanity checks on option settings and/or unconsumed
++# arguments.
++libtool_validate_options ()
++{
++    # save first non-option argument
++    if test 0 -lt $#; then
++      nonopt=$1
++      shift
+     fi
+ 
+-    # Change the help message to a mode-specific one.
+-    generic_help="$help"
+-    help="Try \`$progname --help --mode=$opt_mode' for more information."
+-  }
++    # preserve --debug
++    test : = "$debug_cmd" || func_append preserve_args " --debug"
++
++    case $host in
++      # Solaris2 added to fix http://debbugs.gnu.org/cgi/bugreport.cgi?bug=16452
++      # see also: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=59788
++      *cygwin* | *mingw* | *pw32* | *cegcc* | *solaris2* | *os2*)
++        # don't eliminate duplications in $postdeps and $predeps
++        opt_duplicate_compiler_generated_deps=:
++        ;;
++      *)
++        opt_duplicate_compiler_generated_deps=$opt_preserve_dup_deps
++        ;;
++    esac
+ 
++    $opt_help || {
++      # Sanity checks first:
++      func_check_version_match
+ 
+-  # Bail if the options were screwed
+-  $exit_cmd $EXIT_FAILURE
++      test yes != "$build_libtool_libs" \
++        && test yes != "$build_old_libs" \
++        && func_fatal_configuration "not configured to build any kind of library"
++
++      # Darwin sucks
++      eval std_shrext=\"$shrext_cmds\"
++
++      # Only execute mode is allowed to have -dlopen flags.
++      if test -n "$opt_dlopen" && test execute != "$opt_mode"; then
++        func_error "unrecognized option '-dlopen'"
++        $ECHO "$help" 1>&2
++        exit $EXIT_FAILURE
++      fi
++
++      # Change the help message to a mode-specific one.
++      generic_help=$help
++      help="Try '$progname --help --mode=$opt_mode' for more information."
++    }
++
++    # Pass back the unparsed argument list
++    func_quote eval ${1+"$@"}
++    libtool_validate_options_result=$func_quote_result
+ }
++func_add_hook func_validate_options libtool_validate_options
+ 
+ 
++# Process options as early as possible so that --help and --version
++# can return quickly.
++func_options ${1+"$@"}
++eval set dummy "$func_options_result"; shift
++
+ 
+ 
+ ## ----------- ##
+ ##    Main.    ##
+ ## ----------- ##
+ 
++magic='%%%MAGIC variable%%%'
++magic_exe='%%%MAGIC EXE variable%%%'
++
++# Global variables.
++extracted_archives=
++extracted_serial=0
++
++# If this variable is set in any of the actions, the command in it
++# will be execed at the end.  This prevents here-documents from being
++# left over by shells.
++exec_cmd=
++
++
++# A function that is used when there is no print builtin or printf.
++func_fallback_echo ()
++{
++  eval 'cat <<_LTECHO_EOF
++$1
++_LTECHO_EOF'
++}
++
++# func_generated_by_libtool
++# True iff stdin has been generated by Libtool. This function is only
++# a basic sanity check; it will hardly flush out determined imposters.
++func_generated_by_libtool_p ()
++{
++  $GREP "^# Generated by .*$PACKAGE" > /dev/null 2>&1
++}
++
+ # func_lalib_p file
+-# True iff FILE is a libtool `.la' library or `.lo' object file.
++# True iff FILE is a libtool '.la' library or '.lo' object file.
+ # This function is only a basic sanity check; it will hardly flush out
+ # determined imposters.
+ func_lalib_p ()
+ {
+     test -f "$1" &&
+-      $SED -e 4q "$1" 2>/dev/null \
+-        | $GREP "^# Generated by .*$PACKAGE" > /dev/null 2>&1
++      $SED -e 4q "$1" 2>/dev/null | func_generated_by_libtool_p
+ }
+ 
+ # func_lalib_unsafe_p file
+-# True iff FILE is a libtool `.la' library or `.lo' object file.
++# True iff FILE is a libtool '.la' library or '.lo' object file.
+ # This function implements the same check as func_lalib_p without
+ # resorting to external programs.  To this end, it redirects stdin and
+ # closes it afterwards, without saving the original file descriptor.
+ # As a safety measure, use it only where a negative result would be
+-# fatal anyway.  Works if `file' does not exist.
++# fatal anyway.  Works if 'file' does not exist.
+ func_lalib_unsafe_p ()
+ {
+     lalib_p=no
+@@ -1249,13 +2735,13 @@ func_lalib_unsafe_p ()
+ 	for lalib_p_l in 1 2 3 4
+ 	do
+ 	    read lalib_p_line
+-	    case "$lalib_p_line" in
++	    case $lalib_p_line in
+ 		\#\ Generated\ by\ *$PACKAGE* ) lalib_p=yes; break;;
+ 	    esac
+ 	done
+ 	exec 0<&5 5<&-
+     fi
+-    test "$lalib_p" = yes
++    test yes = "$lalib_p"
+ }
+ 
+ # func_ltwrapper_script_p file
+@@ -1264,7 +2750,8 @@ func_lalib_unsafe_p ()
+ # determined imposters.
+ func_ltwrapper_script_p ()
+ {
+-    func_lalib_p "$1"
++    test -f "$1" &&
++      $lt_truncate_bin < "$1" 2>/dev/null | func_generated_by_libtool_p
+ }
+ 
+ # func_ltwrapper_executable_p file
+@@ -1289,7 +2776,7 @@ func_ltwrapper_scriptname ()
+ {
+     func_dirname_and_basename "$1" "" "."
+     func_stripname '' '.exe' "$func_basename_result"
+-    func_ltwrapper_scriptname_result="$func_dirname_result/$objdir/${func_stripname_result}_ltshwrapper"
++    func_ltwrapper_scriptname_result=$func_dirname_result/$objdir/${func_stripname_result}_ltshwrapper
+ }
+ 
+ # func_ltwrapper_p file
+@@ -1308,11 +2795,13 @@ func_ltwrapper_p ()
+ # FAIL_CMD may read-access the current command in variable CMD!
+ func_execute_cmds ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     save_ifs=$IFS; IFS='~'
+     for cmd in $1; do
+-      IFS=$save_ifs
++      IFS=$sp$nl
+       eval cmd=\"$cmd\"
++      IFS=$save_ifs
+       func_show_eval "$cmd" "${2-:}"
+     done
+     IFS=$save_ifs
+@@ -1324,10 +2813,11 @@ func_execute_cmds ()
+ # Note that it is not necessary on cygwin/mingw to append a dot to
+ # FILE even if both FILE and FILE.exe exist: automatic-append-.exe
+ # behavior happens only for exec(3), not for open(2)!  Also, sourcing
+-# `FILE.' does not work on cygwin managed mounts.
++# 'FILE.' does not work on cygwin managed mounts.
+ func_source ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     case $1 in
+     */* | *\\*)	. "$1" ;;
+     *)		. "./$1" ;;
+@@ -1354,10 +2844,10 @@ func_resolve_sysroot ()
+ # store the result into func_replace_sysroot_result.
+ func_replace_sysroot ()
+ {
+-  case "$lt_sysroot:$1" in
++  case $lt_sysroot:$1 in
+   ?*:"$lt_sysroot"*)
+     func_stripname "$lt_sysroot" '' "$1"
+-    func_replace_sysroot_result="=$func_stripname_result"
++    func_replace_sysroot_result='='$func_stripname_result
+     ;;
+   *)
+     # Including no sysroot.
+@@ -1374,7 +2864,8 @@ func_replace_sysroot ()
+ # arg is usually of the form 'gcc ...'
+ func_infer_tag ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     if test -n "$available_tags" && test -z "$tagname"; then
+       CC_quoted=
+       for arg in $CC; do
+@@ -1393,7 +2884,7 @@ func_infer_tag ()
+ 	for z in $available_tags; do
+ 	  if $GREP "^# ### BEGIN LIBTOOL TAG CONFIG: $z$" < "$progpath" > /dev/null; then
+ 	    # Evaluate the configuration.
+-	    eval "`${SED} -n -e '/^# ### BEGIN LIBTOOL TAG CONFIG: '$z'$/,/^# ### END LIBTOOL TAG CONFIG: '$z'$/p' < $progpath`"
++	    eval "`$SED -n -e '/^# ### BEGIN LIBTOOL TAG CONFIG: '$z'$/,/^# ### END LIBTOOL TAG CONFIG: '$z'$/p' < $progpath`"
+ 	    CC_quoted=
+ 	    for arg in $CC; do
+ 	      # Double-quote args containing other shell metacharacters.
+@@ -1418,7 +2909,7 @@ func_infer_tag ()
+ 	# line option must be used.
+ 	if test -z "$tagname"; then
+ 	  func_echo "unable to infer tagged configuration"
+-	  func_fatal_error "specify a tag with \`--tag'"
++	  func_fatal_error "specify a tag with '--tag'"
+ #	else
+ #	  func_verbose "using $tagname tagged configuration"
+ 	fi
+@@ -1434,15 +2925,15 @@ func_infer_tag ()
+ # but don't create it if we're doing a dry run.
+ func_write_libtool_object ()
+ {
+-    write_libobj=${1}
+-    if test "$build_libtool_libs" = yes; then
+-      write_lobj=\'${2}\'
++    write_libobj=$1
++    if test yes = "$build_libtool_libs"; then
++      write_lobj=\'$2\'
+     else
+       write_lobj=none
+     fi
+ 
+-    if test "$build_old_libs" = yes; then
+-      write_oldobj=\'${3}\'
++    if test yes = "$build_old_libs"; then
++      write_oldobj=\'$3\'
+     else
+       write_oldobj=none
+     fi
+@@ -1450,7 +2941,7 @@ func_write_libtool_object ()
+     $opt_dry_run || {
+       cat >${write_libobj}T <<EOF
+ # $write_libobj - a libtool object file
+-# Generated by $PROGRAM (GNU $PACKAGE$TIMESTAMP) $VERSION
++# Generated by $PROGRAM (GNU $PACKAGE) $VERSION
+ #
+ # Please DO NOT delete this file!
+ # It is necessary for linking the library.
+@@ -1462,7 +2953,7 @@ pic_object=$write_lobj
+ non_pic_object=$write_oldobj
+ 
+ EOF
+-      $MV "${write_libobj}T" "${write_libobj}"
++      $MV "${write_libobj}T" "$write_libobj"
+     }
+ }
+ 
+@@ -1482,8 +2973,9 @@ EOF
+ # be empty on error (or when ARG is empty)
+ func_convert_core_file_wine_to_w32 ()
+ {
+-  $opt_debug
+-  func_convert_core_file_wine_to_w32_result="$1"
++  $debug_cmd
++
++  func_convert_core_file_wine_to_w32_result=$1
+   if test -n "$1"; then
+     # Unfortunately, winepath does not exit with a non-zero error code, so we
+     # are forced to check the contents of stdout. On the other hand, if the
+@@ -1491,9 +2983,9 @@ func_convert_core_file_wine_to_w32 ()
+     # *an error message* to stdout. So we must check for both error code of
+     # zero AND non-empty stdout, which explains the odd construction:
+     func_convert_core_file_wine_to_w32_tmp=`winepath -w "$1" 2>/dev/null`
+-    if test "$?" -eq 0 && test -n "${func_convert_core_file_wine_to_w32_tmp}"; then
++    if test "$?" -eq 0 && test -n "$func_convert_core_file_wine_to_w32_tmp"; then
+       func_convert_core_file_wine_to_w32_result=`$ECHO "$func_convert_core_file_wine_to_w32_tmp" |
+-        $SED -e "$lt_sed_naive_backslashify"`
++        $SED -e "$sed_naive_backslashify"`
+     else
+       func_convert_core_file_wine_to_w32_result=
+     fi
+@@ -1514,18 +3006,19 @@ func_convert_core_file_wine_to_w32 ()
+ # are convertible, then the result may be empty.
+ func_convert_core_path_wine_to_w32 ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   # unfortunately, winepath doesn't convert paths, only file names
+-  func_convert_core_path_wine_to_w32_result=""
++  func_convert_core_path_wine_to_w32_result=
+   if test -n "$1"; then
+     oldIFS=$IFS
+     IFS=:
+     for func_convert_core_path_wine_to_w32_f in $1; do
+       IFS=$oldIFS
+       func_convert_core_file_wine_to_w32 "$func_convert_core_path_wine_to_w32_f"
+-      if test -n "$func_convert_core_file_wine_to_w32_result" ; then
++      if test -n "$func_convert_core_file_wine_to_w32_result"; then
+         if test -z "$func_convert_core_path_wine_to_w32_result"; then
+-          func_convert_core_path_wine_to_w32_result="$func_convert_core_file_wine_to_w32_result"
++          func_convert_core_path_wine_to_w32_result=$func_convert_core_file_wine_to_w32_result
+         else
+           func_append func_convert_core_path_wine_to_w32_result ";$func_convert_core_file_wine_to_w32_result"
+         fi
+@@ -1554,7 +3047,8 @@ func_convert_core_path_wine_to_w32 ()
+ # environment variable; do not put it in $PATH.
+ func_cygpath ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   if test -n "$LT_CYGPATH" && test -f "$LT_CYGPATH"; then
+     func_cygpath_result=`$LT_CYGPATH "$@" 2>/dev/null`
+     if test "$?" -ne 0; then
+@@ -1563,7 +3057,7 @@ func_cygpath ()
+     fi
+   else
+     func_cygpath_result=
+-    func_error "LT_CYGPATH is empty or specifies non-existent file: \`$LT_CYGPATH'"
++    func_error "LT_CYGPATH is empty or specifies non-existent file: '$LT_CYGPATH'"
+   fi
+ }
+ #end: func_cygpath
+@@ -1574,10 +3068,11 @@ func_cygpath ()
+ # result in func_convert_core_msys_to_w32_result.
+ func_convert_core_msys_to_w32 ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   # awkward: cmd appends spaces to result
+   func_convert_core_msys_to_w32_result=`( cmd //c echo "$1" ) 2>/dev/null |
+-    $SED -e 's/[ ]*$//' -e "$lt_sed_naive_backslashify"`
++    $SED -e 's/[ ]*$//' -e "$sed_naive_backslashify"`
+ }
+ #end: func_convert_core_msys_to_w32
+ 
+@@ -1588,13 +3083,14 @@ func_convert_core_msys_to_w32 ()
+ # func_to_host_file_result to ARG1).
+ func_convert_file_check ()
+ {
+-  $opt_debug
+-  if test -z "$2" && test -n "$1" ; then
++  $debug_cmd
++
++  if test -z "$2" && test -n "$1"; then
+     func_error "Could not determine host file name corresponding to"
+-    func_error "  \`$1'"
++    func_error "  '$1'"
+     func_error "Continuing, but uninstalled executables may not work."
+     # Fallback:
+-    func_to_host_file_result="$1"
++    func_to_host_file_result=$1
+   fi
+ }
+ # end func_convert_file_check
+@@ -1606,10 +3102,11 @@ func_convert_file_check ()
+ # func_to_host_file_result to a simplistic fallback value (see below).
+ func_convert_path_check ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   if test -z "$4" && test -n "$3"; then
+     func_error "Could not determine the host path corresponding to"
+-    func_error "  \`$3'"
++    func_error "  '$3'"
+     func_error "Continuing, but uninstalled executables may not work."
+     # Fallback.  This is a deliberately simplistic "conversion" and
+     # should not be "improved".  See libtool.info.
+@@ -1618,7 +3115,7 @@ func_convert_path_check ()
+       func_to_host_path_result=`echo "$3" |
+         $SED -e "$lt_replace_pathsep_chars"`
+     else
+-      func_to_host_path_result="$3"
++      func_to_host_path_result=$3
+     fi
+   fi
+ }
+@@ -1630,9 +3127,10 @@ func_convert_path_check ()
+ # and appending REPL if ORIG matches BACKPAT.
+ func_convert_path_front_back_pathsep ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   case $4 in
+-  $1 ) func_to_host_path_result="$3$func_to_host_path_result"
++  $1 ) func_to_host_path_result=$3$func_to_host_path_result
+     ;;
+   esac
+   case $4 in
+@@ -1646,7 +3144,7 @@ func_convert_path_front_back_pathsep ()
+ ##################################################
+ # $build to $host FILE NAME CONVERSION FUNCTIONS #
+ ##################################################
+-# invoked via `$to_host_file_cmd ARG'
++# invoked via '$to_host_file_cmd ARG'
+ #
+ # In each case, ARG is the path to be converted from $build to $host format.
+ # Result will be available in $func_to_host_file_result.
+@@ -1657,7 +3155,8 @@ func_convert_path_front_back_pathsep ()
+ # in func_to_host_file_result.
+ func_to_host_file ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   $to_host_file_cmd "$1"
+ }
+ # end func_to_host_file
+@@ -1669,7 +3168,8 @@ func_to_host_file ()
+ # in (the comma separated) LAZY, no conversion takes place.
+ func_to_tool_file ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   case ,$2, in
+     *,"$to_tool_file_cmd",*)
+       func_to_tool_file_result=$1
+@@ -1687,7 +3187,7 @@ func_to_tool_file ()
+ # Copy ARG to func_to_host_file_result.
+ func_convert_file_noop ()
+ {
+-  func_to_host_file_result="$1"
++  func_to_host_file_result=$1
+ }
+ # end func_convert_file_noop
+ 
+@@ -1698,11 +3198,12 @@ func_convert_file_noop ()
+ # func_to_host_file_result.
+ func_convert_file_msys_to_w32 ()
+ {
+-  $opt_debug
+-  func_to_host_file_result="$1"
++  $debug_cmd
++
++  func_to_host_file_result=$1
+   if test -n "$1"; then
+     func_convert_core_msys_to_w32 "$1"
+-    func_to_host_file_result="$func_convert_core_msys_to_w32_result"
++    func_to_host_file_result=$func_convert_core_msys_to_w32_result
+   fi
+   func_convert_file_check "$1" "$func_to_host_file_result"
+ }
+@@ -1714,8 +3215,9 @@ func_convert_file_msys_to_w32 ()
+ # func_to_host_file_result.
+ func_convert_file_cygwin_to_w32 ()
+ {
+-  $opt_debug
+-  func_to_host_file_result="$1"
++  $debug_cmd
++
++  func_to_host_file_result=$1
+   if test -n "$1"; then
+     # because $build is cygwin, we call "the" cygpath in $PATH; no need to use
+     # LT_CYGPATH in this case.
+@@ -1731,11 +3233,12 @@ func_convert_file_cygwin_to_w32 ()
+ # and a working winepath. Returns result in func_to_host_file_result.
+ func_convert_file_nix_to_w32 ()
+ {
+-  $opt_debug
+-  func_to_host_file_result="$1"
++  $debug_cmd
++
++  func_to_host_file_result=$1
+   if test -n "$1"; then
+     func_convert_core_file_wine_to_w32 "$1"
+-    func_to_host_file_result="$func_convert_core_file_wine_to_w32_result"
++    func_to_host_file_result=$func_convert_core_file_wine_to_w32_result
+   fi
+   func_convert_file_check "$1" "$func_to_host_file_result"
+ }
+@@ -1747,12 +3250,13 @@ func_convert_file_nix_to_w32 ()
+ # Returns result in func_to_host_file_result.
+ func_convert_file_msys_to_cygwin ()
+ {
+-  $opt_debug
+-  func_to_host_file_result="$1"
++  $debug_cmd
++
++  func_to_host_file_result=$1
+   if test -n "$1"; then
+     func_convert_core_msys_to_w32 "$1"
+     func_cygpath -u "$func_convert_core_msys_to_w32_result"
+-    func_to_host_file_result="$func_cygpath_result"
++    func_to_host_file_result=$func_cygpath_result
+   fi
+   func_convert_file_check "$1" "$func_to_host_file_result"
+ }
+@@ -1765,13 +3269,14 @@ func_convert_file_msys_to_cygwin ()
+ # in func_to_host_file_result.
+ func_convert_file_nix_to_cygwin ()
+ {
+-  $opt_debug
+-  func_to_host_file_result="$1"
++  $debug_cmd
++
++  func_to_host_file_result=$1
+   if test -n "$1"; then
+     # convert from *nix to w32, then use cygpath to convert from w32 to cygwin.
+     func_convert_core_file_wine_to_w32 "$1"
+     func_cygpath -u "$func_convert_core_file_wine_to_w32_result"
+-    func_to_host_file_result="$func_cygpath_result"
++    func_to_host_file_result=$func_cygpath_result
+   fi
+   func_convert_file_check "$1" "$func_to_host_file_result"
+ }
+@@ -1781,7 +3286,7 @@ func_convert_file_nix_to_cygwin ()
+ #############################################
+ # $build to $host PATH CONVERSION FUNCTIONS #
+ #############################################
+-# invoked via `$to_host_path_cmd ARG'
++# invoked via '$to_host_path_cmd ARG'
+ #
+ # In each case, ARG is the path to be converted from $build to $host format.
+ # The result will be available in $func_to_host_path_result.
+@@ -1805,10 +3310,11 @@ func_convert_file_nix_to_cygwin ()
+ to_host_path_cmd=
+ func_init_to_host_path_cmd ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   if test -z "$to_host_path_cmd"; then
+     func_stripname 'func_convert_file_' '' "$to_host_file_cmd"
+-    to_host_path_cmd="func_convert_path_${func_stripname_result}"
++    to_host_path_cmd=func_convert_path_$func_stripname_result
+   fi
+ }
+ 
+@@ -1818,7 +3324,8 @@ func_init_to_host_path_cmd ()
+ # in func_to_host_path_result.
+ func_to_host_path ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   func_init_to_host_path_cmd
+   $to_host_path_cmd "$1"
+ }
+@@ -1829,7 +3336,7 @@ func_to_host_path ()
+ # Copy ARG to func_to_host_path_result.
+ func_convert_path_noop ()
+ {
+-  func_to_host_path_result="$1"
++  func_to_host_path_result=$1
+ }
+ # end func_convert_path_noop
+ 
+@@ -1840,8 +3347,9 @@ func_convert_path_noop ()
+ # func_to_host_path_result.
+ func_convert_path_msys_to_w32 ()
+ {
+-  $opt_debug
+-  func_to_host_path_result="$1"
++  $debug_cmd
++
++  func_to_host_path_result=$1
+   if test -n "$1"; then
+     # Remove leading and trailing path separator characters from ARG.  MSYS
+     # behavior is inconsistent here; cygpath turns them into '.;' and ';.';
+@@ -1849,7 +3357,7 @@ func_convert_path_msys_to_w32 ()
+     func_stripname : : "$1"
+     func_to_host_path_tmp1=$func_stripname_result
+     func_convert_core_msys_to_w32 "$func_to_host_path_tmp1"
+-    func_to_host_path_result="$func_convert_core_msys_to_w32_result"
++    func_to_host_path_result=$func_convert_core_msys_to_w32_result
+     func_convert_path_check : ";" \
+       "$func_to_host_path_tmp1" "$func_to_host_path_result"
+     func_convert_path_front_back_pathsep ":*" "*:" ";" "$1"
+@@ -1863,8 +3371,9 @@ func_convert_path_msys_to_w32 ()
+ # func_to_host_file_result.
+ func_convert_path_cygwin_to_w32 ()
+ {
+-  $opt_debug
+-  func_to_host_path_result="$1"
++  $debug_cmd
++
++  func_to_host_path_result=$1
+   if test -n "$1"; then
+     # See func_convert_path_msys_to_w32:
+     func_stripname : : "$1"
+@@ -1883,14 +3392,15 @@ func_convert_path_cygwin_to_w32 ()
+ # a working winepath.  Returns result in func_to_host_file_result.
+ func_convert_path_nix_to_w32 ()
+ {
+-  $opt_debug
+-  func_to_host_path_result="$1"
++  $debug_cmd
++
++  func_to_host_path_result=$1
+   if test -n "$1"; then
+     # See func_convert_path_msys_to_w32:
+     func_stripname : : "$1"
+     func_to_host_path_tmp1=$func_stripname_result
+     func_convert_core_path_wine_to_w32 "$func_to_host_path_tmp1"
+-    func_to_host_path_result="$func_convert_core_path_wine_to_w32_result"
++    func_to_host_path_result=$func_convert_core_path_wine_to_w32_result
+     func_convert_path_check : ";" \
+       "$func_to_host_path_tmp1" "$func_to_host_path_result"
+     func_convert_path_front_back_pathsep ":*" "*:" ";" "$1"
+@@ -1904,15 +3414,16 @@ func_convert_path_nix_to_w32 ()
+ # Returns result in func_to_host_file_result.
+ func_convert_path_msys_to_cygwin ()
+ {
+-  $opt_debug
+-  func_to_host_path_result="$1"
++  $debug_cmd
++
++  func_to_host_path_result=$1
+   if test -n "$1"; then
+     # See func_convert_path_msys_to_w32:
+     func_stripname : : "$1"
+     func_to_host_path_tmp1=$func_stripname_result
+     func_convert_core_msys_to_w32 "$func_to_host_path_tmp1"
+     func_cygpath -u -p "$func_convert_core_msys_to_w32_result"
+-    func_to_host_path_result="$func_cygpath_result"
++    func_to_host_path_result=$func_cygpath_result
+     func_convert_path_check : : \
+       "$func_to_host_path_tmp1" "$func_to_host_path_result"
+     func_convert_path_front_back_pathsep ":*" "*:" : "$1"
+@@ -1927,8 +3438,9 @@ func_convert_path_msys_to_cygwin ()
+ # func_to_host_file_result.
+ func_convert_path_nix_to_cygwin ()
+ {
+-  $opt_debug
+-  func_to_host_path_result="$1"
++  $debug_cmd
++
++  func_to_host_path_result=$1
+   if test -n "$1"; then
+     # Remove leading and trailing path separator characters from
+     # ARG. msys behavior is inconsistent here, cygpath turns them
+@@ -1937,7 +3449,7 @@ func_convert_path_nix_to_cygwin ()
+     func_to_host_path_tmp1=$func_stripname_result
+     func_convert_core_path_wine_to_w32 "$func_to_host_path_tmp1"
+     func_cygpath -u -p "$func_convert_core_path_wine_to_w32_result"
+-    func_to_host_path_result="$func_cygpath_result"
++    func_to_host_path_result=$func_cygpath_result
+     func_convert_path_check : : \
+       "$func_to_host_path_tmp1" "$func_to_host_path_result"
+     func_convert_path_front_back_pathsep ":*" "*:" : "$1"
+@@ -1946,13 +3458,31 @@ func_convert_path_nix_to_cygwin ()
+ # end func_convert_path_nix_to_cygwin
+ 
+ 
++# func_dll_def_p FILE
++# True iff FILE is a Windows DLL '.def' file.
++# Keep in sync with _LT_DLL_DEF_P in libtool.m4
++func_dll_def_p ()
++{
++  $debug_cmd
++
++  func_dll_def_p_tmp=`$SED -n \
++    -e 's/^[	 ]*//' \
++    -e '/^\(;.*\)*$/d' \
++    -e 's/^\(EXPORTS\|LIBRARY\)\([	 ].*\)*$/DEF/p' \
++    -e q \
++    "$1"`
++  test DEF = "$func_dll_def_p_tmp"
++}
++
++
+ # func_mode_compile arg...
+ func_mode_compile ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     # Get the compilation command and the source file.
+     base_compile=
+-    srcfile="$nonopt"  #  always keep a non-empty value in "srcfile"
++    srcfile=$nonopt  #  always keep a non-empty value in "srcfile"
+     suppress_opt=yes
+     suppress_output=
+     arg_mode=normal
+@@ -1965,12 +3495,12 @@ func_mode_compile ()
+       case $arg_mode in
+       arg  )
+ 	# do not "continue".  Instead, add this to base_compile
+-	lastarg="$arg"
++	lastarg=$arg
+ 	arg_mode=normal
+ 	;;
+ 
+       target )
+-	libobj="$arg"
++	libobj=$arg
+ 	arg_mode=normal
+ 	continue
+ 	;;
+@@ -1980,7 +3510,7 @@ func_mode_compile ()
+ 	case $arg in
+ 	-o)
+ 	  test -n "$libobj" && \
+-	    func_fatal_error "you cannot specify \`-o' more than once"
++	    func_fatal_error "you cannot specify '-o' more than once"
+ 	  arg_mode=target
+ 	  continue
+ 	  ;;
+@@ -2009,12 +3539,12 @@ func_mode_compile ()
+ 	  func_stripname '-Wc,' '' "$arg"
+ 	  args=$func_stripname_result
+ 	  lastarg=
+-	  save_ifs="$IFS"; IFS=','
++	  save_ifs=$IFS; IFS=,
+ 	  for arg in $args; do
+-	    IFS="$save_ifs"
++	    IFS=$save_ifs
+ 	    func_append_quoted lastarg "$arg"
+ 	  done
+-	  IFS="$save_ifs"
++	  IFS=$save_ifs
+ 	  func_stripname ' ' '' "$lastarg"
+ 	  lastarg=$func_stripname_result
+ 
+@@ -2027,8 +3557,8 @@ func_mode_compile ()
+ 	  # Accept the current argument as the source file.
+ 	  # The previous "srcfile" becomes the current argument.
+ 	  #
+-	  lastarg="$srcfile"
+-	  srcfile="$arg"
++	  lastarg=$srcfile
++	  srcfile=$arg
+ 	  ;;
+ 	esac  #  case $arg
+ 	;;
+@@ -2043,13 +3573,13 @@ func_mode_compile ()
+       func_fatal_error "you must specify an argument for -Xcompile"
+       ;;
+     target)
+-      func_fatal_error "you must specify a target with \`-o'"
++      func_fatal_error "you must specify a target with '-o'"
+       ;;
+     *)
+       # Get the name of the library object.
+       test -z "$libobj" && {
+ 	func_basename "$srcfile"
+-	libobj="$func_basename_result"
++	libobj=$func_basename_result
+       }
+       ;;
+     esac
+@@ -2069,7 +3599,7 @@ func_mode_compile ()
+     case $libobj in
+     *.lo) func_lo2o "$libobj"; obj=$func_lo2o_result ;;
+     *)
+-      func_fatal_error "cannot determine name of library object from \`$libobj'"
++      func_fatal_error "cannot determine name of library object from '$libobj'"
+       ;;
+     esac
+ 
+@@ -2078,8 +3608,8 @@ func_mode_compile ()
+     for arg in $later; do
+       case $arg in
+       -shared)
+-	test "$build_libtool_libs" != yes && \
+-	  func_fatal_configuration "can not build a shared library"
++	test yes = "$build_libtool_libs" \
++	  || func_fatal_configuration "cannot build a shared library"
+ 	build_old_libs=no
+ 	continue
+ 	;;
+@@ -2102,20 +3632,20 @@ func_mode_compile ()
+       esac
+     done
+ 
+-    func_quote_for_eval "$libobj"
+-    test "X$libobj" != "X$func_quote_for_eval_result" \
++    func_quote_arg pretty "$libobj"
++    test "X$libobj" != "X$func_quote_arg_result" \
+       && $ECHO "X$libobj" | $GREP '[]~#^*{};<>?"'"'"'	 &()|`$[]' \
+-      && func_warning "libobj name \`$libobj' may not contain shell special characters."
++      && func_warning "libobj name '$libobj' may not contain shell special characters."
+     func_dirname_and_basename "$obj" "/" ""
+-    objname="$func_basename_result"
+-    xdir="$func_dirname_result"
+-    lobj=${xdir}$objdir/$objname
++    objname=$func_basename_result
++    xdir=$func_dirname_result
++    lobj=$xdir$objdir/$objname
+ 
+     test -z "$base_compile" && \
+       func_fatal_help "you must specify a compilation command"
+ 
+     # Delete any leftover library objects.
+-    if test "$build_old_libs" = yes; then
++    if test yes = "$build_old_libs"; then
+       removelist="$obj $lobj $libobj ${libobj}T"
+     else
+       removelist="$lobj $libobj ${libobj}T"
+@@ -2127,16 +3657,16 @@ func_mode_compile ()
+       pic_mode=default
+       ;;
+     esac
+-    if test "$pic_mode" = no && test "$deplibs_check_method" != pass_all; then
++    if test no = "$pic_mode" && test pass_all != "$deplibs_check_method"; then
+       # non-PIC code in shared libraries is not supported
+       pic_mode=default
+     fi
+ 
+     # Calculate the filename of the output object if compiler does
+     # not support -o with -c
+-    if test "$compiler_c_o" = no; then
+-      output_obj=`$ECHO "$srcfile" | $SED 's%^.*/%%; s%\.[^.]*$%%'`.${objext}
+-      lockfile="$output_obj.lock"
++    if test no = "$compiler_c_o"; then
++      output_obj=`$ECHO "$srcfile" | $SED 's%^.*/%%; s%\.[^.]*$%%'`.$objext
++      lockfile=$output_obj.lock
+     else
+       output_obj=
+       need_locks=no
+@@ -2145,12 +3675,12 @@ func_mode_compile ()
+ 
+     # Lock this critical section if it is needed
+     # We use this script file to make the link, it avoids creating a new file
+-    if test "$need_locks" = yes; then
++    if test yes = "$need_locks"; then
+       until $opt_dry_run || ln "$progpath" "$lockfile" 2>/dev/null; do
+ 	func_echo "Waiting for $lockfile to be removed"
+ 	sleep 2
+       done
+-    elif test "$need_locks" = warn; then
++    elif test warn = "$need_locks"; then
+       if test -f "$lockfile"; then
+ 	$ECHO "\
+ *** ERROR, $lockfile exists and contains:
+@@ -2158,7 +3688,7 @@ func_mode_compile ()
+ 
+ This indicates that another process is trying to use the same
+ temporary object file, and libtool could not work around it because
+-your compiler does not support \`-c' and \`-o' together.  If you
++your compiler does not support '-c' and '-o' together.  If you
+ repeat this compilation, it may succeed, by chance, but you had better
+ avoid parallel builds (make -j) in this platform, or get a better
+ compiler."
+@@ -2176,15 +3706,15 @@ compiler."
+ 
+     func_to_tool_file "$srcfile" func_convert_file_msys_to_w32
+     srcfile=$func_to_tool_file_result
+-    func_quote_for_eval "$srcfile"
+-    qsrcfile=$func_quote_for_eval_result
++    func_quote_arg pretty "$srcfile"
++    qsrcfile=$func_quote_arg_result
+ 
+     # Only build a PIC object if we are building libtool libraries.
+-    if test "$build_libtool_libs" = yes; then
++    if test yes = "$build_libtool_libs"; then
+       # Without this assignment, base_compile gets emptied.
+       fbsd_hideous_sh_bug=$base_compile
+ 
+-      if test "$pic_mode" != no; then
++      if test no != "$pic_mode"; then
+ 	command="$base_compile $qsrcfile $pic_flag"
+       else
+ 	# Don't build PIC code
+@@ -2201,7 +3731,7 @@ compiler."
+       func_show_eval_locale "$command"	\
+           'test -n "$output_obj" && $RM $removelist; exit $EXIT_FAILURE'
+ 
+-      if test "$need_locks" = warn &&
++      if test warn = "$need_locks" &&
+ 	 test "X`cat $lockfile 2>/dev/null`" != "X$srcfile"; then
+ 	$ECHO "\
+ *** ERROR, $lockfile contains:
+@@ -2212,7 +3742,7 @@ $srcfile
+ 
+ This indicates that another process is trying to use the same
+ temporary object file, and libtool could not work around it because
+-your compiler does not support \`-c' and \`-o' together.  If you
++your compiler does not support '-c' and '-o' together.  If you
+ repeat this compilation, it may succeed, by chance, but you had better
+ avoid parallel builds (make -j) in this platform, or get a better
+ compiler."
+@@ -2228,20 +3758,20 @@ compiler."
+       fi
+ 
+       # Allow error messages only from the first compilation.
+-      if test "$suppress_opt" = yes; then
++      if test yes = "$suppress_opt"; then
+ 	suppress_output=' >/dev/null 2>&1'
+       fi
+     fi
+ 
+     # Only build a position-dependent object if we build old libraries.
+-    if test "$build_old_libs" = yes; then
+-      if test "$pic_mode" != yes; then
++    if test yes = "$build_old_libs"; then
++      if test yes != "$pic_mode"; then
+ 	# Don't build PIC code
+ 	command="$base_compile $qsrcfile$pie_flag"
+       else
+ 	command="$base_compile $qsrcfile $pic_flag"
+       fi
+-      if test "$compiler_c_o" = yes; then
++      if test yes = "$compiler_c_o"; then
+ 	func_append command " -o $obj"
+       fi
+ 
+@@ -2250,7 +3780,7 @@ compiler."
+       func_show_eval_locale "$command" \
+         '$opt_dry_run || $RM $removelist; exit $EXIT_FAILURE'
+ 
+-      if test "$need_locks" = warn &&
++      if test warn = "$need_locks" &&
+ 	 test "X`cat $lockfile 2>/dev/null`" != "X$srcfile"; then
+ 	$ECHO "\
+ *** ERROR, $lockfile contains:
+@@ -2261,7 +3791,7 @@ $srcfile
+ 
+ This indicates that another process is trying to use the same
+ temporary object file, and libtool could not work around it because
+-your compiler does not support \`-c' and \`-o' together.  If you
++your compiler does not support '-c' and '-o' together.  If you
+ repeat this compilation, it may succeed, by chance, but you had better
+ avoid parallel builds (make -j) in this platform, or get a better
+ compiler."
+@@ -2281,7 +3811,7 @@ compiler."
+       func_write_libtool_object "$libobj" "$objdir/$objname" "$objname"
+ 
+       # Unlock the critical section if it was locked
+-      if test "$need_locks" != no; then
++      if test no != "$need_locks"; then
+ 	removelist=$lockfile
+         $RM "$lockfile"
+       fi
+@@ -2291,7 +3821,7 @@ compiler."
+ }
+ 
+ $opt_help || {
+-  test "$opt_mode" = compile && func_mode_compile ${1+"$@"}
++  test compile = "$opt_mode" && func_mode_compile ${1+"$@"}
+ }
+ 
+ func_mode_help ()
+@@ -2311,7 +3841,7 @@ func_mode_help ()
+ Remove files from the build directory.
+ 
+ RM is the name of the program to use to delete files associated with each FILE
+-(typically \`/bin/rm').  RM-OPTIONS are options (such as \`-f') to be passed
++(typically '/bin/rm').  RM-OPTIONS are options (such as '-f') to be passed
+ to RM.
+ 
+ If FILE is a libtool library, object or program, all the files associated
+@@ -2330,16 +3860,16 @@ This mode accepts the following additional options:
+   -no-suppress      do not suppress compiler output for multiple passes
+   -prefer-pic       try to build PIC objects only
+   -prefer-non-pic   try to build non-PIC objects only
+-  -shared           do not build a \`.o' file suitable for static linking
+-  -static           only build a \`.o' file suitable for static linking
++  -shared           do not build a '.o' file suitable for static linking
++  -static           only build a '.o' file suitable for static linking
+   -Wc,FLAG          pass FLAG directly to the compiler
+ 
+-COMPILE-COMMAND is a command to be used in creating a \`standard' object file
++COMPILE-COMMAND is a command to be used in creating a 'standard' object file
+ from the given SOURCEFILE.
+ 
+ The output file name is determined by removing the directory component from
+-SOURCEFILE, then substituting the C source code suffix \`.c' with the
+-library object suffix, \`.lo'."
++SOURCEFILE, then substituting the C source code suffix '.c' with the
++library object suffix, '.lo'."
+         ;;
+ 
+       execute)
+@@ -2352,7 +3882,7 @@ This mode accepts the following additional options:
+ 
+   -dlopen FILE      add the directory containing FILE to the library path
+ 
+-This mode sets the library path environment variable according to \`-dlopen'
++This mode sets the library path environment variable according to '-dlopen'
+ flags.
+ 
+ If any of the ARGS are libtool executable wrappers, then they are translated
+@@ -2371,7 +3901,7 @@ Complete the installation of libtool libraries.
+ Each LIBDIR is a directory that contains libtool libraries.
+ 
+ The commands that this mode executes may require superuser privileges.  Use
+-the \`--dry-run' option if you just want to see what would be executed."
++the '--dry-run' option if you just want to see what would be executed."
+         ;;
+ 
+       install)
+@@ -2381,7 +3911,7 @@ the \`--dry-run' option if you just want to see what would be executed."
+ Install executables or libraries.
+ 
+ INSTALL-COMMAND is the installation command.  The first component should be
+-either the \`install' or \`cp' program.
++either the 'install' or 'cp' program.
+ 
+ The following components of INSTALL-COMMAND are treated specially:
+ 
+@@ -2407,7 +3937,7 @@ The following components of LINK-COMMAND are treated specially:
+   -avoid-version    do not add a version suffix if possible
+   -bindir BINDIR    specify path to binaries directory (for systems where
+                     libraries must be found in the PATH setting at runtime)
+-  -dlopen FILE      \`-dlpreopen' FILE if it cannot be dlopened at runtime
++  -dlopen FILE      '-dlpreopen' FILE if it cannot be dlopened at runtime
+   -dlpreopen FILE   link in FILE and add its symbols to lt_preloaded_symbols
+   -export-dynamic   allow symbols from OUTPUT-FILE to be resolved with dlsym(3)
+   -export-symbols SYMFILE
+@@ -2421,7 +3951,8 @@ The following components of LINK-COMMAND are treated specially:
+   -no-install       link a not-installable executable
+   -no-undefined     declare that a library does not refer to external symbols
+   -o OUTPUT-FILE    create OUTPUT-FILE from the specified objects
+-  -objectlist FILE  Use a list of object files found in FILE to specify objects
++  -objectlist FILE  use a list of object files found in FILE to specify objects
++  -os2dllname NAME  force a short DLL name on OS/2 (no effect on other OSes)
+   -precious-files-regex REGEX
+                     don't remove output files matching REGEX
+   -release RELEASE  specify package release information
+@@ -2441,20 +3972,20 @@ The following components of LINK-COMMAND are treated specially:
+   -Xlinker FLAG     pass linker-specific FLAG directly to the linker
+   -XCClinker FLAG   pass link-specific FLAG to the compiler driver (CC)
+ 
+-All other options (arguments beginning with \`-') are ignored.
++All other options (arguments beginning with '-') are ignored.
+ 
+-Every other argument is treated as a filename.  Files ending in \`.la' are
++Every other argument is treated as a filename.  Files ending in '.la' are
+ treated as uninstalled libtool libraries, other files are standard or library
+ object files.
+ 
+-If the OUTPUT-FILE ends in \`.la', then a libtool library is created,
+-only library objects (\`.lo' files) may be specified, and \`-rpath' is
++If the OUTPUT-FILE ends in '.la', then a libtool library is created,
++only library objects ('.lo' files) may be specified, and '-rpath' is
+ required, except when creating a convenience library.
+ 
+-If OUTPUT-FILE ends in \`.a' or \`.lib', then a standard library is created
+-using \`ar' and \`ranlib', or on Windows using \`lib'.
++If OUTPUT-FILE ends in '.a' or '.lib', then a standard library is created
++using 'ar' and 'ranlib', or on Windows using 'lib'.
+ 
+-If OUTPUT-FILE ends in \`.lo' or \`.${objext}', then a reloadable object file
++If OUTPUT-FILE ends in '.lo' or '.$objext', then a reloadable object file
+ is created, otherwise an executable program is created."
+         ;;
+ 
+@@ -2465,7 +3996,7 @@ is created, otherwise an executable program is created."
+ Remove libraries from an installation directory.
+ 
+ RM is the name of the program to use to delete files associated with each FILE
+-(typically \`/bin/rm').  RM-OPTIONS are options (such as \`-f') to be passed
++(typically '/bin/rm').  RM-OPTIONS are options (such as '-f') to be passed
+ to RM.
+ 
+ If FILE is a libtool library, all the files associated with it are deleted.
+@@ -2473,17 +4004,17 @@ Otherwise, only FILE itself is deleted using RM."
+         ;;
+ 
+       *)
+-        func_fatal_help "invalid operation mode \`$opt_mode'"
++        func_fatal_help "invalid operation mode '$opt_mode'"
+         ;;
+     esac
+ 
+     echo
+-    $ECHO "Try \`$progname --help' for more information about other modes."
++    $ECHO "Try '$progname --help' for more information about other modes."
+ }
+ 
+ # Now that we've collected a possible --mode arg, show help if necessary
+ if $opt_help; then
+-  if test "$opt_help" = :; then
++  if test : = "$opt_help"; then
+     func_mode_help
+   else
+     {
+@@ -2491,7 +4022,7 @@ if $opt_help; then
+       for opt_mode in compile link execute install finish uninstall clean; do
+ 	func_mode_help
+       done
+-    } | sed -n '1p; 2,$s/^Usage:/  or: /p'
++    } | $SED -n '1p; 2,$s/^Usage:/  or: /p'
+     {
+       func_help noexit
+       for opt_mode in compile link execute install finish uninstall clean; do
+@@ -2499,7 +4030,7 @@ if $opt_help; then
+ 	func_mode_help
+       done
+     } |
+-    sed '1d
++    $SED '1d
+       /^When reporting/,/^Report/{
+ 	H
+ 	d
+@@ -2516,16 +4047,17 @@ fi
+ # func_mode_execute arg...
+ func_mode_execute ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     # The first argument is the command name.
+-    cmd="$nonopt"
++    cmd=$nonopt
+     test -z "$cmd" && \
+       func_fatal_help "you must specify a COMMAND"
+ 
+     # Handle -dlopen flags immediately.
+     for file in $opt_dlopen; do
+       test -f "$file" \
+-	|| func_fatal_help "\`$file' is not a file"
++	|| func_fatal_help "'$file' is not a file"
+ 
+       dir=
+       case $file in
+@@ -2535,7 +4067,7 @@ func_mode_execute ()
+ 
+ 	# Check to see that this really is a libtool archive.
+ 	func_lalib_unsafe_p "$file" \
+-	  || func_fatal_help "\`$lib' is not a valid libtool archive"
++	  || func_fatal_help "'$lib' is not a valid libtool archive"
+ 
+ 	# Read the libtool library.
+ 	dlname=
+@@ -2546,18 +4078,18 @@ func_mode_execute ()
+ 	if test -z "$dlname"; then
+ 	  # Warn if it was a shared library.
+ 	  test -n "$library_names" && \
+-	    func_warning "\`$file' was not linked with \`-export-dynamic'"
++	    func_warning "'$file' was not linked with '-export-dynamic'"
+ 	  continue
+ 	fi
+ 
+ 	func_dirname "$file" "" "."
+-	dir="$func_dirname_result"
++	dir=$func_dirname_result
+ 
+ 	if test -f "$dir/$objdir/$dlname"; then
+ 	  func_append dir "/$objdir"
+ 	else
+ 	  if test ! -f "$dir/$dlname"; then
+-	    func_fatal_error "cannot find \`$dlname' in \`$dir' or \`$dir/$objdir'"
++	    func_fatal_error "cannot find '$dlname' in '$dir' or '$dir/$objdir'"
+ 	  fi
+ 	fi
+ 	;;
+@@ -2565,18 +4097,18 @@ func_mode_execute ()
+       *.lo)
+ 	# Just add the directory containing the .lo file.
+ 	func_dirname "$file" "" "."
+-	dir="$func_dirname_result"
++	dir=$func_dirname_result
+ 	;;
+ 
+       *)
+-	func_warning "\`-dlopen' is ignored for non-libtool libraries and objects"
++	func_warning "'-dlopen' is ignored for non-libtool libraries and objects"
+ 	continue
+ 	;;
+       esac
+ 
+       # Get the absolute pathname.
+       absdir=`cd "$dir" && pwd`
+-      test -n "$absdir" && dir="$absdir"
++      test -n "$absdir" && dir=$absdir
+ 
+       # Now add the directory to shlibpath_var.
+       if eval "test -z \"\$$shlibpath_var\""; then
+@@ -2588,7 +4120,7 @@ func_mode_execute ()
+ 
+     # This variable tells wrapper scripts just to set shlibpath_var
+     # rather than running their programs.
+-    libtool_execute_magic="$magic"
++    libtool_execute_magic=$magic
+ 
+     # Check if any of the arguments is a wrapper script.
+     args=
+@@ -2601,12 +4133,12 @@ func_mode_execute ()
+ 	if func_ltwrapper_script_p "$file"; then
+ 	  func_source "$file"
+ 	  # Transform arg to wrapped name.
+-	  file="$progdir/$program"
++	  file=$progdir/$program
+ 	elif func_ltwrapper_executable_p "$file"; then
+ 	  func_ltwrapper_scriptname "$file"
+ 	  func_source "$func_ltwrapper_scriptname_result"
+ 	  # Transform arg to wrapped name.
+-	  file="$progdir/$program"
++	  file=$progdir/$program
+ 	fi
+ 	;;
+       esac
+@@ -2614,7 +4146,15 @@ func_mode_execute ()
+       func_append_quoted args "$file"
+     done
+ 
+-    if test "X$opt_dry_run" = Xfalse; then
++    if $opt_dry_run; then
++      # Display what would be done.
++      if test -n "$shlibpath_var"; then
++	eval "\$ECHO \"\$shlibpath_var=\$$shlibpath_var\""
++	echo "export $shlibpath_var"
++      fi
++      $ECHO "$cmd$args"
++      exit $EXIT_SUCCESS
++    else
+       if test -n "$shlibpath_var"; then
+ 	# Export the shlibpath_var.
+ 	eval "export $shlibpath_var"
+@@ -2631,25 +4171,18 @@ func_mode_execute ()
+       done
+ 
+       # Now prepare to actually exec the command.
+-      exec_cmd="\$cmd$args"
+-    else
+-      # Display what would be done.
+-      if test -n "$shlibpath_var"; then
+-	eval "\$ECHO \"\$shlibpath_var=\$$shlibpath_var\""
+-	echo "export $shlibpath_var"
+-      fi
+-      $ECHO "$cmd$args"
+-      exit $EXIT_SUCCESS
++      exec_cmd=\$cmd$args
+     fi
+ }
+ 
+-test "$opt_mode" = execute && func_mode_execute ${1+"$@"}
++test execute = "$opt_mode" && func_mode_execute ${1+"$@"}
+ 
+ 
+ # func_mode_finish arg...
+ func_mode_finish ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     libs=
+     libdirs=
+     admincmds=
+@@ -2663,11 +4196,11 @@ func_mode_finish ()
+ 	if func_lalib_unsafe_p "$opt"; then
+ 	  func_append libs " $opt"
+ 	else
+-	  func_warning "\`$opt' is not a valid libtool archive"
++	  func_warning "'$opt' is not a valid libtool archive"
+ 	fi
+ 
+       else
+-	func_fatal_error "invalid argument \`$opt'"
++	func_fatal_error "invalid argument '$opt'"
+       fi
+     done
+ 
+@@ -2682,12 +4215,12 @@ func_mode_finish ()
+       # Remove sysroot references
+       if $opt_dry_run; then
+         for lib in $libs; do
+-          echo "removing references to $lt_sysroot and \`=' prefixes from $lib"
++          echo "removing references to $lt_sysroot and '=' prefixes from $lib"
+         done
+       else
+         tmpdir=`func_mktempdir`
+         for lib in $libs; do
+-	  sed -e "${sysroot_cmd} s/\([ ']-[LR]\)=/\1/g; s/\([ ']\)=/\1/g" $lib \
++	  $SED -e "$sysroot_cmd s/\([ ']-[LR]\)=/\1/g; s/\([ ']\)=/\1/g" $lib \
+ 	    > $tmpdir/tmp-la
+ 	  mv -f $tmpdir/tmp-la $lib
+ 	done
+@@ -2712,7 +4245,7 @@ func_mode_finish ()
+     fi
+ 
+     # Exit here if they wanted silent mode.
+-    $opt_silent && exit $EXIT_SUCCESS
++    $opt_quiet && exit $EXIT_SUCCESS
+ 
+     if test -n "$finish_cmds$finish_eval" && test -n "$libdirs"; then
+       echo "----------------------------------------------------------------------"
+@@ -2723,27 +4256,27 @@ func_mode_finish ()
+       echo
+       echo "If you ever happen to want to link against installed libraries"
+       echo "in a given directory, LIBDIR, you must either use libtool, and"
+-      echo "specify the full pathname of the library, or use the \`-LLIBDIR'"
++      echo "specify the full pathname of the library, or use the '-LLIBDIR'"
+       echo "flag during linking and do at least one of the following:"
+       if test -n "$shlibpath_var"; then
+-	echo "   - add LIBDIR to the \`$shlibpath_var' environment variable"
++	echo "   - add LIBDIR to the '$shlibpath_var' environment variable"
+ 	echo "     during execution"
+       fi
+       if test -n "$runpath_var"; then
+-	echo "   - add LIBDIR to the \`$runpath_var' environment variable"
++	echo "   - add LIBDIR to the '$runpath_var' environment variable"
+ 	echo "     during linking"
+       fi
+       if test -n "$hardcode_libdir_flag_spec"; then
+ 	libdir=LIBDIR
+ 	eval flag=\"$hardcode_libdir_flag_spec\"
+ 
+-	$ECHO "   - use the \`$flag' linker flag"
++	$ECHO "   - use the '$flag' linker flag"
+       fi
+       if test -n "$admincmds"; then
+ 	$ECHO "   - have your system administrator run these commands:$admincmds"
+       fi
+       if test -f /etc/ld.so.conf; then
+-	echo "   - have your system administrator add LIBDIR to \`/etc/ld.so.conf'"
++	echo "   - have your system administrator add LIBDIR to '/etc/ld.so.conf'"
+       fi
+       echo
+ 
+@@ -2762,21 +4295,23 @@ func_mode_finish ()
+     exit $EXIT_SUCCESS
+ }
+ 
+-test "$opt_mode" = finish && func_mode_finish ${1+"$@"}
++test finish = "$opt_mode" && func_mode_finish ${1+"$@"}
+ 
+ 
+ # func_mode_install arg...
+ func_mode_install ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     # There may be an optional sh(1) argument at the beginning of
+     # install_prog (especially on Windows NT).
+-    if test "$nonopt" = "$SHELL" || test "$nonopt" = /bin/sh ||
++    if test "$SHELL" = "$nonopt" || test /bin/sh = "$nonopt" ||
+        # Allow the use of GNU shtool's install command.
+-       case $nonopt in *shtool*) :;; *) false;; esac; then
++       case $nonopt in *shtool*) :;; *) false;; esac
++    then
+       # Aesthetically quote it.
+-      func_quote_for_eval "$nonopt"
+-      install_prog="$func_quote_for_eval_result "
++      func_quote_arg pretty "$nonopt"
++      install_prog="$func_quote_arg_result "
+       arg=$1
+       shift
+     else
+@@ -2786,8 +4321,8 @@ func_mode_install ()
+ 
+     # The real first argument should be the name of the installation program.
+     # Aesthetically quote it.
+-    func_quote_for_eval "$arg"
+-    func_append install_prog "$func_quote_for_eval_result"
++    func_quote_arg pretty "$arg"
++    func_append install_prog "$func_quote_arg_result"
+     install_shared_prog=$install_prog
+     case " $install_prog " in
+       *[\\\ /]cp\ *) install_cp=: ;;
+@@ -2800,7 +4335,7 @@ func_mode_install ()
+     opts=
+     prev=
+     install_type=
+-    isdir=no
++    isdir=false
+     stripme=
+     no_mode=:
+     for arg
+@@ -2813,7 +4348,7 @@ func_mode_install ()
+       fi
+ 
+       case $arg in
+-      -d) isdir=yes ;;
++      -d) isdir=: ;;
+       -f)
+ 	if $install_cp; then :; else
+ 	  prev=$arg
+@@ -2831,7 +4366,7 @@ func_mode_install ()
+       *)
+ 	# If the previous option needed an argument, then skip it.
+ 	if test -n "$prev"; then
+-	  if test "x$prev" = x-m && test -n "$install_override_mode"; then
++	  if test X-m = "X$prev" && test -n "$install_override_mode"; then
+ 	    arg2=$install_override_mode
+ 	    no_mode=false
+ 	  fi
+@@ -2844,24 +4379,24 @@ func_mode_install ()
+       esac
+ 
+       # Aesthetically quote the argument.
+-      func_quote_for_eval "$arg"
+-      func_append install_prog " $func_quote_for_eval_result"
++      func_quote_arg pretty "$arg"
++      func_append install_prog " $func_quote_arg_result"
+       if test -n "$arg2"; then
+-	func_quote_for_eval "$arg2"
++	func_quote_arg pretty "$arg2"
+       fi
+-      func_append install_shared_prog " $func_quote_for_eval_result"
++      func_append install_shared_prog " $func_quote_arg_result"
+     done
+ 
+     test -z "$install_prog" && \
+       func_fatal_help "you must specify an install program"
+ 
+     test -n "$prev" && \
+-      func_fatal_help "the \`$prev' option requires an argument"
++      func_fatal_help "the '$prev' option requires an argument"
+ 
+     if test -n "$install_override_mode" && $no_mode; then
+       if $install_cp; then :; else
+-	func_quote_for_eval "$install_override_mode"
+-	func_append install_shared_prog " -m $func_quote_for_eval_result"
++	func_quote_arg pretty "$install_override_mode"
++	func_append install_shared_prog " -m $func_quote_arg_result"
+       fi
+     fi
+ 
+@@ -2878,19 +4413,19 @@ func_mode_install ()
+     dest=$func_stripname_result
+ 
+     # Check to see that the destination is a directory.
+-    test -d "$dest" && isdir=yes
+-    if test "$isdir" = yes; then
+-      destdir="$dest"
++    test -d "$dest" && isdir=:
++    if $isdir; then
++      destdir=$dest
+       destname=
+     else
+       func_dirname_and_basename "$dest" "" "."
+-      destdir="$func_dirname_result"
+-      destname="$func_basename_result"
++      destdir=$func_dirname_result
++      destname=$func_basename_result
+ 
+       # Not a directory, so check to see that there is only one file specified.
+       set dummy $files; shift
+       test "$#" -gt 1 && \
+-	func_fatal_help "\`$dest' is not a directory"
++	func_fatal_help "'$dest' is not a directory"
+     fi
+     case $destdir in
+     [\\/]* | [A-Za-z]:[\\/]*) ;;
+@@ -2899,7 +4434,7 @@ func_mode_install ()
+ 	case $file in
+ 	*.lo) ;;
+ 	*)
+-	  func_fatal_help "\`$destdir' must be an absolute directory name"
++	  func_fatal_help "'$destdir' must be an absolute directory name"
+ 	  ;;
+ 	esac
+       done
+@@ -2908,7 +4443,7 @@ func_mode_install ()
+ 
+     # This variable tells wrapper scripts just to set variables rather
+     # than running their programs.
+-    libtool_install_magic="$magic"
++    libtool_install_magic=$magic
+ 
+     staticlibs=
+     future_libdirs=
+@@ -2928,7 +4463,7 @@ func_mode_install ()
+ 
+ 	# Check to see that this really is a libtool archive.
+ 	func_lalib_unsafe_p "$file" \
+-	  || func_fatal_help "\`$file' is not a valid libtool archive"
++	  || func_fatal_help "'$file' is not a valid libtool archive"
+ 
+ 	library_names=
+ 	old_library=
+@@ -2950,7 +4485,7 @@ func_mode_install ()
+ 	fi
+ 
+ 	func_dirname "$file" "/" ""
+-	dir="$func_dirname_result"
++	dir=$func_dirname_result
+ 	func_append dir "$objdir"
+ 
+ 	if test -n "$relink_command"; then
+@@ -2964,7 +4499,7 @@ func_mode_install ()
+ 	  # are installed into $libdir/../bin (currently, that works fine)
+ 	  # but it's something to keep an eye on.
+ 	  test "$inst_prefix_dir" = "$destdir" && \
+-	    func_fatal_error "error: cannot install \`$file' to a directory not ending in $libdir"
++	    func_fatal_error "error: cannot install '$file' to a directory not ending in $libdir"
+ 
+ 	  if test -n "$inst_prefix_dir"; then
+ 	    # Stick the inst_prefix_dir data into the link command.
+@@ -2973,29 +4508,36 @@ func_mode_install ()
+ 	    relink_command=`$ECHO "$relink_command" | $SED "s%@inst_prefix_dir@%%"`
+ 	  fi
+ 
+-	  func_warning "relinking \`$file'"
++	  func_warning "relinking '$file'"
+ 	  func_show_eval "$relink_command" \
+-	    'func_fatal_error "error: relink \`$file'\'' with the above command before installing it"'
++	    'func_fatal_error "error: relink '\''$file'\'' with the above command before installing it"'
+ 	fi
+ 
+ 	# See the names of the shared library.
+ 	set dummy $library_names; shift
+ 	if test -n "$1"; then
+-	  realname="$1"
++	  realname=$1
+ 	  shift
+ 
+-	  srcname="$realname"
+-	  test -n "$relink_command" && srcname="$realname"T
++	  srcname=$realname
++	  test -n "$relink_command" && srcname=${realname}T
+ 
+ 	  # Install the shared library and build the symlinks.
+ 	  func_show_eval "$install_shared_prog $dir/$srcname $destdir/$realname" \
+ 	      'exit $?'
+-	  tstripme="$stripme"
++	  tstripme=$stripme
+ 	  case $host_os in
+ 	  cygwin* | mingw* | pw32* | cegcc*)
+ 	    case $realname in
+ 	    *.dll.a)
+-	      tstripme=""
++	      tstripme=
++	      ;;
++	    esac
++	    ;;
++	  os2*)
++	    case $realname in
++	    *_dll.a)
++	      tstripme=
+ 	      ;;
+ 	    esac
+ 	    ;;
+@@ -3006,7 +4548,7 @@ func_mode_install ()
+ 
+ 	  if test "$#" -gt 0; then
+ 	    # Delete the old symlinks, and create new ones.
+-	    # Try `ln -sf' first, because the `ln' binary might depend on
++	    # Try 'ln -sf' first, because the 'ln' binary might depend on
+ 	    # the symlink we replace!  Solaris /bin/ln does not understand -f,
+ 	    # so we also need to try rm && ln -s.
+ 	    for linkname
+@@ -3017,14 +4559,14 @@ func_mode_install ()
+ 	  fi
+ 
+ 	  # Do each command in the postinstall commands.
+-	  lib="$destdir/$realname"
++	  lib=$destdir/$realname
+ 	  func_execute_cmds "$postinstall_cmds" 'exit $?'
+ 	fi
+ 
+ 	# Install the pseudo-library for information purposes.
+ 	func_basename "$file"
+-	name="$func_basename_result"
+-	instname="$dir/$name"i
++	name=$func_basename_result
++	instname=$dir/${name}i
+ 	func_show_eval "$install_prog $instname $destdir/$name" 'exit $?'
+ 
+ 	# Maybe install the static library, too.
+@@ -3036,11 +4578,11 @@ func_mode_install ()
+ 
+ 	# Figure out destination file name, if it wasn't already specified.
+ 	if test -n "$destname"; then
+-	  destfile="$destdir/$destname"
++	  destfile=$destdir/$destname
+ 	else
+ 	  func_basename "$file"
+-	  destfile="$func_basename_result"
+-	  destfile="$destdir/$destfile"
++	  destfile=$func_basename_result
++	  destfile=$destdir/$destfile
+ 	fi
+ 
+ 	# Deduce the name of the destination old-style object file.
+@@ -3050,11 +4592,11 @@ func_mode_install ()
+ 	  staticdest=$func_lo2o_result
+ 	  ;;
+ 	*.$objext)
+-	  staticdest="$destfile"
++	  staticdest=$destfile
+ 	  destfile=
+ 	  ;;
+ 	*)
+-	  func_fatal_help "cannot copy a libtool object to \`$destfile'"
++	  func_fatal_help "cannot copy a libtool object to '$destfile'"
+ 	  ;;
+ 	esac
+ 
+@@ -3063,7 +4605,7 @@ func_mode_install ()
+ 	  func_show_eval "$install_prog $file $destfile" 'exit $?'
+ 
+ 	# Install the old object if enabled.
+-	if test "$build_old_libs" = yes; then
++	if test yes = "$build_old_libs"; then
+ 	  # Deduce the name of the old-style object file.
+ 	  func_lo2o "$file"
+ 	  staticobj=$func_lo2o_result
+@@ -3075,23 +4617,23 @@ func_mode_install ()
+       *)
+ 	# Figure out destination file name, if it wasn't already specified.
+ 	if test -n "$destname"; then
+-	  destfile="$destdir/$destname"
++	  destfile=$destdir/$destname
+ 	else
+ 	  func_basename "$file"
+-	  destfile="$func_basename_result"
+-	  destfile="$destdir/$destfile"
++	  destfile=$func_basename_result
++	  destfile=$destdir/$destfile
+ 	fi
+ 
+ 	# If the file is missing, and there is a .exe on the end, strip it
+ 	# because it is most likely a libtool script we actually want to
+ 	# install
+-	stripped_ext=""
++	stripped_ext=
+ 	case $file in
+ 	  *.exe)
+ 	    if test ! -f "$file"; then
+ 	      func_stripname '' '.exe' "$file"
+ 	      file=$func_stripname_result
+-	      stripped_ext=".exe"
++	      stripped_ext=.exe
+ 	    fi
+ 	    ;;
+ 	esac
+@@ -3119,19 +4661,19 @@ func_mode_install ()
+ 
+ 	  # Check the variables that should have been set.
+ 	  test -z "$generated_by_libtool_version" && \
+-	    func_fatal_error "invalid libtool wrapper script \`$wrapper'"
++	    func_fatal_error "invalid libtool wrapper script '$wrapper'"
+ 
+-	  finalize=yes
++	  finalize=:
+ 	  for lib in $notinst_deplibs; do
+ 	    # Check to see that each library is installed.
+ 	    libdir=
+ 	    if test -f "$lib"; then
+ 	      func_source "$lib"
+ 	    fi
+-	    libfile="$libdir/"`$ECHO "$lib" | $SED 's%^.*/%%g'` ### testsuite: skip nested quoting test
++	    libfile=$libdir/`$ECHO "$lib" | $SED 's%^.*/%%g'`
+ 	    if test -n "$libdir" && test ! -f "$libfile"; then
+-	      func_warning "\`$lib' has not been installed in \`$libdir'"
+-	      finalize=no
++	      func_warning "'$lib' has not been installed in '$libdir'"
++	      finalize=false
+ 	    fi
+ 	  done
+ 
+@@ -3139,29 +4681,29 @@ func_mode_install ()
+ 	  func_source "$wrapper"
+ 
+ 	  outputname=
+-	  if test "$fast_install" = no && test -n "$relink_command"; then
++	  if test no = "$fast_install" && test -n "$relink_command"; then
+ 	    $opt_dry_run || {
+-	      if test "$finalize" = yes; then
++	      if $finalize; then
+ 	        tmpdir=`func_mktempdir`
+ 		func_basename "$file$stripped_ext"
+-		file="$func_basename_result"
+-	        outputname="$tmpdir/$file"
++		file=$func_basename_result
++	        outputname=$tmpdir/$file
+ 	        # Replace the output file specification.
+ 	        relink_command=`$ECHO "$relink_command" | $SED 's%@OUTPUT@%'"$outputname"'%g'`
+ 
+-	        $opt_silent || {
+-	          func_quote_for_expand "$relink_command"
+-		  eval "func_echo $func_quote_for_expand_result"
++	        $opt_quiet || {
++	          func_quote_arg expand,pretty "$relink_command"
++		  eval "func_echo $func_quote_arg_result"
+ 	        }
+ 	        if eval "$relink_command"; then :
+ 	          else
+-		  func_error "error: relink \`$file' with the above command before installing it"
++		  func_error "error: relink '$file' with the above command before installing it"
+ 		  $opt_dry_run || ${RM}r "$tmpdir"
+ 		  continue
+ 	        fi
+-	        file="$outputname"
++	        file=$outputname
+ 	      else
+-	        func_warning "cannot relink \`$file'"
++	        func_warning "cannot relink '$file'"
+ 	      fi
+ 	    }
+ 	  else
+@@ -3198,10 +4740,10 @@ func_mode_install ()
+ 
+     for file in $staticlibs; do
+       func_basename "$file"
+-      name="$func_basename_result"
++      name=$func_basename_result
+ 
+       # Set up the ranlib parameters.
+-      oldlib="$destdir/$name"
++      oldlib=$destdir/$name
+       func_to_tool_file "$oldlib" func_convert_file_msys_to_w32
+       tool_oldlib=$func_to_tool_file_result
+ 
+@@ -3216,18 +4758,18 @@ func_mode_install ()
+     done
+ 
+     test -n "$future_libdirs" && \
+-      func_warning "remember to run \`$progname --finish$future_libdirs'"
++      func_warning "remember to run '$progname --finish$future_libdirs'"
+ 
+     if test -n "$current_libdirs"; then
+       # Maybe just do a dry run.
+       $opt_dry_run && current_libdirs=" -n$current_libdirs"
+-      exec_cmd='$SHELL $progpath $preserve_args --finish$current_libdirs'
++      exec_cmd='$SHELL "$progpath" $preserve_args --finish$current_libdirs'
+     else
+       exit $EXIT_SUCCESS
+     fi
+ }
+ 
+-test "$opt_mode" = install && func_mode_install ${1+"$@"}
++test install = "$opt_mode" && func_mode_install ${1+"$@"}
+ 
+ 
+ # func_generate_dlsyms outputname originator pic_p
+@@ -3235,16 +4777,17 @@ test "$opt_mode" = install && func_mode_install ${1+"$@"}
+ # a dlpreopen symbol table.
+ func_generate_dlsyms ()
+ {
+-    $opt_debug
+-    my_outputname="$1"
+-    my_originator="$2"
+-    my_pic_p="${3-no}"
+-    my_prefix=`$ECHO "$my_originator" | sed 's%[^a-zA-Z0-9]%_%g'`
++    $debug_cmd
++
++    my_outputname=$1
++    my_originator=$2
++    my_pic_p=${3-false}
++    my_prefix=`$ECHO "$my_originator" | $SED 's%[^a-zA-Z0-9]%_%g'`
+     my_dlsyms=
+ 
+-    if test -n "$dlfiles$dlprefiles" || test "$dlself" != no; then
++    if test -n "$dlfiles$dlprefiles" || test no != "$dlself"; then
+       if test -n "$NM" && test -n "$global_symbol_pipe"; then
+-	my_dlsyms="${my_outputname}S.c"
++	my_dlsyms=${my_outputname}S.c
+       else
+ 	func_error "not configured to extract global symbols from dlpreopened files"
+       fi
+@@ -3255,7 +4798,7 @@ func_generate_dlsyms ()
+       "") ;;
+       *.c)
+ 	# Discover the nlist of each of the dlfiles.
+-	nlist="$output_objdir/${my_outputname}.nm"
++	nlist=$output_objdir/$my_outputname.nm
+ 
+ 	func_show_eval "$RM $nlist ${nlist}S ${nlist}T"
+ 
+@@ -3263,34 +4806,36 @@ func_generate_dlsyms ()
+ 	func_verbose "creating $output_objdir/$my_dlsyms"
+ 
+ 	$opt_dry_run || $ECHO > "$output_objdir/$my_dlsyms" "\
+-/* $my_dlsyms - symbol resolution table for \`$my_outputname' dlsym emulation. */
+-/* Generated by $PROGRAM (GNU $PACKAGE$TIMESTAMP) $VERSION */
++/* $my_dlsyms - symbol resolution table for '$my_outputname' dlsym emulation. */
++/* Generated by $PROGRAM (GNU $PACKAGE) $VERSION */
+ 
+ #ifdef __cplusplus
+ extern \"C\" {
+ #endif
+ 
+-#if defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)) || (__GNUC__ > 4))
++#if defined __GNUC__ && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)) || (__GNUC__ > 4))
+ #pragma GCC diagnostic ignored \"-Wstrict-prototypes\"
+ #endif
+ 
+ /* Keep this code in sync between libtool.m4, ltmain, lt_system.h, and tests.  */
+-#if defined(_WIN32) || defined(__CYGWIN__) || defined(_WIN32_WCE)
+-/* DATA imports from DLLs on WIN32 con't be const, because runtime
++#if defined _WIN32 || defined __CYGWIN__ || defined _WIN32_WCE
++/* DATA imports from DLLs on WIN32 can't be const, because runtime
+    relocations are performed -- see ld's documentation on pseudo-relocs.  */
+ # define LT_DLSYM_CONST
+-#elif defined(__osf__)
++#elif defined __osf__
+ /* This system does not cope well with relocations in const data.  */
+ # define LT_DLSYM_CONST
+ #else
+ # define LT_DLSYM_CONST const
+ #endif
+ 
++#define STREQ(s1, s2) (strcmp ((s1), (s2)) == 0)
++
+ /* External symbol declarations for the compiler. */\
+ "
+ 
+-	if test "$dlself" = yes; then
+-	  func_verbose "generating symbol list for \`$output'"
++	if test yes = "$dlself"; then
++	  func_verbose "generating symbol list for '$output'"
+ 
+ 	  $opt_dry_run || echo ': @PROGRAM@ ' > "$nlist"
+ 
+@@ -3298,7 +4843,7 @@ extern \"C\" {
+ 	  progfiles=`$ECHO "$objs$old_deplibs" | $SP2NL | $SED "$lo2o" | $NL2SP`
+ 	  for progfile in $progfiles; do
+ 	    func_to_tool_file "$progfile" func_convert_file_msys_to_w32
+-	    func_verbose "extracting global C symbols from \`$func_to_tool_file_result'"
++	    func_verbose "extracting global C symbols from '$func_to_tool_file_result'"
+ 	    $opt_dry_run || eval "$NM $func_to_tool_file_result | $global_symbol_pipe >> '$nlist'"
+ 	  done
+ 
+@@ -3318,10 +4863,10 @@ extern \"C\" {
+ 
+ 	  # Prepare the list of exported symbols
+ 	  if test -z "$export_symbols"; then
+-	    export_symbols="$output_objdir/$outputname.exp"
++	    export_symbols=$output_objdir/$outputname.exp
+ 	    $opt_dry_run || {
+ 	      $RM $export_symbols
+-	      eval "${SED} -n -e '/^: @PROGRAM@ $/d' -e 's/^.* \(.*\)$/\1/p' "'< "$nlist" > "$export_symbols"'
++	      eval "$SED -n -e '/^: @PROGRAM@ $/d' -e 's/^.* \(.*\)$/\1/p' "'< "$nlist" > "$export_symbols"'
+ 	      case $host in
+ 	      *cygwin* | *mingw* | *cegcc* )
+                 eval "echo EXPORTS "'> "$output_objdir/$outputname.def"'
+@@ -3331,7 +4876,7 @@ extern \"C\" {
+ 	    }
+ 	  else
+ 	    $opt_dry_run || {
+-	      eval "${SED} -e 's/\([].[*^$]\)/\\\\\1/g' -e 's/^/ /' -e 's/$/$/'"' < "$export_symbols" > "$output_objdir/$outputname.exp"'
++	      eval "$SED -e 's/\([].[*^$]\)/\\\\\1/g' -e 's/^/ /' -e 's/$/$/'"' < "$export_symbols" > "$output_objdir/$outputname.exp"'
+ 	      eval '$GREP -f "$output_objdir/$outputname.exp" < "$nlist" > "$nlist"T'
+ 	      eval '$MV "$nlist"T "$nlist"'
+ 	      case $host in
+@@ -3345,22 +4890,22 @@ extern \"C\" {
+ 	fi
+ 
+ 	for dlprefile in $dlprefiles; do
+-	  func_verbose "extracting global C symbols from \`$dlprefile'"
++	  func_verbose "extracting global C symbols from '$dlprefile'"
+ 	  func_basename "$dlprefile"
+-	  name="$func_basename_result"
++	  name=$func_basename_result
+           case $host in
+ 	    *cygwin* | *mingw* | *cegcc* )
+ 	      # if an import library, we need to obtain dlname
+ 	      if func_win32_import_lib_p "$dlprefile"; then
+ 	        func_tr_sh "$dlprefile"
+ 	        eval "curr_lafile=\$libfile_$func_tr_sh_result"
+-	        dlprefile_dlbasename=""
++	        dlprefile_dlbasename=
+ 	        if test -n "$curr_lafile" && func_lalib_p "$curr_lafile"; then
+ 	          # Use subshell, to avoid clobbering current variable values
+ 	          dlprefile_dlname=`source "$curr_lafile" && echo "$dlname"`
+-	          if test -n "$dlprefile_dlname" ; then
++	          if test -n "$dlprefile_dlname"; then
+ 	            func_basename "$dlprefile_dlname"
+-	            dlprefile_dlbasename="$func_basename_result"
++	            dlprefile_dlbasename=$func_basename_result
+ 	          else
+ 	            # no lafile. user explicitly requested -dlpreopen <import library>.
+ 	            $sharedlib_from_linklib_cmd "$dlprefile"
+@@ -3368,7 +4913,7 @@ extern \"C\" {
+ 	          fi
+ 	        fi
+ 	        $opt_dry_run || {
+-	          if test -n "$dlprefile_dlbasename" ; then
++	          if test -n "$dlprefile_dlbasename"; then
+ 	            eval '$ECHO ": $dlprefile_dlbasename" >> "$nlist"'
+ 	          else
+ 	            func_warning "Could not compute DLL name from $name"
+@@ -3424,6 +4969,11 @@ extern \"C\" {
+ 	    echo '/* NONE */' >> "$output_objdir/$my_dlsyms"
+ 	  fi
+ 
++	  func_show_eval '$RM "${nlist}I"'
++	  if test -n "$global_symbol_to_import"; then
++	    eval "$global_symbol_to_import"' < "$nlist"S > "$nlist"I'
++	  fi
++
+ 	  echo >> "$output_objdir/$my_dlsyms" "\
+ 
+ /* The mapping between symbol names and symbols.  */
+@@ -3432,11 +4982,30 @@ typedef struct {
+   void *address;
+ } lt_dlsymlist;
+ extern LT_DLSYM_CONST lt_dlsymlist
+-lt_${my_prefix}_LTX_preloaded_symbols[];
++lt_${my_prefix}_LTX_preloaded_symbols[];\
++"
++
++	  if test -s "$nlist"I; then
++	    echo >> "$output_objdir/$my_dlsyms" "\
++static void lt_syminit(void)
++{
++  LT_DLSYM_CONST lt_dlsymlist *symbol = lt_${my_prefix}_LTX_preloaded_symbols;
++  for (; symbol->name; ++symbol)
++    {"
++	    $SED 's/.*/      if (STREQ (symbol->name, \"&\")) symbol->address = (void *) \&&;/' < "$nlist"I >> "$output_objdir/$my_dlsyms"
++	    echo >> "$output_objdir/$my_dlsyms" "\
++    }
++}"
++	  fi
++	  echo >> "$output_objdir/$my_dlsyms" "\
+ LT_DLSYM_CONST lt_dlsymlist
+ lt_${my_prefix}_LTX_preloaded_symbols[] =
+-{\
+-  { \"$my_originator\", (void *) 0 },"
++{ {\"$my_originator\", (void *) 0},"
++
++	  if test -s "$nlist"I; then
++	    echo >> "$output_objdir/$my_dlsyms" "\
++  {\"@INIT@\", (void *) &lt_syminit},"
++	  fi
+ 
+ 	  case $need_lib_prefix in
+ 	  no)
+@@ -3478,9 +5047,7 @@ static const void *lt_preloaded_setup() {
+ 	  *-*-hpux*)
+ 	    pic_flag_for_symtable=" $pic_flag"  ;;
+ 	  *)
+-	    if test "X$my_pic_p" != Xno; then
+-	      pic_flag_for_symtable=" $pic_flag"
+-	    fi
++	    $my_pic_p && pic_flag_for_symtable=" $pic_flag"
+ 	    ;;
+ 	  esac
+ 	  ;;
+@@ -3497,10 +5064,10 @@ static const void *lt_preloaded_setup() {
+ 	func_show_eval '(cd $output_objdir && $LTCC$symtab_cflags -c$no_builtin_flag$pic_flag_for_symtable "$my_dlsyms")' 'exit $?'
+ 
+ 	# Clean up the generated files.
+-	func_show_eval '$RM "$output_objdir/$my_dlsyms" "$nlist" "${nlist}S" "${nlist}T"'
++	func_show_eval '$RM "$output_objdir/$my_dlsyms" "$nlist" "${nlist}S" "${nlist}T" "${nlist}I"'
+ 
+ 	# Transform the symbol file into the correct name.
+-	symfileobj="$output_objdir/${my_outputname}S.$objext"
++	symfileobj=$output_objdir/${my_outputname}S.$objext
+ 	case $host in
+ 	*cygwin* | *mingw* | *cegcc* )
+ 	  if test -f "$output_objdir/$my_outputname.def"; then
+@@ -3518,7 +5085,7 @@ static const void *lt_preloaded_setup() {
+ 	esac
+ 	;;
+       *)
+-	func_fatal_error "unknown suffix for \`$my_dlsyms'"
++	func_fatal_error "unknown suffix for '$my_dlsyms'"
+ 	;;
+       esac
+     else
+@@ -3532,6 +5099,32 @@ static const void *lt_preloaded_setup() {
+     fi
+ }
+ 
++# func_cygming_gnu_implib_p ARG
++# This predicate returns with zero status (TRUE) if
++# ARG is a GNU/binutils-style import library. Returns
++# with nonzero status (FALSE) otherwise.
++func_cygming_gnu_implib_p ()
++{
++  $debug_cmd
++
++  func_to_tool_file "$1" func_convert_file_msys_to_w32
++  func_cygming_gnu_implib_tmp=`$NM "$func_to_tool_file_result" | eval "$global_symbol_pipe" | $EGREP ' (_head_[A-Za-z0-9_]+_[ad]l*|[A-Za-z0-9_]+_[ad]l*_iname)$'`
++  test -n "$func_cygming_gnu_implib_tmp"
++}
++
++# func_cygming_ms_implib_p ARG
++# This predicate returns with zero status (TRUE) if
++# ARG is an MS-style import library. Returns
++# with nonzero status (FALSE) otherwise.
++func_cygming_ms_implib_p ()
++{
++  $debug_cmd
++
++  func_to_tool_file "$1" func_convert_file_msys_to_w32
++  func_cygming_ms_implib_tmp=`$NM "$func_to_tool_file_result" | eval "$global_symbol_pipe" | $GREP '_NULL_IMPORT_DESCRIPTOR'`
++  test -n "$func_cygming_ms_implib_tmp"
++}
++
+ # func_win32_libid arg
+ # return the library type of file 'arg'
+ #
+@@ -3541,8 +5134,9 @@ static const void *lt_preloaded_setup() {
+ # Despite the name, also deal with 64 bit binaries.
+ func_win32_libid ()
+ {
+-  $opt_debug
+-  win32_libid_type="unknown"
++  $debug_cmd
++
++  win32_libid_type=unknown
+   win32_fileres=`file -L $1 2>/dev/null`
+   case $win32_fileres in
+   *ar\ archive\ import\ library*) # definitely import
+@@ -3552,16 +5146,29 @@ func_win32_libid ()
+     # Keep the egrep pattern in sync with the one in _LT_CHECK_MAGIC_METHOD.
+     if eval $OBJDUMP -f $1 | $SED -e '10q' 2>/dev/null |
+        $EGREP 'file format (pei*-i386(.*architecture: i386)?|pe-arm-wince|pe-x86-64)' >/dev/null; then
+-      func_to_tool_file "$1" func_convert_file_msys_to_w32
+-      win32_nmres=`eval $NM -f posix -A \"$func_to_tool_file_result\" |
+-	$SED -n -e '
++      case $nm_interface in
++      "MS dumpbin")
++	if func_cygming_ms_implib_p "$1" ||
++	   func_cygming_gnu_implib_p "$1"
++	then
++	  win32_nmres=import
++	else
++	  win32_nmres=
++	fi
++	;;
++      *)
++	func_to_tool_file "$1" func_convert_file_msys_to_w32
++	win32_nmres=`eval $NM -f posix -A \"$func_to_tool_file_result\" |
++	  $SED -n -e '
+ 	    1,100{
+ 		/ I /{
+-		    s,.*,import,
++		    s|.*|import|
+ 		    p
+ 		    q
+ 		}
+ 	    }'`
++	;;
++      esac
+       case $win32_nmres in
+       import*)  win32_libid_type="x86 archive import";;
+       *)        win32_libid_type="x86 archive static";;
+@@ -3593,7 +5200,8 @@ func_win32_libid ()
+ #    $sharedlib_from_linklib_result
+ func_cygming_dll_for_implib ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   sharedlib_from_linklib_result=`$DLLTOOL --identify-strict --identify "$1"`
+ }
+ 
+@@ -3610,7 +5218,8 @@ func_cygming_dll_for_implib ()
+ # specified import library.
+ func_cygming_dll_for_implib_fallback_core ()
+ {
+-  $opt_debug
++  $debug_cmd
++
+   match_literal=`$ECHO "$1" | $SED "$sed_make_literal_regex"`
+   $OBJDUMP -s --section "$1" "$2" 2>/dev/null |
+     $SED '/^Contents of section '"$match_literal"':/{
+@@ -3646,8 +5255,8 @@ func_cygming_dll_for_implib_fallback_core ()
+       /./p' |
+     # we now have a list, one entry per line, of the stringified
+     # contents of the appropriate section of all members of the
+-    # archive which possess that section. Heuristic: eliminate
+-    # all those which have a first or second character that is
++    # archive that possess that section. Heuristic: eliminate
++    # all those that have a first or second character that is
+     # a '.' (that is, objdump's representation of an unprintable
+     # character.) This should work for all archives with less than
+     # 0x302f exports -- but will fail for DLLs whose name actually
+@@ -3658,30 +5267,6 @@ func_cygming_dll_for_implib_fallback_core ()
+     $SED -e '/^\./d;/^.\./d;q'
+ }
+ 
+-# func_cygming_gnu_implib_p ARG
+-# This predicate returns with zero status (TRUE) if
+-# ARG is a GNU/binutils-style import library. Returns
+-# with nonzero status (FALSE) otherwise.
+-func_cygming_gnu_implib_p ()
+-{
+-  $opt_debug
+-  func_to_tool_file "$1" func_convert_file_msys_to_w32
+-  func_cygming_gnu_implib_tmp=`$NM "$func_to_tool_file_result" | eval "$global_symbol_pipe" | $EGREP ' (_head_[A-Za-z0-9_]+_[ad]l*|[A-Za-z0-9_]+_[ad]l*_iname)$'`
+-  test -n "$func_cygming_gnu_implib_tmp"
+-}
+-
+-# func_cygming_ms_implib_p ARG
+-# This predicate returns with zero status (TRUE) if
+-# ARG is an MS-style import library. Returns
+-# with nonzero status (FALSE) otherwise.
+-func_cygming_ms_implib_p ()
+-{
+-  $opt_debug
+-  func_to_tool_file "$1" func_convert_file_msys_to_w32
+-  func_cygming_ms_implib_tmp=`$NM "$func_to_tool_file_result" | eval "$global_symbol_pipe" | $GREP '_NULL_IMPORT_DESCRIPTOR'`
+-  test -n "$func_cygming_ms_implib_tmp"
+-}
+-
+ # func_cygming_dll_for_implib_fallback ARG
+ # Platform-specific function to extract the
+ # name of the DLL associated with the specified
+@@ -3695,16 +5280,17 @@ func_cygming_ms_implib_p ()
+ #    $sharedlib_from_linklib_result
+ func_cygming_dll_for_implib_fallback ()
+ {
+-  $opt_debug
+-  if func_cygming_gnu_implib_p "$1" ; then
++  $debug_cmd
++
++  if func_cygming_gnu_implib_p "$1"; then
+     # binutils import library
+     sharedlib_from_linklib_result=`func_cygming_dll_for_implib_fallback_core '.idata$7' "$1"`
+-  elif func_cygming_ms_implib_p "$1" ; then
++  elif func_cygming_ms_implib_p "$1"; then
+     # ms-generated import library
+     sharedlib_from_linklib_result=`func_cygming_dll_for_implib_fallback_core '.idata$6' "$1"`
+   else
+     # unknown
+-    sharedlib_from_linklib_result=""
++    sharedlib_from_linklib_result=
+   fi
+ }
+ 
+@@ -3712,10 +5298,11 @@ func_cygming_dll_for_implib_fallback ()
+ # func_extract_an_archive dir oldlib
+ func_extract_an_archive ()
+ {
+-    $opt_debug
+-    f_ex_an_ar_dir="$1"; shift
+-    f_ex_an_ar_oldlib="$1"
+-    if test "$lock_old_archive_extraction" = yes; then
++    $debug_cmd
++
++    f_ex_an_ar_dir=$1; shift
++    f_ex_an_ar_oldlib=$1
++    if test yes = "$lock_old_archive_extraction"; then
+       lockfile=$f_ex_an_ar_oldlib.lock
+       until $opt_dry_run || ln "$progpath" "$lockfile" 2>/dev/null; do
+ 	func_echo "Waiting for $lockfile to be removed"
+@@ -3724,7 +5311,7 @@ func_extract_an_archive ()
+     fi
+     func_show_eval "(cd \$f_ex_an_ar_dir && $AR x \"\$f_ex_an_ar_oldlib\")" \
+ 		   'stat=$?; rm -f "$lockfile"; exit $stat'
+-    if test "$lock_old_archive_extraction" = yes; then
++    if test yes = "$lock_old_archive_extraction"; then
+       $opt_dry_run || rm -f "$lockfile"
+     fi
+     if ($AR t "$f_ex_an_ar_oldlib" | sort | sort -uc >/dev/null 2>&1); then
+@@ -3738,22 +5325,23 @@ func_extract_an_archive ()
+ # func_extract_archives gentop oldlib ...
+ func_extract_archives ()
+ {
+-    $opt_debug
+-    my_gentop="$1"; shift
++    $debug_cmd
++
++    my_gentop=$1; shift
+     my_oldlibs=${1+"$@"}
+-    my_oldobjs=""
+-    my_xlib=""
+-    my_xabs=""
+-    my_xdir=""
++    my_oldobjs=
++    my_xlib=
++    my_xabs=
++    my_xdir=
+ 
+     for my_xlib in $my_oldlibs; do
+       # Extract the objects.
+       case $my_xlib in
+-	[\\/]* | [A-Za-z]:[\\/]*) my_xabs="$my_xlib" ;;
++	[\\/]* | [A-Za-z]:[\\/]*) my_xabs=$my_xlib ;;
+ 	*) my_xabs=`pwd`"/$my_xlib" ;;
+       esac
+       func_basename "$my_xlib"
+-      my_xlib="$func_basename_result"
++      my_xlib=$func_basename_result
+       my_xlib_u=$my_xlib
+       while :; do
+         case " $extracted_archives " in
+@@ -3765,7 +5353,7 @@ func_extract_archives ()
+ 	esac
+       done
+       extracted_archives="$extracted_archives $my_xlib_u"
+-      my_xdir="$my_gentop/$my_xlib_u"
++      my_xdir=$my_gentop/$my_xlib_u
+ 
+       func_mkdir_p "$my_xdir"
+ 
+@@ -3778,22 +5366,23 @@ func_extract_archives ()
+ 	  cd $my_xdir || exit $?
+ 	  darwin_archive=$my_xabs
+ 	  darwin_curdir=`pwd`
+-	  darwin_base_archive=`basename "$darwin_archive"`
++	  func_basename "$darwin_archive"
++	  darwin_base_archive=$func_basename_result
+ 	  darwin_arches=`$LIPO -info "$darwin_archive" 2>/dev/null | $GREP Architectures 2>/dev/null || true`
+ 	  if test -n "$darwin_arches"; then
+ 	    darwin_arches=`$ECHO "$darwin_arches" | $SED -e 's/.*are://'`
+ 	    darwin_arch=
+ 	    func_verbose "$darwin_base_archive has multiple architectures $darwin_arches"
+-	    for darwin_arch in  $darwin_arches ; do
+-	      func_mkdir_p "unfat-$$/${darwin_base_archive}-${darwin_arch}"
+-	      $LIPO -thin $darwin_arch -output "unfat-$$/${darwin_base_archive}-${darwin_arch}/${darwin_base_archive}" "${darwin_archive}"
+-	      cd "unfat-$$/${darwin_base_archive}-${darwin_arch}"
+-	      func_extract_an_archive "`pwd`" "${darwin_base_archive}"
++	    for darwin_arch in  $darwin_arches; do
++	      func_mkdir_p "unfat-$$/$darwin_base_archive-$darwin_arch"
++	      $LIPO -thin $darwin_arch -output "unfat-$$/$darwin_base_archive-$darwin_arch/$darwin_base_archive" "$darwin_archive"
++	      cd "unfat-$$/$darwin_base_archive-$darwin_arch"
++	      func_extract_an_archive "`pwd`" "$darwin_base_archive"
+ 	      cd "$darwin_curdir"
+-	      $RM "unfat-$$/${darwin_base_archive}-${darwin_arch}/${darwin_base_archive}"
++	      $RM "unfat-$$/$darwin_base_archive-$darwin_arch/$darwin_base_archive"
+ 	    done # $darwin_arches
+             ## Okay now we've a bunch of thin objects, gotta fatten them up :)
+-	    darwin_filelist=`find unfat-$$ -type f -name \*.o -print -o -name \*.lo -print | $SED -e "$basename" | sort -u`
++	    darwin_filelist=`find unfat-$$ -type f -name \*.o -print -o -name \*.lo -print | $SED -e "$sed_basename" | sort -u`
+ 	    darwin_file=
+ 	    darwin_files=
+ 	    for darwin_file in $darwin_filelist; do
+@@ -3815,7 +5404,7 @@ func_extract_archives ()
+       my_oldobjs="$my_oldobjs "`find $my_xdir -name \*.$objext -print -o -name \*.lo -print | sort | $NL2SP`
+     done
+ 
+-    func_extract_archives_result="$my_oldobjs"
++    func_extract_archives_result=$my_oldobjs
+ }
+ 
+ 
+@@ -3830,7 +5419,7 @@ func_extract_archives ()
+ #
+ # ARG is the value that the WRAPPER_SCRIPT_BELONGS_IN_OBJDIR
+ # variable will take.  If 'yes', then the emitted script
+-# will assume that the directory in which it is stored is
++# will assume that the directory where it is stored is
+ # the $objdir directory.  This is a cygwin/mingw-specific
+ # behavior.
+ func_emit_wrapper ()
+@@ -3841,7 +5430,7 @@ func_emit_wrapper ()
+ #! $SHELL
+ 
+ # $output - temporary wrapper script for $objdir/$outputname
+-# Generated by $PROGRAM (GNU $PACKAGE$TIMESTAMP) $VERSION
++# Generated by $PROGRAM (GNU $PACKAGE) $VERSION
+ #
+ # The $output program cannot be directly executed until all the libtool
+ # libraries that it depends on are installed.
+@@ -3883,7 +5472,8 @@ else
+   if test \"\$libtool_execute_magic\" != \"$magic\"; then
+     file=\"\$0\""
+ 
+-    qECHO=`$ECHO "$ECHO" | $SED "$sed_quote_subst"`
++    func_quote_arg pretty "$ECHO"
++    qECHO=$func_quote_arg_result
+     $ECHO "\
+ 
+ # A function that is used when there is no print builtin or printf.
+@@ -3893,14 +5483,14 @@ func_fallback_echo ()
+ \$1
+ _LTECHO_EOF'
+ }
+-    ECHO=\"$qECHO\"
++    ECHO=$qECHO
+   fi
+ 
+ # Very basic option parsing. These options are (a) specific to
+ # the libtool wrapper, (b) are identical between the wrapper
+-# /script/ and the wrapper /executable/ which is used only on
++# /script/ and the wrapper /executable/ that is used only on
+ # windows platforms, and (c) all begin with the string "--lt-"
+-# (application programs are unlikely to have options which match
++# (application programs are unlikely to have options that match
+ # this pattern).
+ #
+ # There are only two supported options: --lt-debug and
+@@ -3933,7 +5523,7 @@ func_parse_lt_options ()
+ 
+   # Print the debug banner immediately:
+   if test -n \"\$lt_option_debug\"; then
+-    echo \"${outputname}:${output}:\${LINENO}: libtool wrapper (GNU $PACKAGE$TIMESTAMP) $VERSION\" 1>&2
++    echo \"$outputname:$output:\$LINENO: libtool wrapper (GNU $PACKAGE) $VERSION\" 1>&2
+   fi
+ }
+ 
+@@ -3944,7 +5534,7 @@ func_lt_dump_args ()
+   lt_dump_args_N=1;
+   for lt_arg
+   do
+-    \$ECHO \"${outputname}:${output}:\${LINENO}: newargv[\$lt_dump_args_N]: \$lt_arg\"
++    \$ECHO \"$outputname:$output:\$LINENO: newargv[\$lt_dump_args_N]: \$lt_arg\"
+     lt_dump_args_N=\`expr \$lt_dump_args_N + 1\`
+   done
+ }
+@@ -3958,7 +5548,7 @@ func_exec_program_core ()
+   *-*-mingw | *-*-os2* | *-cegcc*)
+     $ECHO "\
+       if test -n \"\$lt_option_debug\"; then
+-        \$ECHO \"${outputname}:${output}:\${LINENO}: newargv[0]: \$progdir\\\\\$program\" 1>&2
++        \$ECHO \"$outputname:$output:\$LINENO: newargv[0]: \$progdir\\\\\$program\" 1>&2
+         func_lt_dump_args \${1+\"\$@\"} 1>&2
+       fi
+       exec \"\$progdir\\\\\$program\" \${1+\"\$@\"}
+@@ -3968,7 +5558,7 @@ func_exec_program_core ()
+   *)
+     $ECHO "\
+       if test -n \"\$lt_option_debug\"; then
+-        \$ECHO \"${outputname}:${output}:\${LINENO}: newargv[0]: \$progdir/\$program\" 1>&2
++        \$ECHO \"$outputname:$output:\$LINENO: newargv[0]: \$progdir/\$program\" 1>&2
+         func_lt_dump_args \${1+\"\$@\"} 1>&2
+       fi
+       exec \"\$progdir/\$program\" \${1+\"\$@\"}
+@@ -4043,13 +5633,13 @@ func_exec_program ()
+   test -n \"\$absdir\" && thisdir=\"\$absdir\"
+ "
+ 
+-	if test "$fast_install" = yes; then
++	if test yes = "$fast_install"; then
+ 	  $ECHO "\
+   program=lt-'$outputname'$exeext
+   progdir=\"\$thisdir/$objdir\"
+ 
+   if test ! -f \"\$progdir/\$program\" ||
+-     { file=\`ls -1dt \"\$progdir/\$program\" \"\$progdir/../\$program\" 2>/dev/null | ${SED} 1q\`; \\
++     { file=\`ls -1dt \"\$progdir/\$program\" \"\$progdir/../\$program\" 2>/dev/null | $SED 1q\`; \\
+        test \"X\$file\" != \"X\$progdir/\$program\"; }; then
+ 
+     file=\"\$\$-\$program\"
+@@ -4066,7 +5656,7 @@ func_exec_program ()
+     if test -n \"\$relink_command\"; then
+       if relink_command_output=\`eval \$relink_command 2>&1\`; then :
+       else
+-	$ECHO \"\$relink_command_output\" >&2
++	\$ECHO \"\$relink_command_output\" >&2
+ 	$RM \"\$progdir/\$file\"
+ 	exit 1
+       fi
+@@ -4101,7 +5691,7 @@ func_exec_program ()
+ 	fi
+ 
+ 	# Export our shlibpath_var if we have one.
+-	if test "$shlibpath_overrides_runpath" = yes && test -n "$shlibpath_var" && test -n "$temp_rpath"; then
++	if test yes = "$shlibpath_overrides_runpath" && test -n "$shlibpath_var" && test -n "$temp_rpath"; then
+ 	  $ECHO "\
+     # Add our own library path to $shlibpath_var
+     $shlibpath_var=\"$temp_rpath\$$shlibpath_var\"
+@@ -4121,7 +5711,7 @@ func_exec_program ()
+     fi
+   else
+     # The program doesn't exist.
+-    \$ECHO \"\$0: error: \\\`\$progdir/\$program' does not exist\" 1>&2
++    \$ECHO \"\$0: error: '\$progdir/\$program' does not exist\" 1>&2
+     \$ECHO \"This script is just a wrapper for \$program.\" 1>&2
+     \$ECHO \"See the $PACKAGE documentation for more information.\" 1>&2
+     exit 1
+@@ -4140,7 +5730,7 @@ func_emit_cwrapperexe_src ()
+ 	cat <<EOF
+ 
+ /* $cwrappersource - temporary wrapper executable for $objdir/$outputname
+-   Generated by $PROGRAM (GNU $PACKAGE$TIMESTAMP) $VERSION
++   Generated by $PROGRAM (GNU $PACKAGE) $VERSION
+ 
+    The $output program cannot be directly executed until all the libtool
+    libraries that it depends on are installed.
+@@ -4175,47 +5765,45 @@ EOF
+ #include <fcntl.h>
+ #include <sys/stat.h>
+ 
++#define STREQ(s1, s2) (strcmp ((s1), (s2)) == 0)
++
+ /* declarations of non-ANSI functions */
+-#if defined(__MINGW32__)
++#if defined __MINGW32__
+ # ifdef __STRICT_ANSI__
+ int _putenv (const char *);
+ # endif
+-#elif defined(__CYGWIN__)
++#elif defined __CYGWIN__
+ # ifdef __STRICT_ANSI__
+ char *realpath (const char *, char *);
+ int putenv (char *);
+ int setenv (const char *, const char *, int);
+ # endif
+-/* #elif defined (other platforms) ... */
++/* #elif defined other_platform || defined ... */
+ #endif
+ 
+ /* portability defines, excluding path handling macros */
+-#if defined(_MSC_VER)
++#if defined _MSC_VER
+ # define setmode _setmode
+ # define stat    _stat
+ # define chmod   _chmod
+ # define getcwd  _getcwd
+ # define putenv  _putenv
+ # define S_IXUSR _S_IEXEC
+-# ifndef _INTPTR_T_DEFINED
+-#  define _INTPTR_T_DEFINED
+-#  define intptr_t int
+-# endif
+-#elif defined(__MINGW32__)
++#elif defined __MINGW32__
+ # define setmode _setmode
+ # define stat    _stat
+ # define chmod   _chmod
+ # define getcwd  _getcwd
+ # define putenv  _putenv
+-#elif defined(__CYGWIN__)
++#elif defined __CYGWIN__
+ # define HAVE_SETENV
+ # define FOPEN_WB "wb"
+-/* #elif defined (other platforms) ... */
++/* #elif defined other platforms ... */
+ #endif
+ 
+-#if defined(PATH_MAX)
++#if defined PATH_MAX
+ # define LT_PATHMAX PATH_MAX
+-#elif defined(MAXPATHLEN)
++#elif defined MAXPATHLEN
+ # define LT_PATHMAX MAXPATHLEN
+ #else
+ # define LT_PATHMAX 1024
+@@ -4234,8 +5822,8 @@ int setenv (const char *, const char *, int);
+ # define PATH_SEPARATOR ':'
+ #endif
+ 
+-#if defined (_WIN32) || defined (__MSDOS__) || defined (__DJGPP__) || \
+-  defined (__OS2__)
++#if defined _WIN32 || defined __MSDOS__ || defined __DJGPP__ || \
++  defined __OS2__
+ # define HAVE_DOS_BASED_FILE_SYSTEM
+ # define FOPEN_WB "wb"
+ # ifndef DIR_SEPARATOR_2
+@@ -4268,10 +5856,10 @@ int setenv (const char *, const char *, int);
+ 
+ #define XMALLOC(type, num)      ((type *) xmalloc ((num) * sizeof(type)))
+ #define XFREE(stale) do { \
+-  if (stale) { free ((void *) stale); stale = 0; } \
++  if (stale) { free (stale); stale = 0; } \
+ } while (0)
+ 
+-#if defined(LT_DEBUGWRAPPER)
++#if defined LT_DEBUGWRAPPER
+ static int lt_debug = 1;
+ #else
+ static int lt_debug = 0;
+@@ -4300,11 +5888,16 @@ void lt_dump_script (FILE *f);
+ EOF
+ 
+ 	    cat <<EOF
+-volatile const char * MAGIC_EXE = "$magic_exe";
++#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)
++# define externally_visible volatile
++#else
++# define externally_visible __attribute__((externally_visible)) volatile
++#endif
++externally_visible const char * MAGIC_EXE = "$magic_exe";
+ const char * LIB_PATH_VARNAME = "$shlibpath_var";
+ EOF
+ 
+-	    if test "$shlibpath_overrides_runpath" = yes && test -n "$shlibpath_var" && test -n "$temp_rpath"; then
++	    if test yes = "$shlibpath_overrides_runpath" && test -n "$shlibpath_var" && test -n "$temp_rpath"; then
+               func_to_host_path "$temp_rpath"
+ 	      cat <<EOF
+ const char * LIB_PATH_VALUE   = "$func_to_host_path_result";
+@@ -4328,7 +5921,7 @@ const char * EXE_PATH_VALUE   = "";
+ EOF
+ 	    fi
+ 
+-	    if test "$fast_install" = yes; then
++	    if test yes = "$fast_install"; then
+ 	      cat <<EOF
+ const char * TARGET_PROGRAM_NAME = "lt-$outputname"; /* hopefully, no .exe */
+ EOF
+@@ -4357,12 +5950,12 @@ main (int argc, char *argv[])
+   char *actual_cwrapper_name;
+   char *target_name;
+   char *lt_argv_zero;
+-  intptr_t rval = 127;
++  int rval = 127;
+ 
+   int i;
+ 
+   program_name = (char *) xstrdup (base_name (argv[0]));
+-  newargz = XMALLOC (char *, argc + 1);
++  newargz = XMALLOC (char *, (size_t) argc + 1);
+ 
+   /* very simple arg parsing; don't want to rely on getopt
+    * also, copy all non cwrapper options to newargz, except
+@@ -4371,10 +5964,10 @@ main (int argc, char *argv[])
+   newargc=0;
+   for (i = 1; i < argc; i++)
+     {
+-      if (strcmp (argv[i], dumpscript_opt) == 0)
++      if (STREQ (argv[i], dumpscript_opt))
+ 	{
+ EOF
+-	    case "$host" in
++	    case $host in
+ 	      *mingw* | *cygwin* )
+ 		# make stdout use "unix" line endings
+ 		echo "          setmode(1,_O_BINARY);"
+@@ -4385,12 +5978,12 @@ EOF
+ 	  lt_dump_script (stdout);
+ 	  return 0;
+ 	}
+-      if (strcmp (argv[i], debug_opt) == 0)
++      if (STREQ (argv[i], debug_opt))
+ 	{
+           lt_debug = 1;
+           continue;
+ 	}
+-      if (strcmp (argv[i], ltwrapper_option_prefix) == 0)
++      if (STREQ (argv[i], ltwrapper_option_prefix))
+         {
+           /* however, if there is an option in the LTWRAPPER_OPTION_PREFIX
+              namespace, but it is not one of the ones we know about and
+@@ -4413,7 +6006,7 @@ EOF
+ EOF
+ 	    cat <<EOF
+   /* The GNU banner must be the first non-error debug message */
+-  lt_debugprintf (__FILE__, __LINE__, "libtool wrapper (GNU $PACKAGE$TIMESTAMP) $VERSION\n");
++  lt_debugprintf (__FILE__, __LINE__, "libtool wrapper (GNU $PACKAGE) $VERSION\n");
+ EOF
+ 	    cat <<"EOF"
+   lt_debugprintf (__FILE__, __LINE__, "(main) argv[0]: %s\n", argv[0]);
+@@ -4524,7 +6117,7 @@ EOF
+ 		cat <<"EOF"
+   /* execv doesn't actually work on mingw as expected on unix */
+   newargz = prepare_spawn (newargz);
+-  rval = _spawnv (_P_WAIT, lt_argv_zero, (const char * const *) newargz);
++  rval = (int) _spawnv (_P_WAIT, lt_argv_zero, (const char * const *) newargz);
+   if (rval == -1)
+     {
+       /* failed to start process */
+@@ -4569,7 +6162,7 @@ base_name (const char *name)
+ {
+   const char *base;
+ 
+-#if defined (HAVE_DOS_BASED_FILE_SYSTEM)
++#if defined HAVE_DOS_BASED_FILE_SYSTEM
+   /* Skip over the disk name in MSDOS pathnames. */
+   if (isalpha ((unsigned char) name[0]) && name[1] == ':')
+     name += 2;
+@@ -4628,7 +6221,7 @@ find_executable (const char *wrapper)
+   const char *p_next;
+   /* static buffer for getcwd */
+   char tmp[LT_PATHMAX + 1];
+-  int tmp_len;
++  size_t tmp_len;
+   char *concat_name;
+ 
+   lt_debugprintf (__FILE__, __LINE__, "(find_executable): %s\n",
+@@ -4638,7 +6231,7 @@ find_executable (const char *wrapper)
+     return NULL;
+ 
+   /* Absolute path? */
+-#if defined (HAVE_DOS_BASED_FILE_SYSTEM)
++#if defined HAVE_DOS_BASED_FILE_SYSTEM
+   if (isalpha ((unsigned char) wrapper[0]) && wrapper[1] == ':')
+     {
+       concat_name = xstrdup (wrapper);
+@@ -4656,7 +6249,7 @@ find_executable (const char *wrapper)
+ 	    return concat_name;
+ 	  XFREE (concat_name);
+ 	}
+-#if defined (HAVE_DOS_BASED_FILE_SYSTEM)
++#if defined HAVE_DOS_BASED_FILE_SYSTEM
+     }
+ #endif
+ 
+@@ -4679,7 +6272,7 @@ find_executable (const char *wrapper)
+ 	      for (q = p; *q; q++)
+ 		if (IS_PATH_SEPARATOR (*q))
+ 		  break;
+-	      p_len = q - p;
++	      p_len = (size_t) (q - p);
+ 	      p_next = (*q == '\0' ? q : q + 1);
+ 	      if (p_len == 0)
+ 		{
+@@ -4798,7 +6391,7 @@ strendzap (char *str, const char *pat)
+   if (patlen <= len)
+     {
+       str += len - patlen;
+-      if (strcmp (str, pat) == 0)
++      if (STREQ (str, pat))
+ 	*str = '\0';
+     }
+   return str;
+@@ -4863,7 +6456,7 @@ lt_setenv (const char *name, const char *value)
+     char *str = xstrdup (value);
+     setenv (name, str, 1);
+ #else
+-    int len = strlen (name) + 1 + strlen (value) + 1;
++    size_t len = strlen (name) + 1 + strlen (value) + 1;
+     char *str = XMALLOC (char, len);
+     sprintf (str, "%s=%s", name, value);
+     if (putenv (str) != EXIT_SUCCESS)
+@@ -4880,8 +6473,8 @@ lt_extend_str (const char *orig_value, const char *add, int to_end)
+   char *new_value;
+   if (orig_value && *orig_value)
+     {
+-      int orig_value_len = strlen (orig_value);
+-      int add_len = strlen (add);
++      size_t orig_value_len = strlen (orig_value);
++      size_t add_len = strlen (add);
+       new_value = XMALLOC (char, add_len + orig_value_len + 1);
+       if (to_end)
+         {
+@@ -4912,10 +6505,10 @@ lt_update_exe_path (const char *name, const char *value)
+     {
+       char *new_value = lt_extend_str (getenv (name), value, 0);
+       /* some systems can't cope with a ':'-terminated path #' */
+-      int len = strlen (new_value);
+-      while (((len = strlen (new_value)) > 0) && IS_PATH_SEPARATOR (new_value[len-1]))
++      size_t len = strlen (new_value);
++      while ((len > 0) && IS_PATH_SEPARATOR (new_value[len-1]))
+         {
+-          new_value[len-1] = '\0';
++          new_value[--len] = '\0';
+         }
+       lt_setenv (name, new_value);
+       XFREE (new_value);
+@@ -5082,27 +6675,47 @@ EOF
+ # True if ARG is an import lib, as indicated by $file_magic_cmd
+ func_win32_import_lib_p ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     case `eval $file_magic_cmd \"\$1\" 2>/dev/null | $SED -e 10q` in
+     *import*) : ;;
+     *) false ;;
+     esac
+ }
+ 
++# func_suncc_cstd_abi
++# !!ONLY CALL THIS FOR SUN CC AFTER $compile_command IS FULLY EXPANDED!!
++# Several compiler flags select an ABI that is incompatible with the
++# Cstd library. Avoid specifying it if any are in CXXFLAGS.
++func_suncc_cstd_abi ()
++{
++    $debug_cmd
++
++    case " $compile_command " in
++    *" -compat=g "*|*\ -std=c++[0-9][0-9]\ *|*" -library=stdcxx4 "*|*" -library=stlport4 "*)
++      suncc_use_cstd_abi=no
++      ;;
++    *)
++      suncc_use_cstd_abi=yes
++      ;;
++    esac
++}
++
+ # func_mode_link arg...
+ func_mode_link ()
+ {
+-    $opt_debug
++    $debug_cmd
++
+     case $host in
+     *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
+       # It is impossible to link a dll without this setting, and
+       # we shouldn't force the makefile maintainer to figure out
+-      # which system we are compiling for in order to pass an extra
++      # what system we are compiling for in order to pass an extra
+       # flag for every libtool invocation.
+       # allow_undefined=no
+ 
+       # FIXME: Unfortunately, there are problems with the above when trying
+-      # to make a dll which has undefined symbols, in which case not
++      # to make a dll that has undefined symbols, in which case not
+       # even a static library is built.  For now, we need to specify
+       # -no-undefined on the libtool link line when we can be certain
+       # that all symbols are satisfied, otherwise we get a static library.
+@@ -5146,10 +6759,11 @@ func_mode_link ()
+     module=no
+     no_install=no
+     objs=
++    os2dllname=
+     non_pic_objects=
+     precious_files_regex=
+     prefer_static_libs=no
+-    preload=no
++    preload=false
+     prev=
+     prevarg=
+     release=
+@@ -5161,7 +6775,7 @@ func_mode_link ()
+     vinfo=
+     vinfo_number=no
+     weak_libs=
+-    single_module="${wl}-single_module"
++    single_module=$wl-single_module
+     func_infer_tag $base_compile
+ 
+     # We need to know -static, to get the right output filenames.
+@@ -5169,15 +6783,15 @@ func_mode_link ()
+     do
+       case $arg in
+       -shared)
+-	test "$build_libtool_libs" != yes && \
+-	  func_fatal_configuration "can not build a shared library"
++	test yes != "$build_libtool_libs" \
++	  && func_fatal_configuration "cannot build a shared library"
+ 	build_old_libs=no
+ 	break
+ 	;;
+       -all-static | -static | -static-libtool-libs)
+ 	case $arg in
+ 	-all-static)
+-	  if test "$build_libtool_libs" = yes && test -z "$link_static_flag"; then
++	  if test yes = "$build_libtool_libs" && test -z "$link_static_flag"; then
+ 	    func_warning "complete static linking is impossible in this configuration"
+ 	  fi
+ 	  if test -n "$link_static_flag"; then
+@@ -5210,11 +6824,11 @@ func_mode_link ()
+ 
+     # Go through the arguments, transforming them on the way.
+     while test "$#" -gt 0; do
+-      arg="$1"
++      arg=$1
+       shift
+-      func_quote_for_eval "$arg"
+-      qarg=$func_quote_for_eval_unquoted_result
+-      func_append libtool_args " $func_quote_for_eval_result"
++      func_quote_arg pretty,unquoted "$arg"
++      qarg=$func_quote_arg_unquoted_result
++      func_append libtool_args " $func_quote_arg_result"
+ 
+       # If the previous option needs an argument, assign it.
+       if test -n "$prev"; then
+@@ -5227,21 +6841,21 @@ func_mode_link ()
+ 
+ 	case $prev in
+ 	bindir)
+-	  bindir="$arg"
++	  bindir=$arg
+ 	  prev=
+ 	  continue
+ 	  ;;
+ 	dlfiles|dlprefiles)
+-	  if test "$preload" = no; then
++	  $preload || {
+ 	    # Add the symbol object into the linking commands.
+ 	    func_append compile_command " @SYMFILE@"
+ 	    func_append finalize_command " @SYMFILE@"
+-	    preload=yes
+-	  fi
++	    preload=:
++	  }
+ 	  case $arg in
+ 	  *.la | *.lo) ;;  # We handle these cases below.
+ 	  force)
+-	    if test "$dlself" = no; then
++	    if test no = "$dlself"; then
+ 	      dlself=needless
+ 	      export_dynamic=yes
+ 	    fi
+@@ -5249,9 +6863,9 @@ func_mode_link ()
+ 	    continue
+ 	    ;;
+ 	  self)
+-	    if test "$prev" = dlprefiles; then
++	    if test dlprefiles = "$prev"; then
+ 	      dlself=yes
+-	    elif test "$prev" = dlfiles && test "$dlopen_self" != yes; then
++	    elif test dlfiles = "$prev" && test yes != "$dlopen_self"; then
+ 	      dlself=yes
+ 	    else
+ 	      dlself=needless
+@@ -5261,7 +6875,7 @@ func_mode_link ()
+ 	    continue
+ 	    ;;
+ 	  *)
+-	    if test "$prev" = dlfiles; then
++	    if test dlfiles = "$prev"; then
+ 	      func_append dlfiles " $arg"
+ 	    else
+ 	      func_append dlprefiles " $arg"
+@@ -5272,14 +6886,14 @@ func_mode_link ()
+ 	  esac
+ 	  ;;
+ 	expsyms)
+-	  export_symbols="$arg"
++	  export_symbols=$arg
+ 	  test -f "$arg" \
+-	    || func_fatal_error "symbol file \`$arg' does not exist"
++	    || func_fatal_error "symbol file '$arg' does not exist"
+ 	  prev=
+ 	  continue
+ 	  ;;
+ 	expsyms_regex)
+-	  export_symbols_regex="$arg"
++	  export_symbols_regex=$arg
+ 	  prev=
+ 	  continue
+ 	  ;;
+@@ -5297,7 +6911,13 @@ func_mode_link ()
+ 	  continue
+ 	  ;;
+ 	inst_prefix)
+-	  inst_prefix_dir="$arg"
++	  inst_prefix_dir=$arg
++	  prev=
++	  continue
++	  ;;
++	mllvm)
++	  # Clang does not use LLVM to link, so we can simply discard any
++	  # '-mllvm $arg' options when doing the link step.
+ 	  prev=
+ 	  continue
+ 	  ;;
+@@ -5321,21 +6941,21 @@ func_mode_link ()
+ 
+ 		if test -z "$pic_object" ||
+ 		   test -z "$non_pic_object" ||
+-		   test "$pic_object" = none &&
+-		   test "$non_pic_object" = none; then
+-		  func_fatal_error "cannot find name of object for \`$arg'"
++		   test none = "$pic_object" &&
++		   test none = "$non_pic_object"; then
++		  func_fatal_error "cannot find name of object for '$arg'"
+ 		fi
+ 
+ 		# Extract subdirectory from the argument.
+ 		func_dirname "$arg" "/" ""
+-		xdir="$func_dirname_result"
++		xdir=$func_dirname_result
+ 
+-		if test "$pic_object" != none; then
++		if test none != "$pic_object"; then
+ 		  # Prepend the subdirectory the object is found in.
+-		  pic_object="$xdir$pic_object"
++		  pic_object=$xdir$pic_object
+ 
+-		  if test "$prev" = dlfiles; then
+-		    if test "$build_libtool_libs" = yes && test "$dlopen_support" = yes; then
++		  if test dlfiles = "$prev"; then
++		    if test yes = "$build_libtool_libs" && test yes = "$dlopen_support"; then
+ 		      func_append dlfiles " $pic_object"
+ 		      prev=
+ 		      continue
+@@ -5346,7 +6966,7 @@ func_mode_link ()
+ 		  fi
+ 
+ 		  # CHECK ME:  I think I busted this.  -Ossama
+-		  if test "$prev" = dlprefiles; then
++		  if test dlprefiles = "$prev"; then
+ 		    # Preload the old-style object.
+ 		    func_append dlprefiles " $pic_object"
+ 		    prev=
+@@ -5354,23 +6974,23 @@ func_mode_link ()
+ 
+ 		  # A PIC object.
+ 		  func_append libobjs " $pic_object"
+-		  arg="$pic_object"
++		  arg=$pic_object
+ 		fi
+ 
+ 		# Non-PIC object.
+-		if test "$non_pic_object" != none; then
++		if test none != "$non_pic_object"; then
+ 		  # Prepend the subdirectory the object is found in.
+-		  non_pic_object="$xdir$non_pic_object"
++		  non_pic_object=$xdir$non_pic_object
+ 
+ 		  # A standard non-PIC object
+ 		  func_append non_pic_objects " $non_pic_object"
+-		  if test -z "$pic_object" || test "$pic_object" = none ; then
+-		    arg="$non_pic_object"
++		  if test -z "$pic_object" || test none = "$pic_object"; then
++		    arg=$non_pic_object
+ 		  fi
+ 		else
+ 		  # If the PIC object exists, use it instead.
+ 		  # $xdir was prepended to $pic_object above.
+-		  non_pic_object="$pic_object"
++		  non_pic_object=$pic_object
+ 		  func_append non_pic_objects " $non_pic_object"
+ 		fi
+ 	      else
+@@ -5378,7 +6998,7 @@ func_mode_link ()
+ 		if $opt_dry_run; then
+ 		  # Extract subdirectory from the argument.
+ 		  func_dirname "$arg" "/" ""
+-		  xdir="$func_dirname_result"
++		  xdir=$func_dirname_result
+ 
+ 		  func_lo2o "$arg"
+ 		  pic_object=$xdir$objdir/$func_lo2o_result
+@@ -5386,24 +7006,29 @@ func_mode_link ()
+ 		  func_append libobjs " $pic_object"
+ 		  func_append non_pic_objects " $non_pic_object"
+ 	        else
+-		  func_fatal_error "\`$arg' is not a valid libtool object"
++		  func_fatal_error "'$arg' is not a valid libtool object"
+ 		fi
+ 	      fi
+ 	    done
+ 	  else
+-	    func_fatal_error "link input file \`$arg' does not exist"
++	    func_fatal_error "link input file '$arg' does not exist"
+ 	  fi
+ 	  arg=$save_arg
+ 	  prev=
+ 	  continue
+ 	  ;;
++	os2dllname)
++	  os2dllname=$arg
++	  prev=
++	  continue
++	  ;;
+ 	precious_regex)
+-	  precious_files_regex="$arg"
++	  precious_files_regex=$arg
+ 	  prev=
+ 	  continue
+ 	  ;;
+ 	release)
+-	  release="-$arg"
++	  release=-$arg
+ 	  prev=
+ 	  continue
+ 	  ;;
+@@ -5415,7 +7040,7 @@ func_mode_link ()
+ 	    func_fatal_error "only absolute run-paths are allowed"
+ 	    ;;
+ 	  esac
+-	  if test "$prev" = rpath; then
++	  if test rpath = "$prev"; then
+ 	    case "$rpath " in
+ 	    *" $arg "*) ;;
+ 	    *) func_append rpath " $arg" ;;
+@@ -5430,7 +7055,7 @@ func_mode_link ()
+ 	  continue
+ 	  ;;
+ 	shrext)
+-	  shrext_cmds="$arg"
++	  shrext_cmds=$arg
+ 	  prev=
+ 	  continue
+ 	  ;;
+@@ -5470,7 +7095,7 @@ func_mode_link ()
+ 	esac
+       fi # test -n "$prev"
+ 
+-      prevarg="$arg"
++      prevarg=$arg
+ 
+       case $arg in
+       -all-static)
+@@ -5484,7 +7109,7 @@ func_mode_link ()
+ 
+       -allow-undefined)
+ 	# FIXME: remove this flag sometime in the future.
+-	func_fatal_error "\`-allow-undefined' must not be used because it is the default"
++	func_fatal_error "'-allow-undefined' must not be used because it is the default"
+ 	;;
+ 
+       -avoid-version)
+@@ -5516,7 +7141,7 @@ func_mode_link ()
+ 	if test -n "$export_symbols" || test -n "$export_symbols_regex"; then
+ 	  func_fatal_error "more than one -exported-symbols argument is not allowed"
+ 	fi
+-	if test "X$arg" = "X-export-symbols"; then
++	if test X-export-symbols = "X$arg"; then
+ 	  prev=expsyms
+ 	else
+ 	  prev=expsyms_regex
+@@ -5550,9 +7175,9 @@ func_mode_link ()
+ 	func_stripname "-L" '' "$arg"
+ 	if test -z "$func_stripname_result"; then
+ 	  if test "$#" -gt 0; then
+-	    func_fatal_error "require no space between \`-L' and \`$1'"
++	    func_fatal_error "require no space between '-L' and '$1'"
+ 	  else
+-	    func_fatal_error "need path for \`-L' option"
++	    func_fatal_error "need path for '-L' option"
+ 	  fi
+ 	fi
+ 	func_resolve_sysroot "$func_stripname_result"
+@@ -5563,8 +7188,8 @@ func_mode_link ()
+ 	*)
+ 	  absdir=`cd "$dir" && pwd`
+ 	  test -z "$absdir" && \
+-	    func_fatal_error "cannot determine absolute directory name of \`$dir'"
+-	  dir="$absdir"
++	    func_fatal_error "cannot determine absolute directory name of '$dir'"
++	  dir=$absdir
+ 	  ;;
+ 	esac
+ 	case "$deplibs " in
+@@ -5599,7 +7224,7 @@ func_mode_link ()
+ 	;;
+ 
+       -l*)
+-	if test "X$arg" = "X-lc" || test "X$arg" = "X-lm"; then
++	if test X-lc = "X$arg" || test X-lm = "X$arg"; then
+ 	  case $host in
+ 	  *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-beos* | *-cegcc* | *-*-haiku*)
+ 	    # These systems don't actually have a C or math library (as such)
+@@ -5607,11 +7232,11 @@ func_mode_link ()
+ 	    ;;
+ 	  *-*-os2*)
+ 	    # These systems don't actually have a C library (as such)
+-	    test "X$arg" = "X-lc" && continue
++	    test X-lc = "X$arg" && continue
+ 	    ;;
+-	  *-*-openbsd* | *-*-freebsd* | *-*-dragonfly*)
++	  *-*-openbsd* | *-*-freebsd* | *-*-dragonfly* | *-*-bitrig*)
+ 	    # Do not include libc due to us having libc/libc_r.
+-	    test "X$arg" = "X-lc" && continue
++	    test X-lc = "X$arg" && continue
+ 	    ;;
+ 	  *-*-rhapsody* | *-*-darwin1.[012])
+ 	    # Rhapsody C and math libraries are in the System framework
+@@ -5620,16 +7245,16 @@ func_mode_link ()
+ 	    ;;
+ 	  *-*-sco3.2v5* | *-*-sco5v6*)
+ 	    # Causes problems with __ctype
+-	    test "X$arg" = "X-lc" && continue
++	    test X-lc = "X$arg" && continue
+ 	    ;;
+ 	  *-*-sysv4.2uw2* | *-*-sysv5* | *-*-unixware* | *-*-OpenUNIX*)
+ 	    # Compiler inserts libc in the correct place for threads to work
+-	    test "X$arg" = "X-lc" && continue
++	    test X-lc = "X$arg" && continue
+ 	    ;;
+ 	  esac
+-	elif test "X$arg" = "X-lc_r"; then
++	elif test X-lc_r = "X$arg"; then
+ 	 case $host in
+-	 *-*-openbsd* | *-*-freebsd* | *-*-dragonfly*)
++	 *-*-openbsd* | *-*-freebsd* | *-*-dragonfly* | *-*-bitrig*)
+ 	   # Do not include libc_r directly, use -pthread flag.
+ 	   continue
+ 	   ;;
+@@ -5639,6 +7264,11 @@ func_mode_link ()
+ 	continue
+ 	;;
+ 
++      -mllvm)
++	prev=mllvm
++	continue
++	;;
++
+       -module)
+ 	module=yes
+ 	continue
+@@ -5668,7 +7298,7 @@ func_mode_link ()
+ 	;;
+ 
+       -multi_module)
+-	single_module="${wl}-multi_module"
++	single_module=$wl-multi_module
+ 	continue
+ 	;;
+ 
+@@ -5682,8 +7312,8 @@ func_mode_link ()
+ 	*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-*-darwin* | *-cegcc*)
+ 	  # The PATH hackery in wrapper scripts is required on Windows
+ 	  # and Darwin in order for the loader to find any dlls it needs.
+-	  func_warning "\`-no-install' is ignored for $host"
+-	  func_warning "assuming \`-no-fast-install' instead"
++	  func_warning "'-no-install' is ignored for $host"
++	  func_warning "assuming '-no-fast-install' instead"
+ 	  fast_install=no
+ 	  ;;
+ 	*) no_install=yes ;;
+@@ -5701,6 +7331,11 @@ func_mode_link ()
+ 	continue
+ 	;;
+ 
++      -os2dllname)
++	prev=os2dllname
++	continue
++	;;
++
+       -o) prev=output ;;
+ 
+       -precious-files-regex)
+@@ -5788,14 +7423,14 @@ func_mode_link ()
+ 	func_stripname '-Wc,' '' "$arg"
+ 	args=$func_stripname_result
+ 	arg=
+-	save_ifs="$IFS"; IFS=','
++	save_ifs=$IFS; IFS=,
+ 	for flag in $args; do
+-	  IFS="$save_ifs"
+-          func_quote_for_eval "$flag"
+-	  func_append arg " $func_quote_for_eval_result"
+-	  func_append compiler_flags " $func_quote_for_eval_result"
++	  IFS=$save_ifs
++          func_quote_arg pretty "$flag"
++	  func_append arg " $func_quote_arg_result"
++	  func_append compiler_flags " $func_quote_arg_result"
+ 	done
+-	IFS="$save_ifs"
++	IFS=$save_ifs
+ 	func_stripname ' ' '' "$arg"
+ 	arg=$func_stripname_result
+ 	;;
+@@ -5804,15 +7439,15 @@ func_mode_link ()
+ 	func_stripname '-Wl,' '' "$arg"
+ 	args=$func_stripname_result
+ 	arg=
+-	save_ifs="$IFS"; IFS=','
++	save_ifs=$IFS; IFS=,
+ 	for flag in $args; do
+-	  IFS="$save_ifs"
+-          func_quote_for_eval "$flag"
+-	  func_append arg " $wl$func_quote_for_eval_result"
+-	  func_append compiler_flags " $wl$func_quote_for_eval_result"
+-	  func_append linker_flags " $func_quote_for_eval_result"
++	  IFS=$save_ifs
++          func_quote_arg pretty "$flag"
++	  func_append arg " $wl$func_quote_arg_result"
++	  func_append compiler_flags " $wl$func_quote_arg_result"
++	  func_append linker_flags " $func_quote_arg_result"
+ 	done
+-	IFS="$save_ifs"
++	IFS=$save_ifs
+ 	func_stripname ' ' '' "$arg"
+ 	arg=$func_stripname_result
+ 	;;
+@@ -5834,8 +7469,8 @@ func_mode_link ()
+ 
+       # -msg_* for osf cc
+       -msg_*)
+-	func_quote_for_eval "$arg"
+-	arg="$func_quote_for_eval_result"
++	func_quote_arg pretty "$arg"
++	arg=$func_quote_arg_result
+ 	;;
+ 
+       # Flags to be passed through unchanged, with rationale:
+@@ -5847,25 +7482,50 @@ func_mode_link ()
+       # -m*, -t[45]*, -txscale* architecture-specific flags for GCC
+       # -F/path              path to uninstalled frameworks, gcc on darwin
+       # -p, -pg, --coverage, -fprofile-*  profiling flags for GCC
++      # -fstack-protector*   stack protector flags for GCC
+       # @file                GCC response files
+       # -tp=*                Portland pgcc target processor selection
+       # --sysroot=*          for sysroot support
+-      # -O*, -flto*, -fwhopr*, -fuse-linker-plugin GCC link-time optimization
++      # -O*, -g*, -flto*, -fwhopr*, -fuse-linker-plugin GCC link-time optimization
++      # -specs=*             GCC specs files
++      # -stdlib=*            select c++ std lib with clang
++      # -fsanitize=*         Clang/GCC memory and address sanitizer
++      # -fuse-ld=*           Linker select flags for GCC
+       -64|-mips[0-9]|-r[0-9][0-9]*|-xarch=*|-xtarget=*|+DA*|+DD*|-q*|-m*| \
+       -t[45]*|-txscale*|-p|-pg|--coverage|-fprofile-*|-F*|@*|-tp=*|--sysroot=*| \
+-      -O*|-flto*|-fwhopr*|-fuse-linker-plugin)
+-        func_quote_for_eval "$arg"
+-	arg="$func_quote_for_eval_result"
++      -O*|-g*|-flto*|-fwhopr*|-fuse-linker-plugin|-fstack-protector*|-stdlib=*| \
++      -specs=*|-fsanitize=*|-fuse-ld=*)
++        func_quote_arg pretty "$arg"
++	arg=$func_quote_arg_result
+         func_append compile_command " $arg"
+         func_append finalize_command " $arg"
+         func_append compiler_flags " $arg"
+         continue
+         ;;
+ 
++      -Z*)
++        if test os2 = "`expr $host : '.*\(os2\)'`"; then
++          # OS/2 uses -Zxxx to specify OS/2-specific options
++	  compiler_flags="$compiler_flags $arg"
++	  func_append compile_command " $arg"
++	  func_append finalize_command " $arg"
++	  case $arg in
++	  -Zlinker | -Zstack)
++	    prev=xcompiler
++	    ;;
++	  esac
++	  continue
++        else
++	  # Otherwise treat like 'Some other compiler flag' below
++	  func_quote_arg pretty "$arg"
++	  arg=$func_quote_arg_result
++        fi
++	;;
++
+       # Some other compiler flag.
+       -* | +*)
+-        func_quote_for_eval "$arg"
+-	arg="$func_quote_for_eval_result"
++        func_quote_arg pretty "$arg"
++	arg=$func_quote_arg_result
+ 	;;
+ 
+       *.$objext)
+@@ -5886,21 +7546,21 @@ func_mode_link ()
+ 
+ 	  if test -z "$pic_object" ||
+ 	     test -z "$non_pic_object" ||
+-	     test "$pic_object" = none &&
+-	     test "$non_pic_object" = none; then
+-	    func_fatal_error "cannot find name of object for \`$arg'"
++	     test none = "$pic_object" &&
++	     test none = "$non_pic_object"; then
++	    func_fatal_error "cannot find name of object for '$arg'"
+ 	  fi
+ 
+ 	  # Extract subdirectory from the argument.
+ 	  func_dirname "$arg" "/" ""
+-	  xdir="$func_dirname_result"
++	  xdir=$func_dirname_result
+ 
+-	  if test "$pic_object" != none; then
++	  test none = "$pic_object" || {
+ 	    # Prepend the subdirectory the object is found in.
+-	    pic_object="$xdir$pic_object"
++	    pic_object=$xdir$pic_object
+ 
+-	    if test "$prev" = dlfiles; then
+-	      if test "$build_libtool_libs" = yes && test "$dlopen_support" = yes; then
++	    if test dlfiles = "$prev"; then
++	      if test yes = "$build_libtool_libs" && test yes = "$dlopen_support"; then
+ 		func_append dlfiles " $pic_object"
+ 		prev=
+ 		continue
+@@ -5911,7 +7571,7 @@ func_mode_link ()
+ 	    fi
+ 
+ 	    # CHECK ME:  I think I busted this.  -Ossama
+-	    if test "$prev" = dlprefiles; then
++	    if test dlprefiles = "$prev"; then
+ 	      # Preload the old-style object.
+ 	      func_append dlprefiles " $pic_object"
+ 	      prev=
+@@ -5919,23 +7579,23 @@ func_mode_link ()
+ 
+ 	    # A PIC object.
+ 	    func_append libobjs " $pic_object"
+-	    arg="$pic_object"
+-	  fi
++	    arg=$pic_object
++	  }
+ 
+ 	  # Non-PIC object.
+-	  if test "$non_pic_object" != none; then
++	  if test none != "$non_pic_object"; then
+ 	    # Prepend the subdirectory the object is found in.
+-	    non_pic_object="$xdir$non_pic_object"
++	    non_pic_object=$xdir$non_pic_object
+ 
+ 	    # A standard non-PIC object
+ 	    func_append non_pic_objects " $non_pic_object"
+-	    if test -z "$pic_object" || test "$pic_object" = none ; then
+-	      arg="$non_pic_object"
++	    if test -z "$pic_object" || test none = "$pic_object"; then
++	      arg=$non_pic_object
+ 	    fi
+ 	  else
+ 	    # If the PIC object exists, use it instead.
+ 	    # $xdir was prepended to $pic_object above.
+-	    non_pic_object="$pic_object"
++	    non_pic_object=$pic_object
+ 	    func_append non_pic_objects " $non_pic_object"
+ 	  fi
+ 	else
+@@ -5943,7 +7603,7 @@ func_mode_link ()
+ 	  if $opt_dry_run; then
+ 	    # Extract subdirectory from the argument.
+ 	    func_dirname "$arg" "/" ""
+-	    xdir="$func_dirname_result"
++	    xdir=$func_dirname_result
+ 
+ 	    func_lo2o "$arg"
+ 	    pic_object=$xdir$objdir/$func_lo2o_result
+@@ -5951,7 +7611,7 @@ func_mode_link ()
+ 	    func_append libobjs " $pic_object"
+ 	    func_append non_pic_objects " $non_pic_object"
+ 	  else
+-	    func_fatal_error "\`$arg' is not a valid libtool object"
++	    func_fatal_error "'$arg' is not a valid libtool object"
+ 	  fi
+ 	fi
+ 	;;
+@@ -5967,11 +7627,11 @@ func_mode_link ()
+ 	# A libtool-controlled library.
+ 
+ 	func_resolve_sysroot "$arg"
+-	if test "$prev" = dlfiles; then
++	if test dlfiles = "$prev"; then
+ 	  # This library was specified with -dlopen.
+ 	  func_append dlfiles " $func_resolve_sysroot_result"
+ 	  prev=
+-	elif test "$prev" = dlprefiles; then
++	elif test dlprefiles = "$prev"; then
+ 	  # The library was specified with -dlpreopen.
+ 	  func_append dlprefiles " $func_resolve_sysroot_result"
+ 	  prev=
+@@ -5985,8 +7645,8 @@ func_mode_link ()
+       *)
+ 	# Unknown arguments in both finalize_command and compile_command need
+ 	# to be aesthetically quoted because they are evaled later.
+-	func_quote_for_eval "$arg"
+-	arg="$func_quote_for_eval_result"
++	func_quote_arg pretty "$arg"
++	arg=$func_quote_arg_result
+ 	;;
+       esac # arg
+ 
+@@ -5998,9 +7658,9 @@ func_mode_link ()
+     done # argument parsing loop
+ 
+     test -n "$prev" && \
+-      func_fatal_help "the \`$prevarg' option requires an argument"
++      func_fatal_help "the '$prevarg' option requires an argument"
+ 
+-    if test "$export_dynamic" = yes && test -n "$export_dynamic_flag_spec"; then
++    if test yes = "$export_dynamic" && test -n "$export_dynamic_flag_spec"; then
+       eval arg=\"$export_dynamic_flag_spec\"
+       func_append compile_command " $arg"
+       func_append finalize_command " $arg"
+@@ -6009,20 +7669,23 @@ func_mode_link ()
+     oldlibs=
+     # calculate the name of the file, without its directory
+     func_basename "$output"
+-    outputname="$func_basename_result"
+-    libobjs_save="$libobjs"
++    outputname=$func_basename_result
++    libobjs_save=$libobjs
+ 
+     if test -n "$shlibpath_var"; then
+       # get the directories listed in $shlibpath_var
+-      eval shlib_search_path=\`\$ECHO \"\${$shlibpath_var}\" \| \$SED \'s/:/ /g\'\`
++      eval shlib_search_path=\`\$ECHO \"\$$shlibpath_var\" \| \$SED \'s/:/ /g\'\`
+     else
+       shlib_search_path=
+     fi
+     eval sys_lib_search_path=\"$sys_lib_search_path_spec\"
+     eval sys_lib_dlsearch_path=\"$sys_lib_dlsearch_path_spec\"
+ 
++    # Definition is injected by LT_CONFIG during libtool generation.
++    func_munge_path_list sys_lib_dlsearch_path "$LT_SYS_LIBRARY_PATH"
++
+     func_dirname "$output" "/" ""
+-    output_objdir="$func_dirname_result$objdir"
++    output_objdir=$func_dirname_result$objdir
+     func_to_tool_file "$output_objdir/"
+     tool_output_objdir=$func_to_tool_file_result
+     # Create the object directory.
+@@ -6045,7 +7708,7 @@ func_mode_link ()
+     # Find all interdependent deplibs by searching for libraries
+     # that are linked more than once (e.g. -la -lb -la)
+     for deplib in $deplibs; do
+-      if $opt_preserve_dup_deps ; then
++      if $opt_preserve_dup_deps; then
+ 	case "$libs " in
+ 	*" $deplib "*) func_append specialdeplibs " $deplib" ;;
+ 	esac
+@@ -6053,7 +7716,7 @@ func_mode_link ()
+       func_append libs " $deplib"
+     done
+ 
+-    if test "$linkmode" = lib; then
++    if test lib = "$linkmode"; then
+       libs="$predeps $libs $compiler_lib_search_path $postdeps"
+ 
+       # Compute libraries that are listed more than once in $predeps
+@@ -6085,7 +7748,7 @@ func_mode_link ()
+ 	  case $file in
+ 	  *.la) ;;
+ 	  *)
+-	    func_fatal_help "libraries can \`-dlopen' only libtool libraries: $file"
++	    func_fatal_help "libraries can '-dlopen' only libtool libraries: $file"
+ 	    ;;
+ 	  esac
+ 	done
+@@ -6093,7 +7756,7 @@ func_mode_link ()
+     prog)
+ 	compile_deplibs=
+ 	finalize_deplibs=
+-	alldeplibs=no
++	alldeplibs=false
+ 	newdlfiles=
+ 	newdlprefiles=
+ 	passes="conv scan dlopen dlpreopen link"
+@@ -6105,29 +7768,29 @@ func_mode_link ()
+     for pass in $passes; do
+       # The preopen pass in lib mode reverses $deplibs; put it back here
+       # so that -L comes before libs that need it for instance...
+-      if test "$linkmode,$pass" = "lib,link"; then
++      if test lib,link = "$linkmode,$pass"; then
+ 	## FIXME: Find the place where the list is rebuilt in the wrong
+ 	##        order, and fix it there properly
+         tmp_deplibs=
+ 	for deplib in $deplibs; do
+ 	  tmp_deplibs="$deplib $tmp_deplibs"
+ 	done
+-	deplibs="$tmp_deplibs"
++	deplibs=$tmp_deplibs
+       fi
+ 
+-      if test "$linkmode,$pass" = "lib,link" ||
+-	 test "$linkmode,$pass" = "prog,scan"; then
+-	libs="$deplibs"
++      if test lib,link = "$linkmode,$pass" ||
++	 test prog,scan = "$linkmode,$pass"; then
++	libs=$deplibs
+ 	deplibs=
+       fi
+-      if test "$linkmode" = prog; then
++      if test prog = "$linkmode"; then
+ 	case $pass in
+-	dlopen) libs="$dlfiles" ;;
+-	dlpreopen) libs="$dlprefiles" ;;
++	dlopen) libs=$dlfiles ;;
++	dlpreopen) libs=$dlprefiles ;;
+ 	link) libs="$deplibs %DEPLIBS% $dependency_libs" ;;
+ 	esac
+       fi
+-      if test "$linkmode,$pass" = "lib,dlpreopen"; then
++      if test lib,dlpreopen = "$linkmode,$pass"; then
+ 	# Collect and forward deplibs of preopened libtool libs
+ 	for lib in $dlprefiles; do
+ 	  # Ignore non-libtool-libs
+@@ -6148,26 +7811,26 @@ func_mode_link ()
+ 	    esac
+ 	  done
+ 	done
+-	libs="$dlprefiles"
++	libs=$dlprefiles
+       fi
+-      if test "$pass" = dlopen; then
++      if test dlopen = "$pass"; then
+ 	# Collect dlpreopened libraries
+-	save_deplibs="$deplibs"
++	save_deplibs=$deplibs
+ 	deplibs=
+       fi
+ 
+       for deplib in $libs; do
+ 	lib=
+-	found=no
++	found=false
+ 	case $deplib in
+ 	-mt|-mthreads|-kthread|-Kthread|-pthread|-pthreads|--thread-safe \
+         |-threads|-fopenmp|-openmp|-mp|-xopenmp|-omp|-qsmp=*)
+-	  if test "$linkmode,$pass" = "prog,link"; then
++	  if test prog,link = "$linkmode,$pass"; then
+ 	    compile_deplibs="$deplib $compile_deplibs"
+ 	    finalize_deplibs="$deplib $finalize_deplibs"
+ 	  else
+ 	    func_append compiler_flags " $deplib"
+-	    if test "$linkmode" = lib ; then
++	    if test lib = "$linkmode"; then
+ 		case "$new_inherited_linker_flags " in
+ 		    *" $deplib "*) ;;
+ 		    * ) func_append new_inherited_linker_flags " $deplib" ;;
+@@ -6177,13 +7840,13 @@ func_mode_link ()
+ 	  continue
+ 	  ;;
+ 	-l*)
+-	  if test "$linkmode" != lib && test "$linkmode" != prog; then
+-	    func_warning "\`-l' is ignored for archives/objects"
++	  if test lib != "$linkmode" && test prog != "$linkmode"; then
++	    func_warning "'-l' is ignored for archives/objects"
+ 	    continue
+ 	  fi
+ 	  func_stripname '-l' '' "$deplib"
+ 	  name=$func_stripname_result
+-	  if test "$linkmode" = lib; then
++	  if test lib = "$linkmode"; then
+ 	    searchdirs="$newlib_search_path $lib_search_path $compiler_lib_search_dirs $sys_lib_search_path $shlib_search_path"
+ 	  else
+ 	    searchdirs="$newlib_search_path $lib_search_path $sys_lib_search_path $shlib_search_path"
+@@ -6191,31 +7854,22 @@ func_mode_link ()
+ 	  for searchdir in $searchdirs; do
+ 	    for search_ext in .la $std_shrext .so .a; do
+ 	      # Search the libtool library
+-	      lib="$searchdir/lib${name}${search_ext}"
++	      lib=$searchdir/lib$name$search_ext
+ 	      if test -f "$lib"; then
+-		if test "$search_ext" = ".la"; then
+-		  found=yes
++		if test .la = "$search_ext"; then
++		  found=:
+ 		else
+-		  found=no
++		  found=false
+ 		fi
+ 		break 2
+ 	      fi
+ 	    done
+ 	  done
+-	  if test "$found" != yes; then
+-	    # deplib doesn't seem to be a libtool library
+-	    if test "$linkmode,$pass" = "prog,link"; then
+-	      compile_deplibs="$deplib $compile_deplibs"
+-	      finalize_deplibs="$deplib $finalize_deplibs"
+-	    else
+-	      deplibs="$deplib $deplibs"
+-	      test "$linkmode" = lib && newdependency_libs="$deplib $newdependency_libs"
+-	    fi
+-	    continue
+-	  else # deplib is a libtool library
++	  if $found; then
++	    # deplib is a libtool library
+ 	    # If $allow_libtool_libs_with_static_runtimes && $deplib is a stdlib,
+ 	    # We need to do some special things here, and not later.
+-	    if test "X$allow_libtool_libs_with_static_runtimes" = "Xyes" ; then
++	    if test yes = "$allow_libtool_libs_with_static_runtimes"; then
+ 	      case " $predeps $postdeps " in
+ 	      *" $deplib "*)
+ 		if func_lalib_p "$lib"; then
+@@ -6223,19 +7877,19 @@ func_mode_link ()
+ 		  old_library=
+ 		  func_source "$lib"
+ 		  for l in $old_library $library_names; do
+-		    ll="$l"
++		    ll=$l
+ 		  done
+-		  if test "X$ll" = "X$old_library" ; then # only static version available
+-		    found=no
++		  if test "X$ll" = "X$old_library"; then # only static version available
++		    found=false
+ 		    func_dirname "$lib" "" "."
+-		    ladir="$func_dirname_result"
++		    ladir=$func_dirname_result
+ 		    lib=$ladir/$old_library
+-		    if test "$linkmode,$pass" = "prog,link"; then
++		    if test prog,link = "$linkmode,$pass"; then
+ 		      compile_deplibs="$deplib $compile_deplibs"
+ 		      finalize_deplibs="$deplib $finalize_deplibs"
+ 		    else
+ 		      deplibs="$deplib $deplibs"
+-		      test "$linkmode" = lib && newdependency_libs="$deplib $newdependency_libs"
++		      test lib = "$linkmode" && newdependency_libs="$deplib $newdependency_libs"
+ 		    fi
+ 		    continue
+ 		  fi
+@@ -6244,15 +7898,25 @@ func_mode_link ()
+ 	      *) ;;
+ 	      esac
+ 	    fi
++	  else
++	    # deplib doesn't seem to be a libtool library
++	    if test prog,link = "$linkmode,$pass"; then
++	      compile_deplibs="$deplib $compile_deplibs"
++	      finalize_deplibs="$deplib $finalize_deplibs"
++	    else
++	      deplibs="$deplib $deplibs"
++	      test lib = "$linkmode" && newdependency_libs="$deplib $newdependency_libs"
++	    fi
++	    continue
+ 	  fi
+ 	  ;; # -l
+ 	*.ltframework)
+-	  if test "$linkmode,$pass" = "prog,link"; then
++	  if test prog,link = "$linkmode,$pass"; then
+ 	    compile_deplibs="$deplib $compile_deplibs"
+ 	    finalize_deplibs="$deplib $finalize_deplibs"
+ 	  else
+ 	    deplibs="$deplib $deplibs"
+-	    if test "$linkmode" = lib ; then
++	    if test lib = "$linkmode"; then
+ 		case "$new_inherited_linker_flags " in
+ 		    *" $deplib "*) ;;
+ 		    * ) func_append new_inherited_linker_flags " $deplib" ;;
+@@ -6265,18 +7929,18 @@ func_mode_link ()
+ 	  case $linkmode in
+ 	  lib)
+ 	    deplibs="$deplib $deplibs"
+-	    test "$pass" = conv && continue
++	    test conv = "$pass" && continue
+ 	    newdependency_libs="$deplib $newdependency_libs"
+ 	    func_stripname '-L' '' "$deplib"
+ 	    func_resolve_sysroot "$func_stripname_result"
+ 	    func_append newlib_search_path " $func_resolve_sysroot_result"
+ 	    ;;
+ 	  prog)
+-	    if test "$pass" = conv; then
++	    if test conv = "$pass"; then
+ 	      deplibs="$deplib $deplibs"
+ 	      continue
+ 	    fi
+-	    if test "$pass" = scan; then
++	    if test scan = "$pass"; then
+ 	      deplibs="$deplib $deplibs"
+ 	    else
+ 	      compile_deplibs="$deplib $compile_deplibs"
+@@ -6287,13 +7951,13 @@ func_mode_link ()
+ 	    func_append newlib_search_path " $func_resolve_sysroot_result"
+ 	    ;;
+ 	  *)
+-	    func_warning "\`-L' is ignored for archives/objects"
++	    func_warning "'-L' is ignored for archives/objects"
+ 	    ;;
+ 	  esac # linkmode
+ 	  continue
+ 	  ;; # -L
+ 	-R*)
+-	  if test "$pass" = link; then
++	  if test link = "$pass"; then
+ 	    func_stripname '-R' '' "$deplib"
+ 	    func_resolve_sysroot "$func_stripname_result"
+ 	    dir=$func_resolve_sysroot_result
+@@ -6311,7 +7975,7 @@ func_mode_link ()
+ 	  lib=$func_resolve_sysroot_result
+ 	  ;;
+ 	*.$libext)
+-	  if test "$pass" = conv; then
++	  if test conv = "$pass"; then
+ 	    deplibs="$deplib $deplibs"
+ 	    continue
+ 	  fi
+@@ -6322,21 +7986,26 @@ func_mode_link ()
+ 	    case " $dlpreconveniencelibs " in
+ 	    *" $deplib "*) ;;
+ 	    *)
+-	      valid_a_lib=no
++	      valid_a_lib=false
+ 	      case $deplibs_check_method in
+ 		match_pattern*)
+ 		  set dummy $deplibs_check_method; shift
+ 		  match_pattern_regex=`expr "$deplibs_check_method" : "$1 \(.*\)"`
+ 		  if eval "\$ECHO \"$deplib\"" 2>/dev/null | $SED 10q \
+ 		    | $EGREP "$match_pattern_regex" > /dev/null; then
+-		    valid_a_lib=yes
++		    valid_a_lib=:
+ 		  fi
+ 		;;
+ 		pass_all)
+-		  valid_a_lib=yes
++		  valid_a_lib=:
+ 		;;
+ 	      esac
+-	      if test "$valid_a_lib" != yes; then
++	      if $valid_a_lib; then
++		echo
++		$ECHO "*** Warning: Linking the shared library $output against the"
++		$ECHO "*** static library $deplib is not portable!"
++		deplibs="$deplib $deplibs"
++	      else
+ 		echo
+ 		$ECHO "*** Warning: Trying to link with static lib archive $deplib."
+ 		echo "*** I have the capability to make that library automatically link in when"
+@@ -6344,18 +8013,13 @@ func_mode_link ()
+ 		echo "*** shared version of the library, which you do not appear to have"
+ 		echo "*** because the file extensions .$libext of this argument makes me believe"
+ 		echo "*** that it is just a static archive that I should not use here."
+-	      else
+-		echo
+-		$ECHO "*** Warning: Linking the shared library $output against the"
+-		$ECHO "*** static library $deplib is not portable!"
+-		deplibs="$deplib $deplibs"
+ 	      fi
+ 	      ;;
+ 	    esac
+ 	    continue
+ 	    ;;
+ 	  prog)
+-	    if test "$pass" != link; then
++	    if test link != "$pass"; then
+ 	      deplibs="$deplib $deplibs"
+ 	    else
+ 	      compile_deplibs="$deplib $compile_deplibs"
+@@ -6366,10 +8030,10 @@ func_mode_link ()
+ 	  esac # linkmode
+ 	  ;; # *.$libext
+ 	*.lo | *.$objext)
+-	  if test "$pass" = conv; then
++	  if test conv = "$pass"; then
+ 	    deplibs="$deplib $deplibs"
+-	  elif test "$linkmode" = prog; then
+-	    if test "$pass" = dlpreopen || test "$dlopen_support" != yes || test "$build_libtool_libs" = no; then
++	  elif test prog = "$linkmode"; then
++	    if test dlpreopen = "$pass" || test yes != "$dlopen_support" || test no = "$build_libtool_libs"; then
+ 	      # If there is no dlopen support or we're linking statically,
+ 	      # we need to preload.
+ 	      func_append newdlprefiles " $deplib"
+@@ -6382,22 +8046,20 @@ func_mode_link ()
+ 	  continue
+ 	  ;;
+ 	%DEPLIBS%)
+-	  alldeplibs=yes
++	  alldeplibs=:
+ 	  continue
+ 	  ;;
+ 	esac # case $deplib
+ 
+-	if test "$found" = yes || test -f "$lib"; then :
+-	else
+-	  func_fatal_error "cannot find the library \`$lib' or unhandled argument \`$deplib'"
+-	fi
++	$found || test -f "$lib" \
++	  || func_fatal_error "cannot find the library '$lib' or unhandled argument '$deplib'"
+ 
+ 	# Check to see that this really is a libtool archive.
+ 	func_lalib_unsafe_p "$lib" \
+-	  || func_fatal_error "\`$lib' is not a valid libtool archive"
++	  || func_fatal_error "'$lib' is not a valid libtool archive"
+ 
+ 	func_dirname "$lib" "" "."
+-	ladir="$func_dirname_result"
++	ladir=$func_dirname_result
+ 
+ 	dlname=
+ 	dlopen=
+@@ -6427,30 +8089,30 @@ func_mode_link ()
+ 	  done
+ 	fi
+ 	dependency_libs=`$ECHO " $dependency_libs" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
+-	if test "$linkmode,$pass" = "lib,link" ||
+-	   test "$linkmode,$pass" = "prog,scan" ||
+-	   { test "$linkmode" != prog && test "$linkmode" != lib; }; then
++	if test lib,link = "$linkmode,$pass" ||
++	   test prog,scan = "$linkmode,$pass" ||
++	   { test prog != "$linkmode" && test lib != "$linkmode"; }; then
+ 	  test -n "$dlopen" && func_append dlfiles " $dlopen"
+ 	  test -n "$dlpreopen" && func_append dlprefiles " $dlpreopen"
+ 	fi
+ 
+-	if test "$pass" = conv; then
++	if test conv = "$pass"; then
+ 	  # Only check for convenience libraries
+ 	  deplibs="$lib $deplibs"
+ 	  if test -z "$libdir"; then
+ 	    if test -z "$old_library"; then
+-	      func_fatal_error "cannot find name of link library for \`$lib'"
++	      func_fatal_error "cannot find name of link library for '$lib'"
+ 	    fi
+ 	    # It is a libtool convenience library, so add in its objects.
+ 	    func_append convenience " $ladir/$objdir/$old_library"
+ 	    func_append old_convenience " $ladir/$objdir/$old_library"
+-	  elif test "$linkmode" != prog && test "$linkmode" != lib; then
+-	    func_fatal_error "\`$lib' is not a convenience library"
++	  elif test prog != "$linkmode" && test lib != "$linkmode"; then
++	    func_fatal_error "'$lib' is not a convenience library"
+ 	  fi
+ 	  tmp_libs=
+ 	  for deplib in $dependency_libs; do
+ 	    deplibs="$deplib $deplibs"
+-	    if $opt_preserve_dup_deps ; then
++	    if $opt_preserve_dup_deps; then
+ 	      case "$tmp_libs " in
+ 	      *" $deplib "*) func_append specialdeplibs " $deplib" ;;
+ 	      esac
+@@ -6464,26 +8126,26 @@ func_mode_link ()
+ 	# Get the name of the library we link against.
+ 	linklib=
+ 	if test -n "$old_library" &&
+-	   { test "$prefer_static_libs" = yes ||
+-	     test "$prefer_static_libs,$installed" = "built,no"; }; then
++	   { test yes = "$prefer_static_libs" ||
++	     test built,no = "$prefer_static_libs,$installed"; }; then
+ 	  linklib=$old_library
+ 	else
+ 	  for l in $old_library $library_names; do
+-	    linklib="$l"
++	    linklib=$l
+ 	  done
+ 	fi
+ 	if test -z "$linklib"; then
+-	  func_fatal_error "cannot find name of link library for \`$lib'"
++	  func_fatal_error "cannot find name of link library for '$lib'"
+ 	fi
+ 
+ 	# This library was specified with -dlopen.
+-	if test "$pass" = dlopen; then
+-	  if test -z "$libdir"; then
+-	    func_fatal_error "cannot -dlopen a convenience library: \`$lib'"
+-	  fi
++	if test dlopen = "$pass"; then
++	  test -z "$libdir" \
++	    && func_fatal_error "cannot -dlopen a convenience library: '$lib'"
+ 	  if test -z "$dlname" ||
+-	     test "$dlopen_support" != yes ||
+-	     test "$build_libtool_libs" = no; then
++	     test yes != "$dlopen_support" ||
++	     test no = "$build_libtool_libs"
++	  then
+ 	    # If there is no dlname, no dlopen support or we're linking
+ 	    # statically, we need to preload.  We also need to preload any
+ 	    # dependent libraries so libltdl's deplib preloader doesn't
+@@ -6497,40 +8159,40 @@ func_mode_link ()
+ 
+ 	# We need an absolute path.
+ 	case $ladir in
+-	[\\/]* | [A-Za-z]:[\\/]*) abs_ladir="$ladir" ;;
++	[\\/]* | [A-Za-z]:[\\/]*) abs_ladir=$ladir ;;
+ 	*)
+ 	  abs_ladir=`cd "$ladir" && pwd`
+ 	  if test -z "$abs_ladir"; then
+-	    func_warning "cannot determine absolute directory name of \`$ladir'"
++	    func_warning "cannot determine absolute directory name of '$ladir'"
+ 	    func_warning "passing it literally to the linker, although it might fail"
+-	    abs_ladir="$ladir"
++	    abs_ladir=$ladir
+ 	  fi
+ 	  ;;
+ 	esac
+ 	func_basename "$lib"
+-	laname="$func_basename_result"
++	laname=$func_basename_result
+ 
+ 	# Find the relevant object directory and library name.
+-	if test "X$installed" = Xyes; then
++	if test yes = "$installed"; then
+ 	  if test ! -f "$lt_sysroot$libdir/$linklib" && test -f "$abs_ladir/$linklib"; then
+-	    func_warning "library \`$lib' was moved."
+-	    dir="$ladir"
+-	    absdir="$abs_ladir"
+-	    libdir="$abs_ladir"
++	    func_warning "library '$lib' was moved."
++	    dir=$ladir
++	    absdir=$abs_ladir
++	    libdir=$abs_ladir
+ 	  else
+-	    dir="$lt_sysroot$libdir"
+-	    absdir="$lt_sysroot$libdir"
++	    dir=$lt_sysroot$libdir
++	    absdir=$lt_sysroot$libdir
+ 	  fi
+-	  test "X$hardcode_automatic" = Xyes && avoidtemprpath=yes
++	  test yes = "$hardcode_automatic" && avoidtemprpath=yes
+ 	else
+ 	  if test ! -f "$ladir/$objdir/$linklib" && test -f "$abs_ladir/$linklib"; then
+-	    dir="$ladir"
+-	    absdir="$abs_ladir"
++	    dir=$ladir
++	    absdir=$abs_ladir
+ 	    # Remove this search path later
+ 	    func_append notinst_path " $abs_ladir"
+ 	  else
+-	    dir="$ladir/$objdir"
+-	    absdir="$abs_ladir/$objdir"
++	    dir=$ladir/$objdir
++	    absdir=$abs_ladir/$objdir
+ 	    # Remove this search path later
+ 	    func_append notinst_path " $abs_ladir"
+ 	  fi
+@@ -6539,11 +8201,11 @@ func_mode_link ()
+ 	name=$func_stripname_result
+ 
+ 	# This library was specified with -dlpreopen.
+-	if test "$pass" = dlpreopen; then
+-	  if test -z "$libdir" && test "$linkmode" = prog; then
+-	    func_fatal_error "only libraries may -dlpreopen a convenience library: \`$lib'"
++	if test dlpreopen = "$pass"; then
++	  if test -z "$libdir" && test prog = "$linkmode"; then
++	    func_fatal_error "only libraries may -dlpreopen a convenience library: '$lib'"
+ 	  fi
+-	  case "$host" in
++	  case $host in
+ 	    # special handling for platforms with PE-DLLs.
+ 	    *cygwin* | *mingw* | *cegcc* )
+ 	      # Linker will automatically link against shared library if both
+@@ -6587,9 +8249,9 @@ func_mode_link ()
+ 
+ 	if test -z "$libdir"; then
+ 	  # Link the convenience library
+-	  if test "$linkmode" = lib; then
++	  if test lib = "$linkmode"; then
+ 	    deplibs="$dir/$old_library $deplibs"
+-	  elif test "$linkmode,$pass" = "prog,link"; then
++	  elif test prog,link = "$linkmode,$pass"; then
+ 	    compile_deplibs="$dir/$old_library $compile_deplibs"
+ 	    finalize_deplibs="$dir/$old_library $finalize_deplibs"
+ 	  else
+@@ -6599,14 +8261,14 @@ func_mode_link ()
+ 	fi
+ 
+ 
+-	if test "$linkmode" = prog && test "$pass" != link; then
++	if test prog = "$linkmode" && test link != "$pass"; then
+ 	  func_append newlib_search_path " $ladir"
+ 	  deplibs="$lib $deplibs"
+ 
+-	  linkalldeplibs=no
+-	  if test "$link_all_deplibs" != no || test -z "$library_names" ||
+-	     test "$build_libtool_libs" = no; then
+-	    linkalldeplibs=yes
++	  linkalldeplibs=false
++	  if test no != "$link_all_deplibs" || test -z "$library_names" ||
++	     test no = "$build_libtool_libs"; then
++	    linkalldeplibs=:
+ 	  fi
+ 
+ 	  tmp_libs=
+@@ -6618,14 +8280,14 @@ func_mode_link ()
+ 		 ;;
+ 	    esac
+ 	    # Need to link against all dependency_libs?
+-	    if test "$linkalldeplibs" = yes; then
++	    if $linkalldeplibs; then
+ 	      deplibs="$deplib $deplibs"
+ 	    else
+ 	      # Need to hardcode shared library paths
+ 	      # or/and link against static libraries
+ 	      newdependency_libs="$deplib $newdependency_libs"
+ 	    fi
+-	    if $opt_preserve_dup_deps ; then
++	    if $opt_preserve_dup_deps; then
+ 	      case "$tmp_libs " in
+ 	      *" $deplib "*) func_append specialdeplibs " $deplib" ;;
+ 	      esac
+@@ -6635,15 +8297,15 @@ func_mode_link ()
+ 	  continue
+ 	fi # $linkmode = prog...
+ 
+-	if test "$linkmode,$pass" = "prog,link"; then
++	if test prog,link = "$linkmode,$pass"; then
+ 	  if test -n "$library_names" &&
+-	     { { test "$prefer_static_libs" = no ||
+-	         test "$prefer_static_libs,$installed" = "built,yes"; } ||
++	     { { test no = "$prefer_static_libs" ||
++	         test built,yes = "$prefer_static_libs,$installed"; } ||
+ 	       test -z "$old_library"; }; then
+ 	    # We need to hardcode the library path
+-	    if test -n "$shlibpath_var" && test -z "$avoidtemprpath" ; then
++	    if test -n "$shlibpath_var" && test -z "$avoidtemprpath"; then
+ 	      # Make sure the rpath contains only unique directories.
+-	      case "$temp_rpath:" in
++	      case $temp_rpath: in
+ 	      *"$absdir:"*) ;;
+ 	      *) func_append temp_rpath "$absdir:" ;;
+ 	      esac
+@@ -6672,9 +8334,9 @@ func_mode_link ()
+ 	    esac
+ 	  fi # $linkmode,$pass = prog,link...
+ 
+-	  if test "$alldeplibs" = yes &&
+-	     { test "$deplibs_check_method" = pass_all ||
+-	       { test "$build_libtool_libs" = yes &&
++	  if $alldeplibs &&
++	     { test pass_all = "$deplibs_check_method" ||
++	       { test yes = "$build_libtool_libs" &&
+ 		 test -n "$library_names"; }; }; then
+ 	    # We only need to search for static libraries
+ 	    continue
+@@ -6683,19 +8345,19 @@ func_mode_link ()
+ 
+ 	link_static=no # Whether the deplib will be linked statically
+ 	use_static_libs=$prefer_static_libs
+-	if test "$use_static_libs" = built && test "$installed" = yes; then
++	if test built = "$use_static_libs" && test yes = "$installed"; then
+ 	  use_static_libs=no
+ 	fi
+ 	if test -n "$library_names" &&
+-	   { test "$use_static_libs" = no || test -z "$old_library"; }; then
++	   { test no = "$use_static_libs" || test -z "$old_library"; }; then
+ 	  case $host in
+-	  *cygwin* | *mingw* | *cegcc*)
++	  *cygwin* | *mingw* | *cegcc* | *os2*)
+ 	      # No point in relinking DLLs because paths are not encoded
+ 	      func_append notinst_deplibs " $lib"
+ 	      need_relink=no
+ 	    ;;
+ 	  *)
+-	    if test "$installed" = no; then
++	    if test no = "$installed"; then
+ 	      func_append notinst_deplibs " $lib"
+ 	      need_relink=yes
+ 	    fi
+@@ -6705,24 +8367,24 @@ func_mode_link ()
+ 
+ 	  # Warn about portability, can't link against -module's on some
+ 	  # systems (darwin).  Don't bleat about dlopened modules though!
+-	  dlopenmodule=""
++	  dlopenmodule=
+ 	  for dlpremoduletest in $dlprefiles; do
+ 	    if test "X$dlpremoduletest" = "X$lib"; then
+-	      dlopenmodule="$dlpremoduletest"
++	      dlopenmodule=$dlpremoduletest
+ 	      break
+ 	    fi
+ 	  done
+-	  if test -z "$dlopenmodule" && test "$shouldnotlink" = yes && test "$pass" = link; then
++	  if test -z "$dlopenmodule" && test yes = "$shouldnotlink" && test link = "$pass"; then
+ 	    echo
+-	    if test "$linkmode" = prog; then
++	    if test prog = "$linkmode"; then
+ 	      $ECHO "*** Warning: Linking the executable $output against the loadable module"
+ 	    else
+ 	      $ECHO "*** Warning: Linking the shared library $output against the loadable module"
+ 	    fi
+ 	    $ECHO "*** $linklib is not portable!"
+ 	  fi
+-	  if test "$linkmode" = lib &&
+-	     test "$hardcode_into_libs" = yes; then
++	  if test lib = "$linkmode" &&
++	     test yes = "$hardcode_into_libs"; then
+ 	    # Hardcode the library path.
+ 	    # Skip directories that are in the system default run-time
+ 	    # search path.
+@@ -6750,43 +8412,43 @@ func_mode_link ()
+ 	    # figure out the soname
+ 	    set dummy $library_names
+ 	    shift
+-	    realname="$1"
++	    realname=$1
+ 	    shift
+ 	    libname=`eval "\\$ECHO \"$libname_spec\""`
+ 	    # use dlname if we got it. it's perfectly good, no?
+ 	    if test -n "$dlname"; then
+-	      soname="$dlname"
++	      soname=$dlname
+ 	    elif test -n "$soname_spec"; then
+ 	      # bleh windows
+ 	      case $host in
+-	      *cygwin* | mingw* | *cegcc*)
++	      *cygwin* | mingw* | *cegcc* | *os2*)
+ 	        func_arith $current - $age
+ 		major=$func_arith_result
+-		versuffix="-$major"
++		versuffix=-$major
+ 		;;
+ 	      esac
+ 	      eval soname=\"$soname_spec\"
+ 	    else
+-	      soname="$realname"
++	      soname=$realname
+ 	    fi
+ 
+ 	    # Make a new name for the extract_expsyms_cmds to use
+-	    soroot="$soname"
++	    soroot=$soname
+ 	    func_basename "$soroot"
+-	    soname="$func_basename_result"
++	    soname=$func_basename_result
+ 	    func_stripname 'lib' '.dll' "$soname"
+ 	    newlib=libimp-$func_stripname_result.a
+ 
+ 	    # If the library has no export list, then create one now
+ 	    if test -f "$output_objdir/$soname-def"; then :
+ 	    else
+-	      func_verbose "extracting exported symbol list from \`$soname'"
++	      func_verbose "extracting exported symbol list from '$soname'"
+ 	      func_execute_cmds "$extract_expsyms_cmds" 'exit $?'
+ 	    fi
+ 
+ 	    # Create $newlib
+ 	    if test -f "$output_objdir/$newlib"; then :; else
+-	      func_verbose "generating import library for \`$soname'"
++	      func_verbose "generating import library for '$soname'"
+ 	      func_execute_cmds "$old_archive_from_expsyms_cmds" 'exit $?'
+ 	    fi
+ 	    # make sure the library variables are pointing to the new library
+@@ -6794,58 +8456,58 @@ func_mode_link ()
+ 	    linklib=$newlib
+ 	  fi # test -n "$old_archive_from_expsyms_cmds"
+ 
+-	  if test "$linkmode" = prog || test "$opt_mode" != relink; then
++	  if test prog = "$linkmode" || test relink != "$opt_mode"; then
+ 	    add_shlibpath=
+ 	    add_dir=
+ 	    add=
+ 	    lib_linked=yes
+ 	    case $hardcode_action in
+ 	    immediate | unsupported)
+-	      if test "$hardcode_direct" = no; then
+-		add="$dir/$linklib"
++	      if test no = "$hardcode_direct"; then
++		add=$dir/$linklib
+ 		case $host in
+-		  *-*-sco3.2v5.0.[024]*) add_dir="-L$dir" ;;
+-		  *-*-sysv4*uw2*) add_dir="-L$dir" ;;
++		  *-*-sco3.2v5.0.[024]*) add_dir=-L$dir ;;
++		  *-*-sysv4*uw2*) add_dir=-L$dir ;;
+ 		  *-*-sysv5OpenUNIX* | *-*-sysv5UnixWare7.[01].[10]* | \
+-		    *-*-unixware7*) add_dir="-L$dir" ;;
++		    *-*-unixware7*) add_dir=-L$dir ;;
+ 		  *-*-darwin* )
+-		    # if the lib is a (non-dlopened) module then we can not
++		    # if the lib is a (non-dlopened) module then we cannot
+ 		    # link against it, someone is ignoring the earlier warnings
+ 		    if /usr/bin/file -L $add 2> /dev/null |
+-			 $GREP ": [^:]* bundle" >/dev/null ; then
++			 $GREP ": [^:]* bundle" >/dev/null; then
+ 		      if test "X$dlopenmodule" != "X$lib"; then
+ 			$ECHO "*** Warning: lib $linklib is a module, not a shared library"
+-			if test -z "$old_library" ; then
++			if test -z "$old_library"; then
+ 			  echo
+ 			  echo "*** And there doesn't seem to be a static archive available"
+ 			  echo "*** The link will probably fail, sorry"
+ 			else
+-			  add="$dir/$old_library"
++			  add=$dir/$old_library
+ 			fi
+ 		      elif test -n "$old_library"; then
+-			add="$dir/$old_library"
++			add=$dir/$old_library
+ 		      fi
+ 		    fi
+ 		esac
+-	      elif test "$hardcode_minus_L" = no; then
++	      elif test no = "$hardcode_minus_L"; then
+ 		case $host in
+-		*-*-sunos*) add_shlibpath="$dir" ;;
++		*-*-sunos*) add_shlibpath=$dir ;;
+ 		esac
+-		add_dir="-L$dir"
+-		add="-l$name"
+-	      elif test "$hardcode_shlibpath_var" = no; then
+-		add_shlibpath="$dir"
+-		add="-l$name"
++		add_dir=-L$dir
++		add=-l$name
++	      elif test no = "$hardcode_shlibpath_var"; then
++		add_shlibpath=$dir
++		add=-l$name
+ 	      else
+ 		lib_linked=no
+ 	      fi
+ 	      ;;
+ 	    relink)
+-	      if test "$hardcode_direct" = yes &&
+-	         test "$hardcode_direct_absolute" = no; then
+-		add="$dir/$linklib"
+-	      elif test "$hardcode_minus_L" = yes; then
+-		add_dir="-L$absdir"
++	      if test yes = "$hardcode_direct" &&
++	         test no = "$hardcode_direct_absolute"; then
++		add=$dir/$linklib
++	      elif test yes = "$hardcode_minus_L"; then
++		add_dir=-L$absdir
+ 		# Try looking first in the location we're being installed to.
+ 		if test -n "$inst_prefix_dir"; then
+ 		  case $libdir in
+@@ -6854,10 +8516,10 @@ func_mode_link ()
+ 		      ;;
+ 		  esac
+ 		fi
+-		add="-l$name"
+-	      elif test "$hardcode_shlibpath_var" = yes; then
+-		add_shlibpath="$dir"
+-		add="-l$name"
++		add=-l$name
++	      elif test yes = "$hardcode_shlibpath_var"; then
++		add_shlibpath=$dir
++		add=-l$name
+ 	      else
+ 		lib_linked=no
+ 	      fi
+@@ -6865,7 +8527,7 @@ func_mode_link ()
+ 	    *) lib_linked=no ;;
+ 	    esac
+ 
+-	    if test "$lib_linked" != yes; then
++	    if test yes != "$lib_linked"; then
+ 	      func_fatal_configuration "unsupported hardcode properties"
+ 	    fi
+ 
+@@ -6875,15 +8537,15 @@ func_mode_link ()
+ 	      *) func_append compile_shlibpath "$add_shlibpath:" ;;
+ 	      esac
+ 	    fi
+-	    if test "$linkmode" = prog; then
++	    if test prog = "$linkmode"; then
+ 	      test -n "$add_dir" && compile_deplibs="$add_dir $compile_deplibs"
+ 	      test -n "$add" && compile_deplibs="$add $compile_deplibs"
+ 	    else
+ 	      test -n "$add_dir" && deplibs="$add_dir $deplibs"
+ 	      test -n "$add" && deplibs="$add $deplibs"
+-	      if test "$hardcode_direct" != yes &&
+-		 test "$hardcode_minus_L" != yes &&
+-		 test "$hardcode_shlibpath_var" = yes; then
++	      if test yes != "$hardcode_direct" &&
++		 test yes != "$hardcode_minus_L" &&
++		 test yes = "$hardcode_shlibpath_var"; then
+ 		case :$finalize_shlibpath: in
+ 		*":$libdir:"*) ;;
+ 		*) func_append finalize_shlibpath "$libdir:" ;;
+@@ -6892,33 +8554,33 @@ func_mode_link ()
+ 	    fi
+ 	  fi
+ 
+-	  if test "$linkmode" = prog || test "$opt_mode" = relink; then
++	  if test prog = "$linkmode" || test relink = "$opt_mode"; then
+ 	    add_shlibpath=
+ 	    add_dir=
+ 	    add=
+ 	    # Finalize command for both is simple: just hardcode it.
+-	    if test "$hardcode_direct" = yes &&
+-	       test "$hardcode_direct_absolute" = no; then
+-	      add="$libdir/$linklib"
+-	    elif test "$hardcode_minus_L" = yes; then
+-	      add_dir="-L$libdir"
+-	      add="-l$name"
+-	    elif test "$hardcode_shlibpath_var" = yes; then
++	    if test yes = "$hardcode_direct" &&
++	       test no = "$hardcode_direct_absolute"; then
++	      add=$libdir/$linklib
++	    elif test yes = "$hardcode_minus_L"; then
++	      add_dir=-L$libdir
++	      add=-l$name
++	    elif test yes = "$hardcode_shlibpath_var"; then
+ 	      case :$finalize_shlibpath: in
+ 	      *":$libdir:"*) ;;
+ 	      *) func_append finalize_shlibpath "$libdir:" ;;
+ 	      esac
+-	      add="-l$name"
+-	    elif test "$hardcode_automatic" = yes; then
++	      add=-l$name
++	    elif test yes = "$hardcode_automatic"; then
+ 	      if test -n "$inst_prefix_dir" &&
+-		 test -f "$inst_prefix_dir$libdir/$linklib" ; then
+-		add="$inst_prefix_dir$libdir/$linklib"
++		 test -f "$inst_prefix_dir$libdir/$linklib"; then
++		add=$inst_prefix_dir$libdir/$linklib
+ 	      else
+-		add="$libdir/$linklib"
++		add=$libdir/$linklib
+ 	      fi
+ 	    else
+ 	      # We cannot seem to hardcode it, guess we'll fake it.
+-	      add_dir="-L$libdir"
++	      add_dir=-L$libdir
+ 	      # Try looking first in the location we're being installed to.
+ 	      if test -n "$inst_prefix_dir"; then
+ 		case $libdir in
+@@ -6927,10 +8589,10 @@ func_mode_link ()
+ 		    ;;
+ 		esac
+ 	      fi
+-	      add="-l$name"
++	      add=-l$name
+ 	    fi
+ 
+-	    if test "$linkmode" = prog; then
++	    if test prog = "$linkmode"; then
+ 	      test -n "$add_dir" && finalize_deplibs="$add_dir $finalize_deplibs"
+ 	      test -n "$add" && finalize_deplibs="$add $finalize_deplibs"
+ 	    else
+@@ -6938,43 +8600,43 @@ func_mode_link ()
+ 	      test -n "$add" && deplibs="$add $deplibs"
+ 	    fi
+ 	  fi
+-	elif test "$linkmode" = prog; then
++	elif test prog = "$linkmode"; then
+ 	  # Here we assume that one of hardcode_direct or hardcode_minus_L
+ 	  # is not unsupported.  This is valid on all known static and
+ 	  # shared platforms.
+-	  if test "$hardcode_direct" != unsupported; then
+-	    test -n "$old_library" && linklib="$old_library"
++	  if test unsupported != "$hardcode_direct"; then
++	    test -n "$old_library" && linklib=$old_library
+ 	    compile_deplibs="$dir/$linklib $compile_deplibs"
+ 	    finalize_deplibs="$dir/$linklib $finalize_deplibs"
+ 	  else
+ 	    compile_deplibs="-l$name -L$dir $compile_deplibs"
+ 	    finalize_deplibs="-l$name -L$dir $finalize_deplibs"
+ 	  fi
+-	elif test "$build_libtool_libs" = yes; then
++	elif test yes = "$build_libtool_libs"; then
+ 	  # Not a shared library
+-	  if test "$deplibs_check_method" != pass_all; then
++	  if test pass_all != "$deplibs_check_method"; then
+ 	    # We're trying link a shared library against a static one
+ 	    # but the system doesn't support it.
+ 
+ 	    # Just print a warning and add the library to dependency_libs so
+ 	    # that the program can be linked against the static library.
+ 	    echo
+-	    $ECHO "*** Warning: This system can not link to static lib archive $lib."
++	    $ECHO "*** Warning: This system cannot link to static lib archive $lib."
+ 	    echo "*** I have the capability to make that library automatically link in when"
+ 	    echo "*** you link to this library.  But I can only do this if you have a"
+ 	    echo "*** shared version of the library, which you do not appear to have."
+-	    if test "$module" = yes; then
++	    if test yes = "$module"; then
+ 	      echo "*** But as you try to build a module library, libtool will still create "
+ 	      echo "*** a static module, that should work as long as the dlopening application"
+ 	      echo "*** is linked with the -dlopen flag to resolve symbols at runtime."
+ 	      if test -z "$global_symbol_pipe"; then
+ 		echo
+ 		echo "*** However, this would only work if libtool was able to extract symbol"
+-		echo "*** lists from a program, using \`nm' or equivalent, but libtool could"
++		echo "*** lists from a program, using 'nm' or equivalent, but libtool could"
+ 		echo "*** not find such a program.  So, this module is probably useless."
+-		echo "*** \`nm' from GNU binutils and a full rebuild may help."
++		echo "*** 'nm' from GNU binutils and a full rebuild may help."
+ 	      fi
+-	      if test "$build_old_libs" = no; then
++	      if test no = "$build_old_libs"; then
+ 		build_libtool_libs=module
+ 		build_old_libs=yes
+ 	      else
+@@ -6987,11 +8649,11 @@ func_mode_link ()
+ 	  fi
+ 	fi # link shared/static library?
+ 
+-	if test "$linkmode" = lib; then
++	if test lib = "$linkmode"; then
+ 	  if test -n "$dependency_libs" &&
+-	     { test "$hardcode_into_libs" != yes ||
+-	       test "$build_old_libs" = yes ||
+-	       test "$link_static" = yes; }; then
++	     { test yes != "$hardcode_into_libs" ||
++	       test yes = "$build_old_libs" ||
++	       test yes = "$link_static"; }; then
+ 	    # Extract -R from dependency_libs
+ 	    temp_deplibs=
+ 	    for libdir in $dependency_libs; do
+@@ -7005,12 +8667,12 @@ func_mode_link ()
+ 	      *) func_append temp_deplibs " $libdir";;
+ 	      esac
+ 	    done
+-	    dependency_libs="$temp_deplibs"
++	    dependency_libs=$temp_deplibs
+ 	  fi
+ 
+ 	  func_append newlib_search_path " $absdir"
+ 	  # Link against this library
+-	  test "$link_static" = no && newdependency_libs="$abs_ladir/$laname $newdependency_libs"
++	  test no = "$link_static" && newdependency_libs="$abs_ladir/$laname $newdependency_libs"
+ 	  # ... and its dependency_libs
+ 	  tmp_libs=
+ 	  for deplib in $dependency_libs; do
+@@ -7020,7 +8682,7 @@ func_mode_link ()
+                    func_resolve_sysroot "$func_stripname_result";;
+               *) func_resolve_sysroot "$deplib" ;;
+             esac
+-	    if $opt_preserve_dup_deps ; then
++	    if $opt_preserve_dup_deps; then
+ 	      case "$tmp_libs " in
+ 	      *" $func_resolve_sysroot_result "*)
+                 func_append specialdeplibs " $func_resolve_sysroot_result" ;;
+@@ -7029,12 +8691,12 @@ func_mode_link ()
+ 	    func_append tmp_libs " $func_resolve_sysroot_result"
+ 	  done
+ 
+-	  if test "$link_all_deplibs" != no; then
++	  if test no != "$link_all_deplibs"; then
+ 	    # Add the search paths of all dependency libraries
+ 	    for deplib in $dependency_libs; do
+ 	      path=
+ 	      case $deplib in
+-	      -L*) path="$deplib" ;;
++	      -L*) path=$deplib ;;
+ 	      *.la)
+ 	        func_resolve_sysroot "$deplib"
+ 	        deplib=$func_resolve_sysroot_result
+@@ -7042,12 +8704,12 @@ func_mode_link ()
+ 		dir=$func_dirname_result
+ 		# We need an absolute path.
+ 		case $dir in
+-		[\\/]* | [A-Za-z]:[\\/]*) absdir="$dir" ;;
++		[\\/]* | [A-Za-z]:[\\/]*) absdir=$dir ;;
+ 		*)
+ 		  absdir=`cd "$dir" && pwd`
+ 		  if test -z "$absdir"; then
+-		    func_warning "cannot determine absolute directory name of \`$dir'"
+-		    absdir="$dir"
++		    func_warning "cannot determine absolute directory name of '$dir'"
++		    absdir=$dir
+ 		  fi
+ 		  ;;
+ 		esac
+@@ -7055,35 +8717,35 @@ func_mode_link ()
+ 		case $host in
+ 		*-*-darwin*)
+ 		  depdepl=
+-		  eval deplibrary_names=`${SED} -n -e 's/^library_names=\(.*\)$/\1/p' $deplib`
+-		  if test -n "$deplibrary_names" ; then
+-		    for tmp in $deplibrary_names ; do
++		  eval deplibrary_names=`$SED -n -e 's/^library_names=\(.*\)$/\1/p' $deplib`
++		  if test -n "$deplibrary_names"; then
++		    for tmp in $deplibrary_names; do
+ 		      depdepl=$tmp
+ 		    done
+-		    if test -f "$absdir/$objdir/$depdepl" ; then
+-		      depdepl="$absdir/$objdir/$depdepl"
+-		      darwin_install_name=`${OTOOL} -L $depdepl | awk '{if (NR == 2) {print $1;exit}}'`
++		    if test -f "$absdir/$objdir/$depdepl"; then
++		      depdepl=$absdir/$objdir/$depdepl
++		      darwin_install_name=`$OTOOL -L $depdepl | awk '{if (NR == 2) {print $1;exit}}'`
+                       if test -z "$darwin_install_name"; then
+-                          darwin_install_name=`${OTOOL64} -L $depdepl  | awk '{if (NR == 2) {print $1;exit}}'`
++                          darwin_install_name=`$OTOOL64 -L $depdepl  | awk '{if (NR == 2) {print $1;exit}}'`
+                       fi
+-		      func_append compiler_flags " ${wl}-dylib_file ${wl}${darwin_install_name}:${depdepl}"
+-		      func_append linker_flags " -dylib_file ${darwin_install_name}:${depdepl}"
++		      func_append compiler_flags " $wl-dylib_file $wl$darwin_install_name:$depdepl"
++		      func_append linker_flags " -dylib_file $darwin_install_name:$depdepl"
+ 		      path=
+ 		    fi
+ 		  fi
+ 		  ;;
+ 		*)
+-		  path="-L$absdir/$objdir"
++		  path=-L$absdir/$objdir
+ 		  ;;
+ 		esac
+ 		else
+-		  eval libdir=`${SED} -n -e 's/^libdir=\(.*\)$/\1/p' $deplib`
++		  eval libdir=`$SED -n -e 's/^libdir=\(.*\)$/\1/p' $deplib`
+ 		  test -z "$libdir" && \
+-		    func_fatal_error "\`$deplib' is not a valid libtool archive"
++		    func_fatal_error "'$deplib' is not a valid libtool archive"
+ 		  test "$absdir" != "$libdir" && \
+-		    func_warning "\`$deplib' seems to be moved"
++		    func_warning "'$deplib' seems to be moved"
+ 
+-		  path="-L$absdir"
++		  path=-L$absdir
+ 		fi
+ 		;;
+ 	      esac
+@@ -7095,23 +8757,23 @@ func_mode_link ()
+ 	  fi # link_all_deplibs != no
+ 	fi # linkmode = lib
+       done # for deplib in $libs
+-      if test "$pass" = link; then
+-	if test "$linkmode" = "prog"; then
++      if test link = "$pass"; then
++	if test prog = "$linkmode"; then
+ 	  compile_deplibs="$new_inherited_linker_flags $compile_deplibs"
+ 	  finalize_deplibs="$new_inherited_linker_flags $finalize_deplibs"
+ 	else
+ 	  compiler_flags="$compiler_flags "`$ECHO " $new_inherited_linker_flags" | $SED 's% \([^ $]*\).ltframework% -framework \1%g'`
+ 	fi
+       fi
+-      dependency_libs="$newdependency_libs"
+-      if test "$pass" = dlpreopen; then
++      dependency_libs=$newdependency_libs
++      if test dlpreopen = "$pass"; then
+ 	# Link the dlpreopened libraries before other libraries
+ 	for deplib in $save_deplibs; do
+ 	  deplibs="$deplib $deplibs"
+ 	done
+       fi
+-      if test "$pass" != dlopen; then
+-	if test "$pass" != conv; then
++      if test dlopen != "$pass"; then
++	test conv = "$pass" || {
+ 	  # Make sure lib_search_path contains only unique directories.
+ 	  lib_search_path=
+ 	  for dir in $newlib_search_path; do
+@@ -7121,12 +8783,12 @@ func_mode_link ()
+ 	    esac
+ 	  done
+ 	  newlib_search_path=
+-	fi
++	}
+ 
+-	if test "$linkmode,$pass" != "prog,link"; then
+-	  vars="deplibs"
+-	else
++	if test prog,link = "$linkmode,$pass"; then
+ 	  vars="compile_deplibs finalize_deplibs"
++	else
++	  vars=deplibs
+ 	fi
+ 	for var in $vars dependency_libs; do
+ 	  # Add libraries to $var in reverse order
+@@ -7184,62 +8846,93 @@ func_mode_link ()
+ 	  eval $var=\"$tmp_libs\"
+ 	done # for var
+       fi
++
++      # Add Sun CC postdeps if required:
++      test CXX = "$tagname" && {
++        case $host_os in
++        linux*)
++          case `$CC -V 2>&1 | sed 5q` in
++          *Sun\ C*) # Sun C++ 5.9
++            func_suncc_cstd_abi
++
++            if test no != "$suncc_use_cstd_abi"; then
++              func_append postdeps ' -library=Cstd -library=Crun'
++            fi
++            ;;
++          esac
++          ;;
++
++        solaris*)
++          func_cc_basename "$CC"
++          case $func_cc_basename_result in
++          CC* | sunCC*)
++            func_suncc_cstd_abi
++
++            if test no != "$suncc_use_cstd_abi"; then
++              func_append postdeps ' -library=Cstd -library=Crun'
++            fi
++            ;;
++          esac
++          ;;
++        esac
++      }
++
+       # Last step: remove runtime libs from dependency_libs
+       # (they stay in deplibs)
+       tmp_libs=
+-      for i in $dependency_libs ; do
++      for i in $dependency_libs; do
+ 	case " $predeps $postdeps $compiler_lib_search_path " in
+ 	*" $i "*)
+-	  i=""
++	  i=
+ 	  ;;
+ 	esac
+-	if test -n "$i" ; then
++	if test -n "$i"; then
+ 	  func_append tmp_libs " $i"
+ 	fi
+       done
+       dependency_libs=$tmp_libs
+     done # for pass
+-    if test "$linkmode" = prog; then
+-      dlfiles="$newdlfiles"
++    if test prog = "$linkmode"; then
++      dlfiles=$newdlfiles
+     fi
+-    if test "$linkmode" = prog || test "$linkmode" = lib; then
+-      dlprefiles="$newdlprefiles"
++    if test prog = "$linkmode" || test lib = "$linkmode"; then
++      dlprefiles=$newdlprefiles
+     fi
+ 
+     case $linkmode in
+     oldlib)
+-      if test -n "$dlfiles$dlprefiles" || test "$dlself" != no; then
+-	func_warning "\`-dlopen' is ignored for archives"
++      if test -n "$dlfiles$dlprefiles" || test no != "$dlself"; then
++	func_warning "'-dlopen' is ignored for archives"
+       fi
+ 
+       case " $deplibs" in
+       *\ -l* | *\ -L*)
+-	func_warning "\`-l' and \`-L' are ignored for archives" ;;
++	func_warning "'-l' and '-L' are ignored for archives" ;;
+       esac
+ 
+       test -n "$rpath" && \
+-	func_warning "\`-rpath' is ignored for archives"
++	func_warning "'-rpath' is ignored for archives"
+ 
+       test -n "$xrpath" && \
+-	func_warning "\`-R' is ignored for archives"
++	func_warning "'-R' is ignored for archives"
+ 
+       test -n "$vinfo" && \
+-	func_warning "\`-version-info/-version-number' is ignored for archives"
++	func_warning "'-version-info/-version-number' is ignored for archives"
+ 
+       test -n "$release" && \
+-	func_warning "\`-release' is ignored for archives"
++	func_warning "'-release' is ignored for archives"
+ 
+       test -n "$export_symbols$export_symbols_regex" && \
+-	func_warning "\`-export-symbols' is ignored for archives"
++	func_warning "'-export-symbols' is ignored for archives"
+ 
+       # Now set the variables for building old libraries.
+       build_libtool_libs=no
+-      oldlibs="$output"
++      oldlibs=$output
+       func_append objs "$old_deplibs"
+       ;;
+ 
+     lib)
+-      # Make sure we only generate libraries of the form `libNAME.la'.
++      # Make sure we only generate libraries of the form 'libNAME.la'.
+       case $outputname in
+       lib*)
+ 	func_stripname 'lib' '.la' "$outputname"
+@@ -7248,10 +8941,10 @@ func_mode_link ()
+ 	eval libname=\"$libname_spec\"
+ 	;;
+       *)
+-	test "$module" = no && \
+-	  func_fatal_help "libtool library \`$output' must begin with \`lib'"
++	test no = "$module" \
++	  && func_fatal_help "libtool library '$output' must begin with 'lib'"
+ 
+-	if test "$need_lib_prefix" != no; then
++	if test no != "$need_lib_prefix"; then
+ 	  # Add the "lib" prefix for modules if required
+ 	  func_stripname '' '.la' "$outputname"
+ 	  name=$func_stripname_result
+@@ -7265,8 +8958,8 @@ func_mode_link ()
+       esac
+ 
+       if test -n "$objs"; then
+-	if test "$deplibs_check_method" != pass_all; then
+-	  func_fatal_error "cannot build libtool library \`$output' from non-libtool objects on this host:$objs"
++	if test pass_all != "$deplibs_check_method"; then
++	  func_fatal_error "cannot build libtool library '$output' from non-libtool objects on this host:$objs"
+ 	else
+ 	  echo
+ 	  $ECHO "*** Warning: Linking the shared library $output against the non-libtool"
+@@ -7275,21 +8968,21 @@ func_mode_link ()
+ 	fi
+       fi
+ 
+-      test "$dlself" != no && \
+-	func_warning "\`-dlopen self' is ignored for libtool libraries"
++      test no = "$dlself" \
++	|| func_warning "'-dlopen self' is ignored for libtool libraries"
+ 
+       set dummy $rpath
+       shift
+-      test "$#" -gt 1 && \
+-	func_warning "ignoring multiple \`-rpath's for a libtool library"
++      test 1 -lt "$#" \
++	&& func_warning "ignoring multiple '-rpath's for a libtool library"
+ 
+-      install_libdir="$1"
++      install_libdir=$1
+ 
+       oldlibs=
+       if test -z "$rpath"; then
+-	if test "$build_libtool_libs" = yes; then
++	if test yes = "$build_libtool_libs"; then
+ 	  # Building a libtool convenience library.
+-	  # Some compilers have problems with a `.al' extension so
++	  # Some compilers have problems with a '.al' extension so
+ 	  # convenience libraries should have the same extension an
+ 	  # archive normally would.
+ 	  oldlibs="$output_objdir/$libname.$libext $oldlibs"
+@@ -7298,20 +8991,20 @@ func_mode_link ()
+ 	fi
+ 
+ 	test -n "$vinfo" && \
+-	  func_warning "\`-version-info/-version-number' is ignored for convenience libraries"
++	  func_warning "'-version-info/-version-number' is ignored for convenience libraries"
+ 
+ 	test -n "$release" && \
+-	  func_warning "\`-release' is ignored for convenience libraries"
++	  func_warning "'-release' is ignored for convenience libraries"
+       else
+ 
+ 	# Parse the version information argument.
+-	save_ifs="$IFS"; IFS=':'
++	save_ifs=$IFS; IFS=:
+ 	set dummy $vinfo 0 0 0
+ 	shift
+-	IFS="$save_ifs"
++	IFS=$save_ifs
+ 
+ 	test -n "$7" && \
+-	  func_fatal_help "too many parameters to \`-version-info'"
++	  func_fatal_help "too many parameters to '-version-info'"
+ 
+ 	# convert absolute version numbers to libtool ages
+ 	# this retains compatibility with .la files and attempts
+@@ -7319,42 +9012,42 @@ func_mode_link ()
+ 
+ 	case $vinfo_number in
+ 	yes)
+-	  number_major="$1"
+-	  number_minor="$2"
+-	  number_revision="$3"
++	  number_major=$1
++	  number_minor=$2
++	  number_revision=$3
+ 	  #
+ 	  # There are really only two kinds -- those that
+ 	  # use the current revision as the major version
+ 	  # and those that subtract age and use age as
+ 	  # a minor version.  But, then there is irix
+-	  # which has an extra 1 added just for fun
++	  # that has an extra 1 added just for fun
+ 	  #
+ 	  case $version_type in
+ 	  # correct linux to gnu/linux during the next big refactor
+-	  darwin|linux|osf|windows|none)
++	  darwin|freebsd-elf|linux|osf|windows|none)
+ 	    func_arith $number_major + $number_minor
+ 	    current=$func_arith_result
+-	    age="$number_minor"
+-	    revision="$number_revision"
++	    age=$number_minor
++	    revision=$number_revision
+ 	    ;;
+-	  freebsd-aout|freebsd-elf|qnx|sunos)
+-	    current="$number_major"
+-	    revision="$number_minor"
+-	    age="0"
++	  freebsd-aout|qnx|sunos)
++	    current=$number_major
++	    revision=$number_minor
++	    age=0
+ 	    ;;
+ 	  irix|nonstopux)
+ 	    func_arith $number_major + $number_minor
+ 	    current=$func_arith_result
+-	    age="$number_minor"
+-	    revision="$number_minor"
++	    age=$number_minor
++	    revision=$number_minor
+ 	    lt_irix_increment=no
+ 	    ;;
+ 	  esac
+ 	  ;;
+ 	no)
+-	  current="$1"
+-	  revision="$2"
+-	  age="$3"
++	  current=$1
++	  revision=$2
++	  age=$3
+ 	  ;;
+ 	esac
+ 
+@@ -7362,30 +9055,30 @@ func_mode_link ()
+ 	case $current in
+ 	0|[1-9]|[1-9][0-9]|[1-9][0-9][0-9]|[1-9][0-9][0-9][0-9]|[1-9][0-9][0-9][0-9][0-9]) ;;
+ 	*)
+-	  func_error "CURRENT \`$current' must be a nonnegative integer"
+-	  func_fatal_error "\`$vinfo' is not valid version information"
++	  func_error "CURRENT '$current' must be a nonnegative integer"
++	  func_fatal_error "'$vinfo' is not valid version information"
+ 	  ;;
+ 	esac
+ 
+ 	case $revision in
+ 	0|[1-9]|[1-9][0-9]|[1-9][0-9][0-9]|[1-9][0-9][0-9][0-9]|[1-9][0-9][0-9][0-9][0-9]) ;;
+ 	*)
+-	  func_error "REVISION \`$revision' must be a nonnegative integer"
+-	  func_fatal_error "\`$vinfo' is not valid version information"
++	  func_error "REVISION '$revision' must be a nonnegative integer"
++	  func_fatal_error "'$vinfo' is not valid version information"
+ 	  ;;
+ 	esac
+ 
+ 	case $age in
+ 	0|[1-9]|[1-9][0-9]|[1-9][0-9][0-9]|[1-9][0-9][0-9][0-9]|[1-9][0-9][0-9][0-9][0-9]) ;;
+ 	*)
+-	  func_error "AGE \`$age' must be a nonnegative integer"
+-	  func_fatal_error "\`$vinfo' is not valid version information"
++	  func_error "AGE '$age' must be a nonnegative integer"
++	  func_fatal_error "'$vinfo' is not valid version information"
+ 	  ;;
+ 	esac
+ 
+ 	if test "$age" -gt "$current"; then
+-	  func_error "AGE \`$age' is greater than the current interface number \`$current'"
+-	  func_fatal_error "\`$vinfo' is not valid version information"
++	  func_error "AGE '$age' is greater than the current interface number '$current'"
++	  func_fatal_error "'$vinfo' is not valid version information"
+ 	fi
+ 
+ 	# Calculate the version variables.
+@@ -7400,26 +9093,36 @@ func_mode_link ()
+ 	  # verstring for coding it into the library header
+ 	  func_arith $current - $age
+ 	  major=.$func_arith_result
+-	  versuffix="$major.$age.$revision"
++	  versuffix=$major.$age.$revision
+ 	  # Darwin ld doesn't like 0 for these options...
+ 	  func_arith $current + 1
+ 	  minor_current=$func_arith_result
+-	  xlcverstring="${wl}-compatibility_version ${wl}$minor_current ${wl}-current_version ${wl}$minor_current.$revision"
++	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
++          # On Darwin other compilers
++          case $CC in
++              nagfor*)
++                  verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
++                  ;;
++              *)
++                  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
++                  ;;
++          esac
+ 	  ;;
+ 
+ 	freebsd-aout)
+-	  major=".$current"
+-	  versuffix=".$current.$revision";
++	  major=.$current
++	  versuffix=.$current.$revision
+ 	  ;;
+ 
+ 	freebsd-elf)
+-	  major=".$current"
+-	  versuffix=".$current"
++	  func_arith $current - $age
++	  major=.$func_arith_result
++	  versuffix=$major.$age.$revision
+ 	  ;;
+ 
+ 	irix | nonstopux)
+-	  if test "X$lt_irix_increment" = "Xno"; then
++	  if test no = "$lt_irix_increment"; then
+ 	    func_arith $current - $age
+ 	  else
+ 	    func_arith $current - $age + 1
+@@ -7430,69 +9133,74 @@ func_mode_link ()
+ 	    nonstopux) verstring_prefix=nonstopux ;;
+ 	    *)         verstring_prefix=sgi ;;
+ 	  esac
+-	  verstring="$verstring_prefix$major.$revision"
++	  verstring=$verstring_prefix$major.$revision
+ 
+ 	  # Add in all the interfaces that we are compatible with.
+ 	  loop=$revision
+-	  while test "$loop" -ne 0; do
++	  while test 0 -ne "$loop"; do
+ 	    func_arith $revision - $loop
+ 	    iface=$func_arith_result
+ 	    func_arith $loop - 1
+ 	    loop=$func_arith_result
+-	    verstring="$verstring_prefix$major.$iface:$verstring"
++	    verstring=$verstring_prefix$major.$iface:$verstring
+ 	  done
+ 
+-	  # Before this point, $major must not contain `.'.
++	  # Before this point, $major must not contain '.'.
+ 	  major=.$major
+-	  versuffix="$major.$revision"
++	  versuffix=$major.$revision
+ 	  ;;
+ 
+ 	linux) # correct to gnu/linux during the next big refactor
+ 	  func_arith $current - $age
+ 	  major=.$func_arith_result
+-	  versuffix="$major.$age.$revision"
++	  versuffix=$major.$age.$revision
+ 	  ;;
+ 
+ 	osf)
+ 	  func_arith $current - $age
+ 	  major=.$func_arith_result
+-	  versuffix=".$current.$age.$revision"
+-	  verstring="$current.$age.$revision"
++	  versuffix=.$current.$age.$revision
++	  verstring=$current.$age.$revision
+ 
+ 	  # Add in all the interfaces that we are compatible with.
+ 	  loop=$age
+-	  while test "$loop" -ne 0; do
++	  while test 0 -ne "$loop"; do
+ 	    func_arith $current - $loop
+ 	    iface=$func_arith_result
+ 	    func_arith $loop - 1
+ 	    loop=$func_arith_result
+-	    verstring="$verstring:${iface}.0"
++	    verstring=$verstring:$iface.0
+ 	  done
+ 
+ 	  # Make executables depend on our current version.
+-	  func_append verstring ":${current}.0"
++	  func_append verstring ":$current.0"
+ 	  ;;
+ 
+ 	qnx)
+-	  major=".$current"
+-	  versuffix=".$current"
++	  major=.$current
++	  versuffix=.$current
++	  ;;
++
++	sco)
++	  major=.$current
++	  versuffix=.$current
+ 	  ;;
+ 
+ 	sunos)
+-	  major=".$current"
+-	  versuffix=".$current.$revision"
++	  major=.$current
++	  versuffix=.$current.$revision
+ 	  ;;
+ 
+ 	windows)
+ 	  # Use '-' rather than '.', since we only want one
+-	  # extension on DOS 8.3 filesystems.
++	  # extension on DOS 8.3 file systems.
+ 	  func_arith $current - $age
+ 	  major=$func_arith_result
+-	  versuffix="-$major"
++	  versuffix=-$major
+ 	  ;;
+ 
+ 	*)
+-	  func_fatal_configuration "unknown library version type \`$version_type'"
++	  func_fatal_configuration "unknown library version type '$version_type'"
+ 	  ;;
+ 	esac
+ 
+@@ -7506,42 +9214,45 @@ func_mode_link ()
+ 	    verstring=
+ 	    ;;
+ 	  *)
+-	    verstring="0.0"
++	    verstring=0.0
+ 	    ;;
+ 	  esac
+-	  if test "$need_version" = no; then
++	  if test no = "$need_version"; then
+ 	    versuffix=
+ 	  else
+-	    versuffix=".0.0"
++	    versuffix=.0.0
+ 	  fi
+ 	fi
+ 
+ 	# Remove version info from name if versioning should be avoided
+-	if test "$avoid_version" = yes && test "$need_version" = no; then
++	if test yes,no = "$avoid_version,$need_version"; then
+ 	  major=
+ 	  versuffix=
+-	  verstring=""
++	  verstring=
+ 	fi
+ 
+ 	# Check to see if the archive will have undefined symbols.
+-	if test "$allow_undefined" = yes; then
+-	  if test "$allow_undefined_flag" = unsupported; then
+-	    func_warning "undefined symbols not allowed in $host shared libraries"
+-	    build_libtool_libs=no
+-	    build_old_libs=yes
++	if test yes = "$allow_undefined"; then
++	  if test unsupported = "$allow_undefined_flag"; then
++	    if test yes = "$build_old_libs"; then
++	      func_warning "undefined symbols not allowed in $host shared libraries; building static only"
++	      build_libtool_libs=no
++	    else
++	      func_fatal_error "can't build $host shared library unless -no-undefined is specified"
++	    fi
+ 	  fi
+ 	else
+ 	  # Don't allow undefined symbols.
+-	  allow_undefined_flag="$no_undefined_flag"
++	  allow_undefined_flag=$no_undefined_flag
+ 	fi
+ 
+       fi
+ 
+-      func_generate_dlsyms "$libname" "$libname" "yes"
++      func_generate_dlsyms "$libname" "$libname" :
+       func_append libobjs " $symfileobj"
+-      test "X$libobjs" = "X " && libobjs=
++      test " " = "$libobjs" && libobjs=
+ 
+-      if test "$opt_mode" != relink; then
++      if test relink != "$opt_mode"; then
+ 	# Remove our outputs, but don't remove object files since they
+ 	# may have been created when compiling PIC objects.
+ 	removelist=
+@@ -7550,8 +9261,8 @@ func_mode_link ()
+ 	  case $p in
+ 	    *.$objext | *.gcno)
+ 	       ;;
+-	    $output_objdir/$outputname | $output_objdir/$libname.* | $output_objdir/${libname}${release}.*)
+-	       if test "X$precious_files_regex" != "X"; then
++	    $output_objdir/$outputname | $output_objdir/$libname.* | $output_objdir/$libname$release.*)
++	       if test -n "$precious_files_regex"; then
+ 		 if $ECHO "$p" | $EGREP -e "$precious_files_regex" >/dev/null 2>&1
+ 		 then
+ 		   continue
+@@ -7567,11 +9278,11 @@ func_mode_link ()
+       fi
+ 
+       # Now set the variables for building old libraries.
+-      if test "$build_old_libs" = yes && test "$build_libtool_libs" != convenience ; then
++      if test yes = "$build_old_libs" && test convenience != "$build_libtool_libs"; then
+ 	func_append oldlibs " $output_objdir/$libname.$libext"
+ 
+ 	# Transform .lo files to .o files.
+-	oldobjs="$objs "`$ECHO "$libobjs" | $SP2NL | $SED "/\.${libext}$/d; $lo2o" | $NL2SP`
++	oldobjs="$objs "`$ECHO "$libobjs" | $SP2NL | $SED "/\.$libext$/d; $lo2o" | $NL2SP`
+       fi
+ 
+       # Eliminate all temporary directories.
+@@ -7592,13 +9303,13 @@ func_mode_link ()
+ 	  *) func_append finalize_rpath " $libdir" ;;
+ 	  esac
+ 	done
+-	if test "$hardcode_into_libs" != yes || test "$build_old_libs" = yes; then
++	if test yes != "$hardcode_into_libs" || test yes = "$build_old_libs"; then
+ 	  dependency_libs="$temp_xrpath $dependency_libs"
+ 	fi
+       fi
+ 
+       # Make sure dlfiles contains only unique files that won't be dlpreopened
+-      old_dlfiles="$dlfiles"
++      old_dlfiles=$dlfiles
+       dlfiles=
+       for lib in $old_dlfiles; do
+ 	case " $dlprefiles $dlfiles " in
+@@ -7608,7 +9319,7 @@ func_mode_link ()
+       done
+ 
+       # Make sure dlprefiles contains only unique files
+-      old_dlprefiles="$dlprefiles"
++      old_dlprefiles=$dlprefiles
+       dlprefiles=
+       for lib in $old_dlprefiles; do
+ 	case "$dlprefiles " in
+@@ -7617,7 +9328,7 @@ func_mode_link ()
+ 	esac
+       done
+ 
+-      if test "$build_libtool_libs" = yes; then
++      if test yes = "$build_libtool_libs"; then
+ 	if test -n "$rpath"; then
+ 	  case $host in
+ 	  *-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-*-beos* | *-cegcc* | *-*-haiku*)
+@@ -7641,7 +9352,7 @@ func_mode_link ()
+ 	    ;;
+ 	  *)
+ 	    # Add libc to deplibs on all other systems if necessary.
+-	    if test "$build_libtool_need_lc" = "yes"; then
++	    if test yes = "$build_libtool_need_lc"; then
+ 	      func_append deplibs " -lc"
+ 	    fi
+ 	    ;;
+@@ -7657,9 +9368,9 @@ func_mode_link ()
+ 	# I'm not sure if I'm treating the release correctly.  I think
+ 	# release should show up in the -l (ie -lgmp5) so we don't want to
+ 	# add it in twice.  Is that correct?
+-	release=""
+-	versuffix=""
+-	major=""
++	release=
++	versuffix=
++	major=
+ 	newdeplibs=
+ 	droppeddeps=no
+ 	case $deplibs_check_method in
+@@ -7688,20 +9399,20 @@ EOF
+ 	      -l*)
+ 		func_stripname -l '' "$i"
+ 		name=$func_stripname_result
+-		if test "X$allow_libtool_libs_with_static_runtimes" = "Xyes" ; then
++		if test yes = "$allow_libtool_libs_with_static_runtimes"; then
+ 		  case " $predeps $postdeps " in
+ 		  *" $i "*)
+ 		    func_append newdeplibs " $i"
+-		    i=""
++		    i=
+ 		    ;;
+ 		  esac
+ 		fi
+-		if test -n "$i" ; then
++		if test -n "$i"; then
+ 		  libname=`eval "\\$ECHO \"$libname_spec\""`
+ 		  deplib_matches=`eval "\\$ECHO \"$library_names_spec\""`
+ 		  set dummy $deplib_matches; shift
+ 		  deplib_match=$1
+-		  if test `expr "$ldd_output" : ".*$deplib_match"` -ne 0 ; then
++		  if test `expr "$ldd_output" : ".*$deplib_match"` -ne 0; then
+ 		    func_append newdeplibs " $i"
+ 		  else
+ 		    droppeddeps=yes
+@@ -7731,20 +9442,20 @@ EOF
+ 		$opt_dry_run || $RM conftest
+ 		if $LTCC $LTCFLAGS -o conftest conftest.c $i; then
+ 		  ldd_output=`ldd conftest`
+-		  if test "X$allow_libtool_libs_with_static_runtimes" = "Xyes" ; then
++		  if test yes = "$allow_libtool_libs_with_static_runtimes"; then
+ 		    case " $predeps $postdeps " in
+ 		    *" $i "*)
+ 		      func_append newdeplibs " $i"
+-		      i=""
++		      i=
+ 		      ;;
+ 		    esac
+ 		  fi
+-		  if test -n "$i" ; then
++		  if test -n "$i"; then
+ 		    libname=`eval "\\$ECHO \"$libname_spec\""`
+ 		    deplib_matches=`eval "\\$ECHO \"$library_names_spec\""`
+ 		    set dummy $deplib_matches; shift
+ 		    deplib_match=$1
+-		    if test `expr "$ldd_output" : ".*$deplib_match"` -ne 0 ; then
++		    if test `expr "$ldd_output" : ".*$deplib_match"` -ne 0; then
+ 		      func_append newdeplibs " $i"
+ 		    else
+ 		      droppeddeps=yes
+@@ -7781,24 +9492,24 @@ EOF
+ 	    -l*)
+ 	      func_stripname -l '' "$a_deplib"
+ 	      name=$func_stripname_result
+-	      if test "X$allow_libtool_libs_with_static_runtimes" = "Xyes" ; then
++	      if test yes = "$allow_libtool_libs_with_static_runtimes"; then
+ 		case " $predeps $postdeps " in
+ 		*" $a_deplib "*)
+ 		  func_append newdeplibs " $a_deplib"
+-		  a_deplib=""
++		  a_deplib=
+ 		  ;;
+ 		esac
+ 	      fi
+-	      if test -n "$a_deplib" ; then
++	      if test -n "$a_deplib"; then
+ 		libname=`eval "\\$ECHO \"$libname_spec\""`
+ 		if test -n "$file_magic_glob"; then
+ 		  libnameglob=`func_echo_all "$libname" | $SED -e $file_magic_glob`
+ 		else
+ 		  libnameglob=$libname
+ 		fi
+-		test "$want_nocaseglob" = yes && nocaseglob=`shopt -p nocaseglob`
++		test yes = "$want_nocaseglob" && nocaseglob=`shopt -p nocaseglob`
+ 		for i in $lib_search_path $sys_lib_search_path $shlib_search_path; do
+-		  if test "$want_nocaseglob" = yes; then
++		  if test yes = "$want_nocaseglob"; then
+ 		    shopt -s nocaseglob
+ 		    potential_libs=`ls $i/$libnameglob[.-]* 2>/dev/null`
+ 		    $nocaseglob
+@@ -7816,25 +9527,25 @@ EOF
+ 		      # We might still enter an endless loop, since a link
+ 		      # loop can be closed while we follow links,
+ 		      # but so what?
+-		      potlib="$potent_lib"
++		      potlib=$potent_lib
+ 		      while test -h "$potlib" 2>/dev/null; do
+-			potliblink=`ls -ld $potlib | ${SED} 's/.* -> //'`
++			potliblink=`ls -ld $potlib | $SED 's/.* -> //'`
+ 			case $potliblink in
+-			[\\/]* | [A-Za-z]:[\\/]*) potlib="$potliblink";;
+-			*) potlib=`$ECHO "$potlib" | $SED 's,[^/]*$,,'`"$potliblink";;
++			[\\/]* | [A-Za-z]:[\\/]*) potlib=$potliblink;;
++			*) potlib=`$ECHO "$potlib" | $SED 's|[^/]*$||'`"$potliblink";;
+ 			esac
+ 		      done
+ 		      if eval $file_magic_cmd \"\$potlib\" 2>/dev/null |
+ 			 $SED -e 10q |
+ 			 $EGREP "$file_magic_regex" > /dev/null; then
+ 			func_append newdeplibs " $a_deplib"
+-			a_deplib=""
++			a_deplib=
+ 			break 2
+ 		      fi
+ 		  done
+ 		done
+ 	      fi
+-	      if test -n "$a_deplib" ; then
++	      if test -n "$a_deplib"; then
+ 		droppeddeps=yes
+ 		echo
+ 		$ECHO "*** Warning: linker path does not have real file for library $a_deplib."
+@@ -7842,7 +9553,7 @@ EOF
+ 		echo "*** you link to this library.  But I can only do this if you have a"
+ 		echo "*** shared version of the library, which you do not appear to have"
+ 		echo "*** because I did check the linker path looking for a file starting"
+-		if test -z "$potlib" ; then
++		if test -z "$potlib"; then
+ 		  $ECHO "*** with $libname but no candidates were found. (...for file magic test)"
+ 		else
+ 		  $ECHO "*** with $libname and none of the candidates passed a file format test"
+@@ -7865,30 +9576,30 @@ EOF
+ 	    -l*)
+ 	      func_stripname -l '' "$a_deplib"
+ 	      name=$func_stripname_result
+-	      if test "X$allow_libtool_libs_with_static_runtimes" = "Xyes" ; then
++	      if test yes = "$allow_libtool_libs_with_static_runtimes"; then
+ 		case " $predeps $postdeps " in
+ 		*" $a_deplib "*)
+ 		  func_append newdeplibs " $a_deplib"
+-		  a_deplib=""
++		  a_deplib=
+ 		  ;;
+ 		esac
+ 	      fi
+-	      if test -n "$a_deplib" ; then
++	      if test -n "$a_deplib"; then
+ 		libname=`eval "\\$ECHO \"$libname_spec\""`
+ 		for i in $lib_search_path $sys_lib_search_path $shlib_search_path; do
+ 		  potential_libs=`ls $i/$libname[.-]* 2>/dev/null`
+ 		  for potent_lib in $potential_libs; do
+-		    potlib="$potent_lib" # see symlink-check above in file_magic test
++		    potlib=$potent_lib # see symlink-check above in file_magic test
+ 		    if eval "\$ECHO \"$potent_lib\"" 2>/dev/null | $SED 10q | \
+ 		       $EGREP "$match_pattern_regex" > /dev/null; then
+ 		      func_append newdeplibs " $a_deplib"
+-		      a_deplib=""
++		      a_deplib=
+ 		      break 2
+ 		    fi
+ 		  done
+ 		done
+ 	      fi
+-	      if test -n "$a_deplib" ; then
++	      if test -n "$a_deplib"; then
+ 		droppeddeps=yes
+ 		echo
+ 		$ECHO "*** Warning: linker path does not have real file for library $a_deplib."
+@@ -7896,7 +9607,7 @@ EOF
+ 		echo "*** you link to this library.  But I can only do this if you have a"
+ 		echo "*** shared version of the library, which you do not appear to have"
+ 		echo "*** because I did check the linker path looking for a file starting"
+-		if test -z "$potlib" ; then
++		if test -z "$potlib"; then
+ 		  $ECHO "*** with $libname but no candidates were found. (...for regex pattern test)"
+ 		else
+ 		  $ECHO "*** with $libname and none of the candidates passed a file format test"
+@@ -7912,18 +9623,18 @@ EOF
+ 	  done # Gone through all deplibs.
+ 	  ;;
+ 	none | unknown | *)
+-	  newdeplibs=""
++	  newdeplibs=
+ 	  tmp_deplibs=`$ECHO " $deplibs" | $SED 's/ -lc$//; s/ -[LR][^ ]*//g'`
+-	  if test "X$allow_libtool_libs_with_static_runtimes" = "Xyes" ; then
+-	    for i in $predeps $postdeps ; do
++	  if test yes = "$allow_libtool_libs_with_static_runtimes"; then
++	    for i in $predeps $postdeps; do
+ 	      # can't use Xsed below, because $i might contain '/'
+-	      tmp_deplibs=`$ECHO " $tmp_deplibs" | $SED "s,$i,,"`
++	      tmp_deplibs=`$ECHO " $tmp_deplibs" | $SED "s|$i||"`
+ 	    done
+ 	  fi
+ 	  case $tmp_deplibs in
+ 	  *[!\	\ ]*)
+ 	    echo
+-	    if test "X$deplibs_check_method" = "Xnone"; then
++	    if test none = "$deplibs_check_method"; then
+ 	      echo "*** Warning: inter-library dependencies are not supported in this platform."
+ 	    else
+ 	      echo "*** Warning: inter-library dependencies are not known to be supported."
+@@ -7947,8 +9658,8 @@ EOF
+ 	  ;;
+ 	esac
+ 
+-	if test "$droppeddeps" = yes; then
+-	  if test "$module" = yes; then
++	if test yes = "$droppeddeps"; then
++	  if test yes = "$module"; then
+ 	    echo
+ 	    echo "*** Warning: libtool could not satisfy all declared inter-library"
+ 	    $ECHO "*** dependencies of module $libname.  Therefore, libtool will create"
+@@ -7957,12 +9668,12 @@ EOF
+ 	    if test -z "$global_symbol_pipe"; then
+ 	      echo
+ 	      echo "*** However, this would only work if libtool was able to extract symbol"
+-	      echo "*** lists from a program, using \`nm' or equivalent, but libtool could"
++	      echo "*** lists from a program, using 'nm' or equivalent, but libtool could"
+ 	      echo "*** not find such a program.  So, this module is probably useless."
+-	      echo "*** \`nm' from GNU binutils and a full rebuild may help."
++	      echo "*** 'nm' from GNU binutils and a full rebuild may help."
+ 	    fi
+-	    if test "$build_old_libs" = no; then
+-	      oldlibs="$output_objdir/$libname.$libext"
++	    if test no = "$build_old_libs"; then
++	      oldlibs=$output_objdir/$libname.$libext
+ 	      build_libtool_libs=module
+ 	      build_old_libs=yes
+ 	    else
+@@ -7973,14 +9684,14 @@ EOF
+ 	    echo "*** automatically added whenever a program is linked with this library"
+ 	    echo "*** or is declared to -dlopen it."
+ 
+-	    if test "$allow_undefined" = no; then
++	    if test no = "$allow_undefined"; then
+ 	      echo
+ 	      echo "*** Since this library must not contain undefined symbols,"
+ 	      echo "*** because either the platform does not support them or"
+ 	      echo "*** it was explicitly requested with -no-undefined,"
+ 	      echo "*** libtool will only create a static version of it."
+-	      if test "$build_old_libs" = no; then
+-		oldlibs="$output_objdir/$libname.$libext"
++	      if test no = "$build_old_libs"; then
++		oldlibs=$output_objdir/$libname.$libext
+ 		build_libtool_libs=module
+ 		build_old_libs=yes
+ 	      else
+@@ -8026,7 +9737,7 @@ EOF
+ 	*) func_append new_libs " $deplib" ;;
+ 	esac
+       done
+-      deplibs="$new_libs"
++      deplibs=$new_libs
+ 
+       # All the library-specific variables (install_libdir is set above).
+       library_names=
+@@ -8034,25 +9745,25 @@ EOF
+       dlname=
+ 
+       # Test again, we may have decided not to build it any more
+-      if test "$build_libtool_libs" = yes; then
+-	# Remove ${wl} instances when linking with ld.
++      if test yes = "$build_libtool_libs"; then
++	# Remove $wl instances when linking with ld.
+ 	# FIXME: should test the right _cmds variable.
+ 	case $archive_cmds in
+ 	  *\$LD\ *) wl= ;;
+         esac
+-	if test "$hardcode_into_libs" = yes; then
++	if test yes = "$hardcode_into_libs"; then
+ 	  # Hardcode the library paths
+ 	  hardcode_libdirs=
+ 	  dep_rpath=
+-	  rpath="$finalize_rpath"
+-	  test "$opt_mode" != relink && rpath="$compile_rpath$rpath"
++	  rpath=$finalize_rpath
++	  test relink = "$opt_mode" || rpath=$compile_rpath$rpath
+ 	  for libdir in $rpath; do
+ 	    if test -n "$hardcode_libdir_flag_spec"; then
+ 	      if test -n "$hardcode_libdir_separator"; then
+ 		func_replace_sysroot "$libdir"
+ 		libdir=$func_replace_sysroot_result
+ 		if test -z "$hardcode_libdirs"; then
+-		  hardcode_libdirs="$libdir"
++		  hardcode_libdirs=$libdir
+ 		else
+ 		  # Just accumulate the unique libdirs.
+ 		  case $hardcode_libdir_separator$hardcode_libdirs$hardcode_libdir_separator in
+@@ -8077,7 +9788,7 @@ EOF
+ 	  # Substitute the hardcoded libdirs into the rpath.
+ 	  if test -n "$hardcode_libdir_separator" &&
+ 	     test -n "$hardcode_libdirs"; then
+-	    libdir="$hardcode_libdirs"
++	    libdir=$hardcode_libdirs
+ 	    eval "dep_rpath=\"$hardcode_libdir_flag_spec\""
+ 	  fi
+ 	  if test -n "$runpath_var" && test -n "$perm_rpath"; then
+@@ -8091,8 +9802,8 @@ EOF
+ 	  test -n "$dep_rpath" && deplibs="$dep_rpath $deplibs"
+ 	fi
+ 
+-	shlibpath="$finalize_shlibpath"
+-	test "$opt_mode" != relink && shlibpath="$compile_shlibpath$shlibpath"
++	shlibpath=$finalize_shlibpath
++	test relink = "$opt_mode" || shlibpath=$compile_shlibpath$shlibpath
+ 	if test -n "$shlibpath"; then
+ 	  eval "$shlibpath_var='$shlibpath\$$shlibpath_var'; export $shlibpath_var"
+ 	fi
+@@ -8102,19 +9813,19 @@ EOF
+ 	eval library_names=\"$library_names_spec\"
+ 	set dummy $library_names
+ 	shift
+-	realname="$1"
++	realname=$1
+ 	shift
+ 
+ 	if test -n "$soname_spec"; then
+ 	  eval soname=\"$soname_spec\"
+ 	else
+-	  soname="$realname"
++	  soname=$realname
+ 	fi
+ 	if test -z "$dlname"; then
+ 	  dlname=$soname
+ 	fi
+ 
+-	lib="$output_objdir/$realname"
++	lib=$output_objdir/$realname
+ 	linknames=
+ 	for link
+ 	do
+@@ -8128,7 +9839,7 @@ EOF
+ 	delfiles=
+ 	if test -n "$export_symbols" && test -n "$include_expsyms"; then
+ 	  $opt_dry_run || cp "$export_symbols" "$output_objdir/$libname.uexp"
+-	  export_symbols="$output_objdir/$libname.uexp"
++	  export_symbols=$output_objdir/$libname.uexp
+ 	  func_append delfiles " $export_symbols"
+ 	fi
+ 
+@@ -8137,31 +9848,31 @@ EOF
+ 	cygwin* | mingw* | cegcc*)
+ 	  if test -n "$export_symbols" && test -z "$export_symbols_regex"; then
+ 	    # exporting using user supplied symfile
+-	    if test "x`$SED 1q $export_symbols`" != xEXPORTS; then
++	    func_dll_def_p "$export_symbols" || {
+ 	      # and it's NOT already a .def file. Must figure out
+ 	      # which of the given symbols are data symbols and tag
+ 	      # them as such. So, trigger use of export_symbols_cmds.
+ 	      # export_symbols gets reassigned inside the "prepare
+ 	      # the list of exported symbols" if statement, so the
+ 	      # include_expsyms logic still works.
+-	      orig_export_symbols="$export_symbols"
++	      orig_export_symbols=$export_symbols
+ 	      export_symbols=
+ 	      always_export_symbols=yes
+-	    fi
++	    }
+ 	  fi
+ 	  ;;
+ 	esac
+ 
+ 	# Prepare the list of exported symbols
+ 	if test -z "$export_symbols"; then
+-	  if test "$always_export_symbols" = yes || test -n "$export_symbols_regex"; then
+-	    func_verbose "generating symbol list for \`$libname.la'"
+-	    export_symbols="$output_objdir/$libname.exp"
++	  if test yes = "$always_export_symbols" || test -n "$export_symbols_regex"; then
++	    func_verbose "generating symbol list for '$libname.la'"
++	    export_symbols=$output_objdir/$libname.exp
+ 	    $opt_dry_run || $RM $export_symbols
+ 	    cmds=$export_symbols_cmds
+-	    save_ifs="$IFS"; IFS='~'
++	    save_ifs=$IFS; IFS='~'
+ 	    for cmd1 in $cmds; do
+-	      IFS="$save_ifs"
++	      IFS=$save_ifs
+ 	      # Take the normal branch if the nm_file_list_spec branch
+ 	      # doesn't work or if tool conversion is not needed.
+ 	      case $nm_file_list_spec~$to_tool_file_cmd in
+@@ -8175,7 +9886,7 @@ EOF
+ 		  try_normal_branch=no
+ 		  ;;
+ 	      esac
+-	      if test "$try_normal_branch" = yes \
++	      if test yes = "$try_normal_branch" \
+ 		 && { test "$len" -lt "$max_cmd_len" \
+ 		      || test "$max_cmd_len" -le -1; }
+ 	      then
+@@ -8186,7 +9897,7 @@ EOF
+ 		output_la=$func_basename_result
+ 		save_libobjs=$libobjs
+ 		save_output=$output
+-		output=${output_objdir}/${output_la}.nm
++		output=$output_objdir/$output_la.nm
+ 		func_to_tool_file "$output"
+ 		libobjs=$nm_file_list_spec$func_to_tool_file_result
+ 		func_append delfiles " $output"
+@@ -8209,8 +9920,8 @@ EOF
+ 		break
+ 	      fi
+ 	    done
+-	    IFS="$save_ifs"
+-	    if test -n "$export_symbols_regex" && test "X$skipped_export" != "X:"; then
++	    IFS=$save_ifs
++	    if test -n "$export_symbols_regex" && test : != "$skipped_export"; then
+ 	      func_show_eval '$EGREP -e "$export_symbols_regex" "$export_symbols" > "${export_symbols}T"'
+ 	      func_show_eval '$MV "${export_symbols}T" "$export_symbols"'
+ 	    fi
+@@ -8218,16 +9929,16 @@ EOF
+ 	fi
+ 
+ 	if test -n "$export_symbols" && test -n "$include_expsyms"; then
+-	  tmp_export_symbols="$export_symbols"
+-	  test -n "$orig_export_symbols" && tmp_export_symbols="$orig_export_symbols"
++	  tmp_export_symbols=$export_symbols
++	  test -n "$orig_export_symbols" && tmp_export_symbols=$orig_export_symbols
+ 	  $opt_dry_run || eval '$ECHO "$include_expsyms" | $SP2NL >> "$tmp_export_symbols"'
+ 	fi
+ 
+-	if test "X$skipped_export" != "X:" && test -n "$orig_export_symbols"; then
++	if test : != "$skipped_export" && test -n "$orig_export_symbols"; then
+ 	  # The given exports_symbols file has to be filtered, so filter it.
+-	  func_verbose "filter symbol list for \`$libname.la' to tag DATA exports"
++	  func_verbose "filter symbol list for '$libname.la' to tag DATA exports"
+ 	  # FIXME: $output_objdir/$libname.filter potentially contains lots of
+-	  # 's' commands which not all seds can handle. GNU sed should be fine
++	  # 's' commands, which not all seds can handle. GNU sed should be fine
+ 	  # though. Also, the filter scales superlinearly with the number of
+ 	  # global variables. join(1) would be nice here, but unfortunately
+ 	  # isn't a blessed tool.
+@@ -8246,11 +9957,11 @@ EOF
+ 	    ;;
+ 	  esac
+ 	done
+-	deplibs="$tmp_deplibs"
++	deplibs=$tmp_deplibs
+ 
+ 	if test -n "$convenience"; then
+ 	  if test -n "$whole_archive_flag_spec" &&
+-	    test "$compiler_needs_object" = yes &&
++	    test yes = "$compiler_needs_object" &&
+ 	    test -z "$libobjs"; then
+ 	    # extract the archives, so we have objects to list.
+ 	    # TODO: could optimize this to just extract one archive.
+@@ -8261,7 +9972,7 @@ EOF
+ 	    eval libobjs=\"\$libobjs $whole_archive_flag_spec\"
+ 	    test "X$libobjs" = "X " && libobjs=
+ 	  else
+-	    gentop="$output_objdir/${outputname}x"
++	    gentop=$output_objdir/${outputname}x
+ 	    func_append generated " $gentop"
+ 
+ 	    func_extract_archives $gentop $convenience
+@@ -8270,18 +9981,18 @@ EOF
+ 	  fi
+ 	fi
+ 
+-	if test "$thread_safe" = yes && test -n "$thread_safe_flag_spec"; then
++	if test yes = "$thread_safe" && test -n "$thread_safe_flag_spec"; then
+ 	  eval flag=\"$thread_safe_flag_spec\"
+ 	  func_append linker_flags " $flag"
+ 	fi
+ 
+ 	# Make a backup of the uninstalled library when relinking
+-	if test "$opt_mode" = relink; then
++	if test relink = "$opt_mode"; then
+ 	  $opt_dry_run || eval '(cd $output_objdir && $RM ${realname}U && $MV $realname ${realname}U)' || exit $?
+ 	fi
+ 
+ 	# Do each of the archive commands.
+-	if test "$module" = yes && test -n "$module_cmds" ; then
++	if test yes = "$module" && test -n "$module_cmds"; then
+ 	  if test -n "$export_symbols" && test -n "$module_expsym_cmds"; then
+ 	    eval test_cmds=\"$module_expsym_cmds\"
+ 	    cmds=$module_expsym_cmds
+@@ -8299,7 +10010,7 @@ EOF
+ 	  fi
+ 	fi
+ 
+-	if test "X$skipped_export" != "X:" &&
++	if test : != "$skipped_export" &&
+ 	   func_len " $test_cmds" &&
+ 	   len=$func_len_result &&
+ 	   test "$len" -lt "$max_cmd_len" || test "$max_cmd_len" -le -1; then
+@@ -8332,8 +10043,8 @@ EOF
+ 	  last_robj=
+ 	  k=1
+ 
+-	  if test -n "$save_libobjs" && test "X$skipped_export" != "X:" && test "$with_gnu_ld" = yes; then
+-	    output=${output_objdir}/${output_la}.lnkscript
++	  if test -n "$save_libobjs" && test : != "$skipped_export" && test yes = "$with_gnu_ld"; then
++	    output=$output_objdir/$output_la.lnkscript
+ 	    func_verbose "creating GNU ld script: $output"
+ 	    echo 'INPUT (' > $output
+ 	    for obj in $save_libobjs
+@@ -8345,14 +10056,14 @@ EOF
+ 	    func_append delfiles " $output"
+ 	    func_to_tool_file "$output"
+ 	    output=$func_to_tool_file_result
+-	  elif test -n "$save_libobjs" && test "X$skipped_export" != "X:" && test "X$file_list_spec" != X; then
+-	    output=${output_objdir}/${output_la}.lnk
++	  elif test -n "$save_libobjs" && test : != "$skipped_export" && test -n "$file_list_spec"; then
++	    output=$output_objdir/$output_la.lnk
+ 	    func_verbose "creating linker input file list: $output"
+ 	    : > $output
+ 	    set x $save_libobjs
+ 	    shift
+ 	    firstobj=
+-	    if test "$compiler_needs_object" = yes; then
++	    if test yes = "$compiler_needs_object"; then
+ 	      firstobj="$1 "
+ 	      shift
+ 	    fi
+@@ -8367,7 +10078,7 @@ EOF
+ 	  else
+ 	    if test -n "$save_libobjs"; then
+ 	      func_verbose "creating reloadable object files..."
+-	      output=$output_objdir/$output_la-${k}.$objext
++	      output=$output_objdir/$output_la-$k.$objext
+ 	      eval test_cmds=\"$reload_cmds\"
+ 	      func_len " $test_cmds"
+ 	      len0=$func_len_result
+@@ -8379,13 +10090,13 @@ EOF
+ 		func_len " $obj"
+ 		func_arith $len + $func_len_result
+ 		len=$func_arith_result
+-		if test "X$objlist" = X ||
++		if test -z "$objlist" ||
+ 		   test "$len" -lt "$max_cmd_len"; then
+ 		  func_append objlist " $obj"
+ 		else
+ 		  # The command $test_cmds is almost too long, add a
+ 		  # command to the queue.
+-		  if test "$k" -eq 1 ; then
++		  if test 1 -eq "$k"; then
+ 		    # The first file doesn't have a previous command to add.
+ 		    reload_objs=$objlist
+ 		    eval concat_cmds=\"$reload_cmds\"
+@@ -8395,10 +10106,10 @@ EOF
+ 		    reload_objs="$objlist $last_robj"
+ 		    eval concat_cmds=\"\$concat_cmds~$reload_cmds~\$RM $last_robj\"
+ 		  fi
+-		  last_robj=$output_objdir/$output_la-${k}.$objext
++		  last_robj=$output_objdir/$output_la-$k.$objext
+ 		  func_arith $k + 1
+ 		  k=$func_arith_result
+-		  output=$output_objdir/$output_la-${k}.$objext
++		  output=$output_objdir/$output_la-$k.$objext
+ 		  objlist=" $obj"
+ 		  func_len " $last_robj"
+ 		  func_arith $len0 + $func_len_result
+@@ -8410,9 +10121,9 @@ EOF
+ 	      # files will link in the last one created.
+ 	      test -z "$concat_cmds" || concat_cmds=$concat_cmds~
+ 	      reload_objs="$objlist $last_robj"
+-	      eval concat_cmds=\"\${concat_cmds}$reload_cmds\"
++	      eval concat_cmds=\"\$concat_cmds$reload_cmds\"
+ 	      if test -n "$last_robj"; then
+-	        eval concat_cmds=\"\${concat_cmds}~\$RM $last_robj\"
++	        eval concat_cmds=\"\$concat_cmds~\$RM $last_robj\"
+ 	      fi
+ 	      func_append delfiles " $output"
+ 
+@@ -8420,9 +10131,9 @@ EOF
+ 	      output=
+ 	    fi
+ 
+-	    if ${skipped_export-false}; then
+-	      func_verbose "generating symbol list for \`$libname.la'"
+-	      export_symbols="$output_objdir/$libname.exp"
++	    ${skipped_export-false} && {
++	      func_verbose "generating symbol list for '$libname.la'"
++	      export_symbols=$output_objdir/$libname.exp
+ 	      $opt_dry_run || $RM $export_symbols
+ 	      libobjs=$output
+ 	      # Append the command to create the export file.
+@@ -8431,24 +10142,24 @@ EOF
+ 	      if test -n "$last_robj"; then
+ 		eval concat_cmds=\"\$concat_cmds~\$RM $last_robj\"
+ 	      fi
+-	    fi
++	    }
+ 
+ 	    test -n "$save_libobjs" &&
+ 	      func_verbose "creating a temporary reloadable object file: $output"
+ 
+ 	    # Loop through the commands generated above and execute them.
+-	    save_ifs="$IFS"; IFS='~'
++	    save_ifs=$IFS; IFS='~'
+ 	    for cmd in $concat_cmds; do
+-	      IFS="$save_ifs"
+-	      $opt_silent || {
+-		  func_quote_for_expand "$cmd"
+-		  eval "func_echo $func_quote_for_expand_result"
++	      IFS=$save_ifs
++	      $opt_quiet || {
++		  func_quote_arg expand,pretty "$cmd"
++		  eval "func_echo $func_quote_arg_result"
+ 	      }
+ 	      $opt_dry_run || eval "$cmd" || {
+ 		lt_exit=$?
+ 
+ 		# Restore the uninstalled library and exit
+-		if test "$opt_mode" = relink; then
++		if test relink = "$opt_mode"; then
+ 		  ( cd "$output_objdir" && \
+ 		    $RM "${realname}T" && \
+ 		    $MV "${realname}U" "$realname" )
+@@ -8457,7 +10168,7 @@ EOF
+ 		exit $lt_exit
+ 	      }
+ 	    done
+-	    IFS="$save_ifs"
++	    IFS=$save_ifs
+ 
+ 	    if test -n "$export_symbols_regex" && ${skipped_export-false}; then
+ 	      func_show_eval '$EGREP -e "$export_symbols_regex" "$export_symbols" > "${export_symbols}T"'
+@@ -8465,18 +10176,18 @@ EOF
+ 	    fi
+ 	  fi
+ 
+-          if ${skipped_export-false}; then
++          ${skipped_export-false} && {
+ 	    if test -n "$export_symbols" && test -n "$include_expsyms"; then
+-	      tmp_export_symbols="$export_symbols"
+-	      test -n "$orig_export_symbols" && tmp_export_symbols="$orig_export_symbols"
++	      tmp_export_symbols=$export_symbols
++	      test -n "$orig_export_symbols" && tmp_export_symbols=$orig_export_symbols
+ 	      $opt_dry_run || eval '$ECHO "$include_expsyms" | $SP2NL >> "$tmp_export_symbols"'
+ 	    fi
+ 
+ 	    if test -n "$orig_export_symbols"; then
+ 	      # The given exports_symbols file has to be filtered, so filter it.
+-	      func_verbose "filter symbol list for \`$libname.la' to tag DATA exports"
++	      func_verbose "filter symbol list for '$libname.la' to tag DATA exports"
+ 	      # FIXME: $output_objdir/$libname.filter potentially contains lots of
+-	      # 's' commands which not all seds can handle. GNU sed should be fine
++	      # 's' commands, which not all seds can handle. GNU sed should be fine
+ 	      # though. Also, the filter scales superlinearly with the number of
+ 	      # global variables. join(1) would be nice here, but unfortunately
+ 	      # isn't a blessed tool.
+@@ -8485,7 +10196,7 @@ EOF
+ 	      export_symbols=$output_objdir/$libname.def
+ 	      $opt_dry_run || $SED -f $output_objdir/$libname.filter < $orig_export_symbols > $export_symbols
+ 	    fi
+-	  fi
++	  }
+ 
+ 	  libobjs=$output
+ 	  # Restore the value of output.
+@@ -8499,7 +10210,7 @@ EOF
+ 	  # value of $libobjs for piecewise linking.
+ 
+ 	  # Do each of the archive commands.
+-	  if test "$module" = yes && test -n "$module_cmds" ; then
++	  if test yes = "$module" && test -n "$module_cmds"; then
+ 	    if test -n "$export_symbols" && test -n "$module_expsym_cmds"; then
+ 	      cmds=$module_expsym_cmds
+ 	    else
+@@ -8521,7 +10232,7 @@ EOF
+ 
+ 	# Add any objects from preloaded convenience libraries
+ 	if test -n "$dlprefiles"; then
+-	  gentop="$output_objdir/${outputname}x"
++	  gentop=$output_objdir/${outputname}x
+ 	  func_append generated " $gentop"
+ 
+ 	  func_extract_archives $gentop $dlprefiles
+@@ -8529,19 +10240,20 @@ EOF
+ 	  test "X$libobjs" = "X " && libobjs=
+ 	fi
+ 
+-	save_ifs="$IFS"; IFS='~'
++	save_ifs=$IFS; IFS='~'
+ 	for cmd in $cmds; do
+-	  IFS="$save_ifs"
++	  IFS=$sp$nl
+ 	  eval cmd=\"$cmd\"
+-	  $opt_silent || {
+-	    func_quote_for_expand "$cmd"
+-	    eval "func_echo $func_quote_for_expand_result"
++	  IFS=$save_ifs
++	  $opt_quiet || {
++	    func_quote_arg expand,pretty "$cmd"
++	    eval "func_echo $func_quote_arg_result"
+ 	  }
+ 	  $opt_dry_run || eval "$cmd" || {
+ 	    lt_exit=$?
+ 
+ 	    # Restore the uninstalled library and exit
+-	    if test "$opt_mode" = relink; then
++	    if test relink = "$opt_mode"; then
+ 	      ( cd "$output_objdir" && \
+ 	        $RM "${realname}T" && \
+ 		$MV "${realname}U" "$realname" )
+@@ -8550,10 +10262,10 @@ EOF
+ 	    exit $lt_exit
+ 	  }
+ 	done
+-	IFS="$save_ifs"
++	IFS=$save_ifs
+ 
+ 	# Restore the uninstalled library and exit
+-	if test "$opt_mode" = relink; then
++	if test relink = "$opt_mode"; then
+ 	  $opt_dry_run || eval '(cd $output_objdir && $RM ${realname}T && $MV $realname ${realname}T && $MV ${realname}U $realname)' || exit $?
+ 
+ 	  if test -n "$convenience"; then
+@@ -8573,39 +10285,39 @@ EOF
+ 	done
+ 
+ 	# If -module or -export-dynamic was specified, set the dlname.
+-	if test "$module" = yes || test "$export_dynamic" = yes; then
++	if test yes = "$module" || test yes = "$export_dynamic"; then
+ 	  # On all known operating systems, these are identical.
+-	  dlname="$soname"
++	  dlname=$soname
+ 	fi
+       fi
+       ;;
+ 
+     obj)
+-      if test -n "$dlfiles$dlprefiles" || test "$dlself" != no; then
+-	func_warning "\`-dlopen' is ignored for objects"
++      if test -n "$dlfiles$dlprefiles" || test no != "$dlself"; then
++	func_warning "'-dlopen' is ignored for objects"
+       fi
+ 
+       case " $deplibs" in
+       *\ -l* | *\ -L*)
+-	func_warning "\`-l' and \`-L' are ignored for objects" ;;
++	func_warning "'-l' and '-L' are ignored for objects" ;;
+       esac
+ 
+       test -n "$rpath" && \
+-	func_warning "\`-rpath' is ignored for objects"
++	func_warning "'-rpath' is ignored for objects"
+ 
+       test -n "$xrpath" && \
+-	func_warning "\`-R' is ignored for objects"
++	func_warning "'-R' is ignored for objects"
+ 
+       test -n "$vinfo" && \
+-	func_warning "\`-version-info' is ignored for objects"
++	func_warning "'-version-info' is ignored for objects"
+ 
+       test -n "$release" && \
+-	func_warning "\`-release' is ignored for objects"
++	func_warning "'-release' is ignored for objects"
+ 
+       case $output in
+       *.lo)
+ 	test -n "$objs$old_deplibs" && \
+-	  func_fatal_error "cannot build library object \`$output' from non-libtool objects"
++	  func_fatal_error "cannot build library object '$output' from non-libtool objects"
+ 
+ 	libobj=$output
+ 	func_lo2o "$libobj"
+@@ -8613,7 +10325,7 @@ EOF
+ 	;;
+       *)
+ 	libobj=
+-	obj="$output"
++	obj=$output
+ 	;;
+       esac
+ 
+@@ -8626,17 +10338,19 @@ EOF
+       # the extraction.
+       reload_conv_objs=
+       gentop=
+-      # reload_cmds runs $LD directly, so let us get rid of
+-      # -Wl from whole_archive_flag_spec and hope we can get by with
+-      # turning comma into space..
+-      wl=
+-
++      # if reload_cmds runs $LD directly, get rid of -Wl from
++      # whole_archive_flag_spec and hope we can get by with turning comma
++      # into space.
++      case $reload_cmds in
++        *\$LD[\ \$]*) wl= ;;
++      esac
+       if test -n "$convenience"; then
+ 	if test -n "$whole_archive_flag_spec"; then
+ 	  eval tmp_whole_archive_flags=\"$whole_archive_flag_spec\"
+-	  reload_conv_objs=$reload_objs\ `$ECHO "$tmp_whole_archive_flags" | $SED 's|,| |g'`
++	  test -n "$wl" || tmp_whole_archive_flags=`$ECHO "$tmp_whole_archive_flags" | $SED 's|,| |g'`
++	  reload_conv_objs=$reload_objs\ $tmp_whole_archive_flags
+ 	else
+-	  gentop="$output_objdir/${obj}x"
++	  gentop=$output_objdir/${obj}x
+ 	  func_append generated " $gentop"
+ 
+ 	  func_extract_archives $gentop $convenience
+@@ -8645,12 +10359,12 @@ EOF
+       fi
+ 
+       # If we're not building shared, we need to use non_pic_objs
+-      test "$build_libtool_libs" != yes && libobjs="$non_pic_objects"
++      test yes = "$build_libtool_libs" || libobjs=$non_pic_objects
+ 
+       # Create the old-style object.
+-      reload_objs="$objs$old_deplibs "`$ECHO "$libobjs" | $SP2NL | $SED "/\.${libext}$/d; /\.lib$/d; $lo2o" | $NL2SP`" $reload_conv_objs" ### testsuite: skip nested quoting test
++      reload_objs=$objs$old_deplibs' '`$ECHO "$libobjs" | $SP2NL | $SED "/\.$libext$/d; /\.lib$/d; $lo2o" | $NL2SP`' '$reload_conv_objs
+ 
+-      output="$obj"
++      output=$obj
+       func_execute_cmds "$reload_cmds" 'exit $?'
+ 
+       # Exit if we aren't doing a library object file.
+@@ -8662,7 +10376,7 @@ EOF
+ 	exit $EXIT_SUCCESS
+       fi
+ 
+-      if test "$build_libtool_libs" != yes; then
++      test yes = "$build_libtool_libs" || {
+ 	if test -n "$gentop"; then
+ 	  func_show_eval '${RM}r "$gentop"'
+ 	fi
+@@ -8672,12 +10386,12 @@ EOF
+ 	# $show "echo timestamp > $libobj"
+ 	# $opt_dry_run || eval "echo timestamp > $libobj" || exit $?
+ 	exit $EXIT_SUCCESS
+-      fi
++      }
+ 
+-      if test -n "$pic_flag" || test "$pic_mode" != default; then
++      if test -n "$pic_flag" || test default != "$pic_mode"; then
+ 	# Only do commands if we really have different PIC objects.
+ 	reload_objs="$libobjs $reload_conv_objs"
+-	output="$libobj"
++	output=$libobj
+ 	func_execute_cmds "$reload_cmds" 'exit $?'
+       fi
+ 
+@@ -8694,16 +10408,14 @@ EOF
+ 	          output=$func_stripname_result.exe;;
+       esac
+       test -n "$vinfo" && \
+-	func_warning "\`-version-info' is ignored for programs"
++	func_warning "'-version-info' is ignored for programs"
+ 
+       test -n "$release" && \
+-	func_warning "\`-release' is ignored for programs"
++	func_warning "'-release' is ignored for programs"
+ 
+-      test "$preload" = yes \
+-        && test "$dlopen_support" = unknown \
+-	&& test "$dlopen_self" = unknown \
+-	&& test "$dlopen_self_static" = unknown && \
+-	  func_warning "\`LT_INIT([dlopen])' not used. Assuming no dlopen support."
++      $preload \
++	&& test unknown,unknown,unknown = "$dlopen_support,$dlopen_self,$dlopen_self_static" \
++	&& func_warning "'LT_INIT([dlopen])' not used. Assuming no dlopen support."
+ 
+       case $host in
+       *-*-rhapsody* | *-*-darwin1.[012])
+@@ -8717,11 +10429,11 @@ EOF
+       *-*-darwin*)
+ 	# Don't allow lazy linking, it breaks C++ global constructors
+ 	# But is supposedly fixed on 10.4 or later (yay!).
+-	if test "$tagname" = CXX ; then
++	if test CXX = "$tagname"; then
+ 	  case ${MACOSX_DEPLOYMENT_TARGET-10.0} in
+ 	    10.[0123])
+-	      func_append compile_command " ${wl}-bind_at_load"
+-	      func_append finalize_command " ${wl}-bind_at_load"
++	      func_append compile_command " $wl-bind_at_load"
++	      func_append finalize_command " $wl-bind_at_load"
+ 	    ;;
+ 	  esac
+ 	fi
+@@ -8757,7 +10469,7 @@ EOF
+ 	*) func_append new_libs " $deplib" ;;
+ 	esac
+       done
+-      compile_deplibs="$new_libs"
++      compile_deplibs=$new_libs
+ 
+ 
+       func_append compile_command " $compile_deplibs"
+@@ -8781,7 +10493,7 @@ EOF
+ 	if test -n "$hardcode_libdir_flag_spec"; then
+ 	  if test -n "$hardcode_libdir_separator"; then
+ 	    if test -z "$hardcode_libdirs"; then
+-	      hardcode_libdirs="$libdir"
++	      hardcode_libdirs=$libdir
+ 	    else
+ 	      # Just accumulate the unique libdirs.
+ 	      case $hardcode_libdir_separator$hardcode_libdirs$hardcode_libdir_separator in
+@@ -8804,7 +10516,7 @@ EOF
+ 	fi
+ 	case $host in
+ 	*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-os2* | *-cegcc*)
+-	  testbindir=`${ECHO} "$libdir" | ${SED} -e 's*/lib$*/bin*'`
++	  testbindir=`$ECHO "$libdir" | $SED -e 's*/lib$*/bin*'`
+ 	  case :$dllsearchpath: in
+ 	  *":$libdir:"*) ;;
+ 	  ::) dllsearchpath=$libdir;;
+@@ -8821,10 +10533,10 @@ EOF
+       # Substitute the hardcoded libdirs into the rpath.
+       if test -n "$hardcode_libdir_separator" &&
+ 	 test -n "$hardcode_libdirs"; then
+-	libdir="$hardcode_libdirs"
++	libdir=$hardcode_libdirs
+ 	eval rpath=\" $hardcode_libdir_flag_spec\"
+       fi
+-      compile_rpath="$rpath"
++      compile_rpath=$rpath
+ 
+       rpath=
+       hardcode_libdirs=
+@@ -8832,7 +10544,7 @@ EOF
+ 	if test -n "$hardcode_libdir_flag_spec"; then
+ 	  if test -n "$hardcode_libdir_separator"; then
+ 	    if test -z "$hardcode_libdirs"; then
+-	      hardcode_libdirs="$libdir"
++	      hardcode_libdirs=$libdir
+ 	    else
+ 	      # Just accumulate the unique libdirs.
+ 	      case $hardcode_libdir_separator$hardcode_libdirs$hardcode_libdir_separator in
+@@ -8857,45 +10569,43 @@ EOF
+       # Substitute the hardcoded libdirs into the rpath.
+       if test -n "$hardcode_libdir_separator" &&
+ 	 test -n "$hardcode_libdirs"; then
+-	libdir="$hardcode_libdirs"
++	libdir=$hardcode_libdirs
+ 	eval rpath=\" $hardcode_libdir_flag_spec\"
+       fi
+-      finalize_rpath="$rpath"
++      finalize_rpath=$rpath
+ 
+-      if test -n "$libobjs" && test "$build_old_libs" = yes; then
++      if test -n "$libobjs" && test yes = "$build_old_libs"; then
+ 	# Transform all the library objects into standard objects.
+ 	compile_command=`$ECHO "$compile_command" | $SP2NL | $SED "$lo2o" | $NL2SP`
+ 	finalize_command=`$ECHO "$finalize_command" | $SP2NL | $SED "$lo2o" | $NL2SP`
+       fi
+ 
+-      func_generate_dlsyms "$outputname" "@PROGRAM@" "no"
++      func_generate_dlsyms "$outputname" "@PROGRAM@" false
+ 
+       # template prelinking step
+       if test -n "$prelink_cmds"; then
+ 	func_execute_cmds "$prelink_cmds" 'exit $?'
+       fi
+ 
+-      wrappers_required=yes
++      wrappers_required=:
+       case $host in
+       *cegcc* | *mingw32ce*)
+         # Disable wrappers for cegcc and mingw32ce hosts, we are cross compiling anyway.
+-        wrappers_required=no
++        wrappers_required=false
+         ;;
+       *cygwin* | *mingw* )
+-        if test "$build_libtool_libs" != yes; then
+-          wrappers_required=no
+-        fi
++        test yes = "$build_libtool_libs" || wrappers_required=false
+         ;;
+       *)
+-        if test "$need_relink" = no || test "$build_libtool_libs" != yes; then
+-          wrappers_required=no
++        if test no = "$need_relink" || test yes != "$build_libtool_libs"; then
++          wrappers_required=false
+         fi
+         ;;
+       esac
+-      if test "$wrappers_required" = no; then
++      $wrappers_required || {
+ 	# Replace the output file specification.
+ 	compile_command=`$ECHO "$compile_command" | $SED 's%@OUTPUT@%'"$output"'%g'`
+-	link_command="$compile_command$compile_rpath"
++	link_command=$compile_command$compile_rpath
+ 
+ 	# We have no uninstalled library dependencies, so finalize right now.
+ 	exit_status=0
+@@ -8908,12 +10618,12 @@ EOF
+ 	fi
+ 
+ 	# Delete the generated files.
+-	if test -f "$output_objdir/${outputname}S.${objext}"; then
+-	  func_show_eval '$RM "$output_objdir/${outputname}S.${objext}"'
++	if test -f "$output_objdir/${outputname}S.$objext"; then
++	  func_show_eval '$RM "$output_objdir/${outputname}S.$objext"'
+ 	fi
+ 
+ 	exit $exit_status
+-      fi
++      }
+ 
+       if test -n "$compile_shlibpath$finalize_shlibpath"; then
+ 	compile_command="$shlibpath_var=\"$compile_shlibpath$finalize_shlibpath\$$shlibpath_var\" $compile_command"
+@@ -8943,9 +10653,9 @@ EOF
+ 	fi
+       fi
+ 
+-      if test "$no_install" = yes; then
++      if test yes = "$no_install"; then
+ 	# We don't need to create a wrapper script.
+-	link_command="$compile_var$compile_command$compile_rpath"
++	link_command=$compile_var$compile_command$compile_rpath
+ 	# Replace the output file specification.
+ 	link_command=`$ECHO "$link_command" | $SED 's%@OUTPUT@%'"$output"'%g'`
+ 	# Delete the old output file.
+@@ -8962,27 +10672,28 @@ EOF
+ 	exit $EXIT_SUCCESS
+       fi
+ 
+-      if test "$hardcode_action" = relink; then
+-	# Fast installation is not supported
+-	link_command="$compile_var$compile_command$compile_rpath"
+-	relink_command="$finalize_var$finalize_command$finalize_rpath"
++      case $hardcode_action,$fast_install in
++        relink,*)
++	  # Fast installation is not supported
++	  link_command=$compile_var$compile_command$compile_rpath
++	  relink_command=$finalize_var$finalize_command$finalize_rpath
+ 
+-	func_warning "this platform does not like uninstalled shared libraries"
+-	func_warning "\`$output' will be relinked during installation"
+-      else
+-	if test "$fast_install" != no; then
+-	  link_command="$finalize_var$compile_command$finalize_rpath"
+-	  if test "$fast_install" = yes; then
+-	    relink_command=`$ECHO "$compile_var$compile_command$compile_rpath" | $SED 's%@OUTPUT@%\$progdir/\$file%g'`
+-	  else
+-	    # fast_install is set to needless
+-	    relink_command=
+-	  fi
+-	else
+-	  link_command="$compile_var$compile_command$compile_rpath"
+-	  relink_command="$finalize_var$finalize_command$finalize_rpath"
+-	fi
+-      fi
++	  func_warning "this platform does not like uninstalled shared libraries"
++	  func_warning "'$output' will be relinked during installation"
++	  ;;
++        *,yes)
++	  link_command=$finalize_var$compile_command$finalize_rpath
++	  relink_command=`$ECHO "$compile_var$compile_command$compile_rpath" | $SED 's%@OUTPUT@%\$progdir/\$file%g'`
++          ;;
++	*,no)
++	  link_command=$compile_var$compile_command$compile_rpath
++	  relink_command=$finalize_var$finalize_command$finalize_rpath
++          ;;
++	*,needless)
++	  link_command=$finalize_var$compile_command$finalize_rpath
++	  relink_command=
++          ;;
++      esac
+ 
+       # Replace the output file specification.
+       link_command=`$ECHO "$link_command" | $SED 's%@OUTPUT@%'"$output_objdir/$outputname"'%g'`
+@@ -9010,12 +10721,12 @@ EOF
+ 	  elif eval var_value=\$$var; test -z "$var_value"; then
+ 	    relink_command="$var=; export $var; $relink_command"
+ 	  else
+-	    func_quote_for_eval "$var_value"
+-	    relink_command="$var=$func_quote_for_eval_result; export $var; $relink_command"
++	    func_quote_arg pretty "$var_value"
++	    relink_command="$var=$func_quote_arg_result; export $var; $relink_command"
+ 	  fi
+ 	done
+-	relink_command="(cd `pwd`; $relink_command)"
+-	relink_command=`$ECHO "$relink_command" | $SED "$sed_quote_subst"`
++	func_quote_arg pretty,unquoted "(cd `pwd`; $relink_command)"
++	relink_command=$func_quote_arg_unquoted_result
+       fi
+ 
+       # Only actually do things if not in dry run mode.
+@@ -9039,8 +10750,8 @@ EOF
+ 	    func_dirname_and_basename "$output" "" "."
+ 	    output_name=$func_basename_result
+ 	    output_path=$func_dirname_result
+-	    cwrappersource="$output_path/$objdir/lt-$output_name.c"
+-	    cwrapper="$output_path/$output_name.exe"
++	    cwrappersource=$output_path/$objdir/lt-$output_name.c
++	    cwrapper=$output_path/$output_name.exe
+ 	    $RM $cwrappersource $cwrapper
+ 	    trap "$RM $cwrappersource $cwrapper; exit $EXIT_FAILURE" 1 2 15
+ 
+@@ -9061,7 +10772,7 @@ EOF
+ 	    trap "$RM $func_ltwrapper_scriptname_result; exit $EXIT_FAILURE" 1 2 15
+ 	    $opt_dry_run || {
+ 	      # note: this script will not be executed, so do not chmod.
+-	      if test "x$build" = "x$host" ; then
++	      if test "x$build" = "x$host"; then
+ 		$cwrapper --lt-dump-script > $func_ltwrapper_scriptname_result
+ 	      else
+ 		func_emit_wrapper no > $func_ltwrapper_scriptname_result
+@@ -9084,25 +10795,27 @@ EOF
+     # See if we need to build an old-fashioned archive.
+     for oldlib in $oldlibs; do
+ 
+-      if test "$build_libtool_libs" = convenience; then
+-	oldobjs="$libobjs_save $symfileobj"
+-	addlibs="$convenience"
+-	build_libtool_libs=no
+-      else
+-	if test "$build_libtool_libs" = module; then
+-	  oldobjs="$libobjs_save"
++      case $build_libtool_libs in
++        convenience)
++	  oldobjs="$libobjs_save $symfileobj"
++	  addlibs=$convenience
+ 	  build_libtool_libs=no
+-	else
++	  ;;
++	module)
++	  oldobjs=$libobjs_save
++	  addlibs=$old_convenience
++	  build_libtool_libs=no
++          ;;
++	*)
+ 	  oldobjs="$old_deplibs $non_pic_objects"
+-	  if test "$preload" = yes && test -f "$symfileobj"; then
+-	    func_append oldobjs " $symfileobj"
+-	  fi
+-	fi
+-	addlibs="$old_convenience"
+-      fi
++	  $preload && test -f "$symfileobj" \
++	    && func_append oldobjs " $symfileobj"
++	  addlibs=$old_convenience
++	  ;;
++      esac
+ 
+       if test -n "$addlibs"; then
+-	gentop="$output_objdir/${outputname}x"
++	gentop=$output_objdir/${outputname}x
+ 	func_append generated " $gentop"
+ 
+ 	func_extract_archives $gentop $addlibs
+@@ -9110,13 +10823,13 @@ EOF
+       fi
+ 
+       # Do each command in the archive commands.
+-      if test -n "$old_archive_from_new_cmds" && test "$build_libtool_libs" = yes; then
++      if test -n "$old_archive_from_new_cmds" && test yes = "$build_libtool_libs"; then
+ 	cmds=$old_archive_from_new_cmds
+       else
+ 
+ 	# Add any objects from preloaded convenience libraries
+ 	if test -n "$dlprefiles"; then
+-	  gentop="$output_objdir/${outputname}x"
++	  gentop=$output_objdir/${outputname}x
+ 	  func_append generated " $gentop"
+ 
+ 	  func_extract_archives $gentop $dlprefiles
+@@ -9137,7 +10850,7 @@ EOF
+ 	  :
+ 	else
+ 	  echo "copying selected object files to avoid basename conflicts..."
+-	  gentop="$output_objdir/${outputname}x"
++	  gentop=$output_objdir/${outputname}x
+ 	  func_append generated " $gentop"
+ 	  func_mkdir_p "$gentop"
+ 	  save_oldobjs=$oldobjs
+@@ -9146,7 +10859,7 @@ EOF
+ 	  for obj in $save_oldobjs
+ 	  do
+ 	    func_basename "$obj"
+-	    objbase="$func_basename_result"
++	    objbase=$func_basename_result
+ 	    case " $oldobjs " in
+ 	    " ") oldobjs=$obj ;;
+ 	    *[\ /]"$objbase "*)
+@@ -9215,18 +10928,18 @@ EOF
+ 	    else
+ 	      # the above command should be used before it gets too long
+ 	      oldobjs=$objlist
+-	      if test "$obj" = "$last_oldobj" ; then
++	      if test "$obj" = "$last_oldobj"; then
+ 		RANLIB=$save_RANLIB
+ 	      fi
+ 	      test -z "$concat_cmds" || concat_cmds=$concat_cmds~
+-	      eval concat_cmds=\"\${concat_cmds}$old_archive_cmds\"
++	      eval concat_cmds=\"\$concat_cmds$old_archive_cmds\"
+ 	      objlist=
+ 	      len=$len0
+ 	    fi
+ 	  done
+ 	  RANLIB=$save_RANLIB
+ 	  oldobjs=$objlist
+-	  if test "X$oldobjs" = "X" ; then
++	  if test -z "$oldobjs"; then
+ 	    eval cmds=\"\$concat_cmds\"
+ 	  else
+ 	    eval cmds=\"\$concat_cmds~\$old_archive_cmds\"
+@@ -9243,7 +10956,7 @@ EOF
+     case $output in
+     *.la)
+       old_library=
+-      test "$build_old_libs" = yes && old_library="$libname.$libext"
++      test yes = "$build_old_libs" && old_library=$libname.$libext
+       func_verbose "creating $output"
+ 
+       # Preserve any variables that may affect compiler behavior
+@@ -9253,36 +10966,37 @@ EOF
+ 	elif eval var_value=\$$var; test -z "$var_value"; then
+ 	  relink_command="$var=; export $var; $relink_command"
+ 	else
+-	  func_quote_for_eval "$var_value"
+-	  relink_command="$var=$func_quote_for_eval_result; export $var; $relink_command"
++	  func_quote_arg pretty,unquoted "$var_value"
++	  relink_command="$var=$func_quote_arg_unquoted_result; export $var; $relink_command"
+ 	fi
+       done
+       # Quote the link command for shipping.
+-      relink_command="(cd `pwd`; $SHELL $progpath $preserve_args --mode=relink $libtool_args @inst_prefix_dir@)"
+-      relink_command=`$ECHO "$relink_command" | $SED "$sed_quote_subst"`
+-      if test "$hardcode_automatic" = yes ; then
++      relink_command="(cd `pwd`; $SHELL \"$progpath\" $preserve_args --mode=relink $libtool_args @inst_prefix_dir@)"
++      func_quote_arg pretty,unquoted "$relink_command"
++      relink_command=$func_quote_arg_unquoted_result
++      if test yes = "$hardcode_automatic"; then
+ 	relink_command=
+       fi
+ 
+       # Only create the output if not a dry run.
+       $opt_dry_run || {
+ 	for installed in no yes; do
+-	  if test "$installed" = yes; then
++	  if test yes = "$installed"; then
+ 	    if test -z "$install_libdir"; then
+ 	      break
+ 	    fi
+-	    output="$output_objdir/$outputname"i
++	    output=$output_objdir/${outputname}i
+ 	    # Replace all uninstalled libtool libraries with the installed ones
+ 	    newdependency_libs=
+ 	    for deplib in $dependency_libs; do
+ 	      case $deplib in
+ 	      *.la)
+ 		func_basename "$deplib"
+-		name="$func_basename_result"
++		name=$func_basename_result
+ 		func_resolve_sysroot "$deplib"
+-		eval libdir=`${SED} -n -e 's/^libdir=\(.*\)$/\1/p' $func_resolve_sysroot_result`
++		eval libdir=`$SED -n -e 's/^libdir=\(.*\)$/\1/p' $func_resolve_sysroot_result`
+ 		test -z "$libdir" && \
+-		  func_fatal_error "\`$deplib' is not a valid libtool archive"
++		  func_fatal_error "'$deplib' is not a valid libtool archive"
+ 		func_append newdependency_libs " ${lt_sysroot:+=}$libdir/$name"
+ 		;;
+ 	      -L*)
+@@ -9298,23 +11012,23 @@ EOF
+ 	      *) func_append newdependency_libs " $deplib" ;;
+ 	      esac
+ 	    done
+-	    dependency_libs="$newdependency_libs"
++	    dependency_libs=$newdependency_libs
+ 	    newdlfiles=
+ 
+ 	    for lib in $dlfiles; do
+ 	      case $lib in
+ 	      *.la)
+ 	        func_basename "$lib"
+-		name="$func_basename_result"
+-		eval libdir=`${SED} -n -e 's/^libdir=\(.*\)$/\1/p' $lib`
++		name=$func_basename_result
++		eval libdir=`$SED -n -e 's/^libdir=\(.*\)$/\1/p' $lib`
+ 		test -z "$libdir" && \
+-		  func_fatal_error "\`$lib' is not a valid libtool archive"
++		  func_fatal_error "'$lib' is not a valid libtool archive"
+ 		func_append newdlfiles " ${lt_sysroot:+=}$libdir/$name"
+ 		;;
+ 	      *) func_append newdlfiles " $lib" ;;
+ 	      esac
+ 	    done
+-	    dlfiles="$newdlfiles"
++	    dlfiles=$newdlfiles
+ 	    newdlprefiles=
+ 	    for lib in $dlprefiles; do
+ 	      case $lib in
+@@ -9324,34 +11038,34 @@ EOF
+ 		# didn't already link the preopened objects directly into
+ 		# the library:
+ 		func_basename "$lib"
+-		name="$func_basename_result"
+-		eval libdir=`${SED} -n -e 's/^libdir=\(.*\)$/\1/p' $lib`
++		name=$func_basename_result
++		eval libdir=`$SED -n -e 's/^libdir=\(.*\)$/\1/p' $lib`
+ 		test -z "$libdir" && \
+-		  func_fatal_error "\`$lib' is not a valid libtool archive"
++		  func_fatal_error "'$lib' is not a valid libtool archive"
+ 		func_append newdlprefiles " ${lt_sysroot:+=}$libdir/$name"
+ 		;;
+ 	      esac
+ 	    done
+-	    dlprefiles="$newdlprefiles"
++	    dlprefiles=$newdlprefiles
+ 	  else
+ 	    newdlfiles=
+ 	    for lib in $dlfiles; do
+ 	      case $lib in
+-		[\\/]* | [A-Za-z]:[\\/]*) abs="$lib" ;;
++		[\\/]* | [A-Za-z]:[\\/]*) abs=$lib ;;
+ 		*) abs=`pwd`"/$lib" ;;
+ 	      esac
+ 	      func_append newdlfiles " $abs"
+ 	    done
+-	    dlfiles="$newdlfiles"
++	    dlfiles=$newdlfiles
+ 	    newdlprefiles=
+ 	    for lib in $dlprefiles; do
+ 	      case $lib in
+-		[\\/]* | [A-Za-z]:[\\/]*) abs="$lib" ;;
++		[\\/]* | [A-Za-z]:[\\/]*) abs=$lib ;;
+ 		*) abs=`pwd`"/$lib" ;;
+ 	      esac
+ 	      func_append newdlprefiles " $abs"
+ 	    done
+-	    dlprefiles="$newdlprefiles"
++	    dlprefiles=$newdlprefiles
+ 	  fi
+ 	  $RM $output
+ 	  # place dlname in correct position for cygwin
+@@ -9367,10 +11081,9 @@ EOF
+ 	  case $host,$output,$installed,$module,$dlname in
+ 	    *cygwin*,*lai,yes,no,*.dll | *mingw*,*lai,yes,no,*.dll | *cegcc*,*lai,yes,no,*.dll)
+ 	      # If a -bindir argument was supplied, place the dll there.
+-	      if test "x$bindir" != x ;
+-	      then
++	      if test -n "$bindir"; then
+ 		func_relative_path "$install_libdir" "$bindir"
+-		tdlname=$func_relative_path_result$dlname
++		tdlname=$func_relative_path_result/$dlname
+ 	      else
+ 		# Otherwise fall back on heuristic.
+ 		tdlname=../bin/$dlname
+@@ -9379,7 +11092,7 @@ EOF
+ 	  esac
+ 	  $ECHO > $output "\
+ # $outputname - a libtool library file
+-# Generated by $PROGRAM (GNU $PACKAGE$TIMESTAMP) $VERSION
++# Generated by $PROGRAM (GNU $PACKAGE) $VERSION
+ #
+ # Please DO NOT delete this file!
+ # It is necessary for linking the library.
+@@ -9393,7 +11106,7 @@ library_names='$library_names'
+ # The name of the static archive.
+ old_library='$old_library'
+ 
+-# Linker flags that can not go in dependency_libs.
++# Linker flags that cannot go in dependency_libs.
+ inherited_linker_flags='$new_inherited_linker_flags'
+ 
+ # Libraries that this one depends upon.
+@@ -9419,7 +11132,7 @@ dlpreopen='$dlprefiles'
+ 
+ # Directory that this library needs to be installed in:
+ libdir='$install_libdir'"
+-	  if test "$installed" = no && test "$need_relink" = yes; then
++	  if test no,yes = "$installed,$need_relink"; then
+ 	    $ECHO >> $output "\
+ relink_command=\"$relink_command\""
+ 	  fi
+@@ -9434,27 +11147,29 @@ relink_command=\"$relink_command\""
+     exit $EXIT_SUCCESS
+ }
+ 
+-{ test "$opt_mode" = link || test "$opt_mode" = relink; } &&
+-    func_mode_link ${1+"$@"}
++if test link = "$opt_mode" || test relink = "$opt_mode"; then
++  func_mode_link ${1+"$@"}
++fi
+ 
+ 
+ # func_mode_uninstall arg...
+ func_mode_uninstall ()
+ {
+-    $opt_debug
+-    RM="$nonopt"
++    $debug_cmd
++
++    RM=$nonopt
+     files=
+-    rmforce=
++    rmforce=false
+     exit_status=0
+ 
+     # This variable tells wrapper scripts just to set variables rather
+     # than running their programs.
+-    libtool_install_magic="$magic"
++    libtool_install_magic=$magic
+ 
+     for arg
+     do
+       case $arg in
+-      -f) func_append RM " $arg"; rmforce=yes ;;
++      -f) func_append RM " $arg"; rmforce=: ;;
+       -*) func_append RM " $arg" ;;
+       *) func_append files " $arg" ;;
+       esac
+@@ -9467,18 +11182,18 @@ func_mode_uninstall ()
+ 
+     for file in $files; do
+       func_dirname "$file" "" "."
+-      dir="$func_dirname_result"
+-      if test "X$dir" = X.; then
+-	odir="$objdir"
++      dir=$func_dirname_result
++      if test . = "$dir"; then
++	odir=$objdir
+       else
+-	odir="$dir/$objdir"
++	odir=$dir/$objdir
+       fi
+       func_basename "$file"
+-      name="$func_basename_result"
+-      test "$opt_mode" = uninstall && odir="$dir"
++      name=$func_basename_result
++      test uninstall = "$opt_mode" && odir=$dir
+ 
+       # Remember odir for removal later, being careful to avoid duplicates
+-      if test "$opt_mode" = clean; then
++      if test clean = "$opt_mode"; then
+ 	case " $rmdirs " in
+ 	  *" $odir "*) ;;
+ 	  *) func_append rmdirs " $odir" ;;
+@@ -9493,11 +11208,11 @@ func_mode_uninstall ()
+       elif test -d "$file"; then
+ 	exit_status=1
+ 	continue
+-      elif test "$rmforce" = yes; then
++      elif $rmforce; then
+ 	continue
+       fi
+ 
+-      rmfiles="$file"
++      rmfiles=$file
+ 
+       case $name in
+       *.la)
+@@ -9511,7 +11226,7 @@ func_mode_uninstall ()
+ 	  done
+ 	  test -n "$old_library" && func_append rmfiles " $odir/$old_library"
+ 
+-	  case "$opt_mode" in
++	  case $opt_mode in
+ 	  clean)
+ 	    case " $library_names " in
+ 	    *" $dlname "*) ;;
+@@ -9522,12 +11237,12 @@ func_mode_uninstall ()
+ 	  uninstall)
+ 	    if test -n "$library_names"; then
+ 	      # Do each command in the postuninstall commands.
+-	      func_execute_cmds "$postuninstall_cmds" 'test "$rmforce" = yes || exit_status=1'
++	      func_execute_cmds "$postuninstall_cmds" '$rmforce || exit_status=1'
+ 	    fi
+ 
+ 	    if test -n "$old_library"; then
+ 	      # Do each command in the old_postuninstall commands.
+-	      func_execute_cmds "$old_postuninstall_cmds" 'test "$rmforce" = yes || exit_status=1'
++	      func_execute_cmds "$old_postuninstall_cmds" '$rmforce || exit_status=1'
+ 	    fi
+ 	    # FIXME: should reinstall the best remaining shared library.
+ 	    ;;
+@@ -9543,21 +11258,19 @@ func_mode_uninstall ()
+ 	  func_source $dir/$name
+ 
+ 	  # Add PIC object to the list of files to remove.
+-	  if test -n "$pic_object" &&
+-	     test "$pic_object" != none; then
++	  if test -n "$pic_object" && test none != "$pic_object"; then
+ 	    func_append rmfiles " $dir/$pic_object"
+ 	  fi
+ 
+ 	  # Add non-PIC object to the list of files to remove.
+-	  if test -n "$non_pic_object" &&
+-	     test "$non_pic_object" != none; then
++	  if test -n "$non_pic_object" && test none != "$non_pic_object"; then
+ 	    func_append rmfiles " $dir/$non_pic_object"
+ 	  fi
+ 	fi
+ 	;;
+ 
+       *)
+-	if test "$opt_mode" = clean ; then
++	if test clean = "$opt_mode"; then
+ 	  noexename=$name
+ 	  case $file in
+ 	  *.exe)
+@@ -9584,12 +11297,12 @@ func_mode_uninstall ()
+ 
+ 	    # note $name still contains .exe if it was in $file originally
+ 	    # as does the version of $file that was added into $rmfiles
+-	    func_append rmfiles " $odir/$name $odir/${name}S.${objext}"
+-	    if test "$fast_install" = yes && test -n "$relink_command"; then
++	    func_append rmfiles " $odir/$name $odir/${name}S.$objext"
++	    if test yes = "$fast_install" && test -n "$relink_command"; then
+ 	      func_append rmfiles " $odir/lt-$name"
+ 	    fi
+-	    if test "X$noexename" != "X$name" ; then
+-	      func_append rmfiles " $odir/lt-${noexename}.c"
++	    if test "X$noexename" != "X$name"; then
++	      func_append rmfiles " $odir/lt-$noexename.c"
+ 	    fi
+ 	  fi
+ 	fi
+@@ -9598,7 +11311,7 @@ func_mode_uninstall ()
+       func_show_eval "$RM $rmfiles" 'exit_status=1'
+     done
+ 
+-    # Try to remove the ${objdir}s in the directories where we deleted files
++    # Try to remove the $objdir's in the directories where we deleted files
+     for dir in $rmdirs; do
+       if test -d "$dir"; then
+ 	func_show_eval "rmdir $dir >/dev/null 2>&1"
+@@ -9608,16 +11321,17 @@ func_mode_uninstall ()
+     exit $exit_status
+ }
+ 
+-{ test "$opt_mode" = uninstall || test "$opt_mode" = clean; } &&
+-    func_mode_uninstall ${1+"$@"}
++if test uninstall = "$opt_mode" || test clean = "$opt_mode"; then
++  func_mode_uninstall ${1+"$@"}
++fi
+ 
+ test -z "$opt_mode" && {
+-  help="$generic_help"
++  help=$generic_help
+   func_fatal_help "you must specify a MODE"
+ }
+ 
+ test -z "$exec_cmd" && \
+-  func_fatal_help "invalid operation mode \`$opt_mode'"
++  func_fatal_help "invalid operation mode '$opt_mode'"
+ 
+ if test -n "$exec_cmd"; then
+   eval exec "$exec_cmd"
+@@ -9628,7 +11342,7 @@ exit $exit_status
+ 
+ 
+ # The TAGs below are defined such that we never get into a situation
+-# in which we disable both kinds of libraries.  Given conflicting
++# where we disable both kinds of libraries.  Given conflicting
+ # choices, we go for a static library, that is the most portable,
+ # since we can't tell whether shared libraries were disabled because
+ # the user asked for that or because the platform doesn't support
+@@ -9651,5 +11365,3 @@ build_old_libs=`case $build_libtool_libs in yes) echo no;; *) echo yes;; esac`
+ # mode:shell-script
+ # sh-indentation:2
+ # End:
+-# vi:sw=2
+-
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index 56666f0..ee292af 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -1,8 +1,6 @@
+ # libtool.m4 - Configure libtool for the host system. -*-Autoconf-*-
+ #
+-#   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005,
+-#                 2006, 2007, 2008, 2009, 2010, 2011 Free Software
+-#                 Foundation, Inc.
++#   Copyright (C) 1996-2001, 2003-2016 Free Software Foundation, Inc.
+ #   Written by Gordon Matzigkeit, 1996
+ #
+ # This file is free software; the Free Software Foundation gives
+@@ -10,36 +8,30 @@
+ # modifications, as long as this notice is preserved.
+ 
+ m4_define([_LT_COPYING], [dnl
+-#   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005,
+-#                 2006, 2007, 2008, 2009, 2010, 2011 Free Software
+-#                 Foundation, Inc.
+-#   Written by Gordon Matzigkeit, 1996
+-#
+-#   This file is part of GNU Libtool.
+-#
+-# GNU Libtool is free software; you can redistribute it and/or
+-# modify it under the terms of the GNU General Public License as
+-# published by the Free Software Foundation; either version 2 of
+-# the License, or (at your option) any later version.
++# Copyright (C) 2014 Free Software Foundation, Inc.
++# This is free software; see the source for copying conditions.  There is NO
++# warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++
++# GNU Libtool is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 2 of of the License, or
++# (at your option) any later version.
+ #
+-# As a special exception to the GNU General Public License,
+-# if you distribute this file as part of a program or library that
+-# is built using GNU Libtool, you may include this file under the
+-# same distribution terms that you use for the rest of that program.
++# As a special exception to the GNU General Public License, if you
++# distribute this file as part of a program or library that is built
++# using GNU Libtool, you may include this file under the  same
++# distribution terms that you use for the rest of that program.
+ #
+-# GNU Libtool is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# GNU Libtool is distributed in the hope that it will be useful, but
++# WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+-# along with GNU Libtool; see the file COPYING.  If not, a copy
+-# can be downloaded from http://www.gnu.org/licenses/gpl.html, or
+-# obtained by writing to the Free Software Foundation, Inc.,
+-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ ])
+ 
+-# serial 57 LT_INIT
++# serial 58 LT_INIT
+ 
+ 
+ # LT_PREREQ(VERSION)
+@@ -67,7 +59,7 @@ esac
+ # LT_INIT([OPTIONS])
+ # ------------------
+ AC_DEFUN([LT_INIT],
+-[AC_PREREQ([2.58])dnl We use AC_INCLUDES_DEFAULT
++[AC_PREREQ([2.62])dnl We use AC_PATH_PROGS_FEATURE_CHECK
+ AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])dnl
+ AC_BEFORE([$0], [LT_LANG])dnl
+ AC_BEFORE([$0], [LT_OUTPUT])dnl
+@@ -91,7 +83,7 @@ dnl Parse OPTIONS
+ _LT_SET_OPTIONS([$0], [$1])
+ 
+ # This can be used to rebuild libtool when needed
+-LIBTOOL_DEPS="$ltmain"
++LIBTOOL_DEPS=$ltmain
+ 
+ # Always use our own libtool.
+ LIBTOOL='$(SHELL) $(top_builddir)/libtool'
+@@ -111,26 +103,43 @@ dnl AC_DEFUN([AC_PROG_LIBTOOL], [])
+ dnl AC_DEFUN([AM_PROG_LIBTOOL], [])
+ 
+ 
++# _LT_PREPARE_CC_BASENAME
++# -----------------------
++m4_defun([_LT_PREPARE_CC_BASENAME], [
++# Calculate cc_basename.  Skip known compiler wrappers and cross-prefix.
++func_cc_basename ()
++{
++    for cc_temp in @S|@*""; do
++      case $cc_temp in
++        compile | *[[\\/]]compile | ccache | *[[\\/]]ccache ) ;;
++        distcc | *[[\\/]]distcc | purify | *[[\\/]]purify ) ;;
++        \-*) ;;
++        *) break;;
++      esac
++    done
++    func_cc_basename_result=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++}
++])# _LT_PREPARE_CC_BASENAME
++
++
+ # _LT_CC_BASENAME(CC)
+ # -------------------
+-# Calculate cc_basename.  Skip known compiler wrappers and cross-prefix.
++# It would be clearer to call AC_REQUIREs from _LT_PREPARE_CC_BASENAME,
++# but that macro is also expanded into generated libtool script, which
++# arranges for $SED and $ECHO to be set by different means.
+ m4_defun([_LT_CC_BASENAME],
+-[for cc_temp in $1""; do
+-  case $cc_temp in
+-    compile | *[[\\/]]compile | ccache | *[[\\/]]ccache ) ;;
+-    distcc | *[[\\/]]distcc | purify | *[[\\/]]purify ) ;;
+-    \-*) ;;
+-    *) break;;
+-  esac
+-done
+-cc_basename=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++[m4_require([_LT_PREPARE_CC_BASENAME])dnl
++AC_REQUIRE([_LT_DECL_SED])dnl
++AC_REQUIRE([_LT_PROG_ECHO_BACKSLASH])dnl
++func_cc_basename $1
++cc_basename=$func_cc_basename_result
+ ])
+ 
+ 
+ # _LT_FILEUTILS_DEFAULTS
+ # ----------------------
+ # It is okay to use these file commands and assume they have been set
+-# sensibly after `m4_require([_LT_FILEUTILS_DEFAULTS])'.
++# sensibly after 'm4_require([_LT_FILEUTILS_DEFAULTS])'.
+ m4_defun([_LT_FILEUTILS_DEFAULTS],
+ [: ${CP="cp -f"}
+ : ${MV="mv -f"}
+@@ -177,15 +186,16 @@ m4_require([_LT_CHECK_SHAREDLIB_FROM_LINKLIB])dnl
+ m4_require([_LT_CMD_OLD_ARCHIVE])dnl
+ m4_require([_LT_CMD_GLOBAL_SYMBOLS])dnl
+ m4_require([_LT_WITH_SYSROOT])dnl
++m4_require([_LT_CMD_TRUNCATE])dnl
+ 
+ _LT_CONFIG_LIBTOOL_INIT([
+-# See if we are running on zsh, and set the options which allow our
++# See if we are running on zsh, and set the options that allow our
+ # commands through without removal of \ escapes INIT.
+-if test -n "\${ZSH_VERSION+set}" ; then
++if test -n "\${ZSH_VERSION+set}"; then
+    setopt NO_GLOB_SUBST
+ fi
+ ])
+-if test -n "${ZSH_VERSION+set}" ; then
++if test -n "${ZSH_VERSION+set}"; then
+    setopt NO_GLOB_SUBST
+ fi
+ 
+@@ -198,7 +208,7 @@ aix3*)
+   # AIX sometimes has problems with the GCC collect2 program.  For some
+   # reason, if we set the COLLECT_NAMES environment variable, the problems
+   # vanish in a puff of smoke.
+-  if test "X${COLLECT_NAMES+set}" != Xset; then
++  if test set != "${COLLECT_NAMES+set}"; then
+     COLLECT_NAMES=
+     export COLLECT_NAMES
+   fi
+@@ -209,14 +219,14 @@ esac
+ ofile=libtool
+ can_build_shared=yes
+ 
+-# All known linkers require a `.a' archive for static linking (except MSVC,
++# All known linkers require a '.a' archive for static linking (except MSVC,
+ # which needs '.lib').
+ libext=a
+ 
+-with_gnu_ld="$lt_cv_prog_gnu_ld"
++with_gnu_ld=$lt_cv_prog_gnu_ld
+ 
+-old_CC="$CC"
+-old_CFLAGS="$CFLAGS"
++old_CC=$CC
++old_CFLAGS=$CFLAGS
+ 
+ # Set sane defaults for various variables
+ test -z "$CC" && CC=cc
+@@ -269,14 +279,14 @@ no_glob_subst='s/\*/\\\*/g'
+ 
+ # _LT_PROG_LTMAIN
+ # ---------------
+-# Note that this code is called both from `configure', and `config.status'
++# Note that this code is called both from 'configure', and 'config.status'
+ # now that we use AC_CONFIG_COMMANDS to generate libtool.  Notably,
+-# `config.status' has no value for ac_aux_dir unless we are using Automake,
++# 'config.status' has no value for ac_aux_dir unless we are using Automake,
+ # so we pass a copy along to make sure it has a sensible value anyway.
+ m4_defun([_LT_PROG_LTMAIN],
+ [m4_ifdef([AC_REQUIRE_AUX_FILE], [AC_REQUIRE_AUX_FILE([ltmain.sh])])dnl
+ _LT_CONFIG_LIBTOOL_INIT([ac_aux_dir='$ac_aux_dir'])
+-ltmain="$ac_aux_dir/ltmain.sh"
++ltmain=$ac_aux_dir/ltmain.sh
+ ])# _LT_PROG_LTMAIN
+ 
+ 
+@@ -286,7 +296,7 @@ ltmain="$ac_aux_dir/ltmain.sh"
+ 
+ # So that we can recreate a full libtool script including additional
+ # tags, we accumulate the chunks of code to send to AC_CONFIG_COMMANDS
+-# in macros and then make a single call at the end using the `libtool'
++# in macros and then make a single call at the end using the 'libtool'
+ # label.
+ 
+ 
+@@ -421,8 +431,8 @@ m4_define([_lt_decl_all_varnames],
+ 
+ # _LT_CONFIG_STATUS_DECLARE([VARNAME])
+ # ------------------------------------
+-# Quote a variable value, and forward it to `config.status' so that its
+-# declaration there will have the same value as in `configure'.  VARNAME
++# Quote a variable value, and forward it to 'config.status' so that its
++# declaration there will have the same value as in 'configure'.  VARNAME
+ # must have a single quote delimited value for this to work.
+ m4_define([_LT_CONFIG_STATUS_DECLARE],
+ [$1='`$ECHO "$][$1" | $SED "$delay_single_quote_subst"`'])
+@@ -446,7 +456,7 @@ m4_defun([_LT_CONFIG_STATUS_DECLARATIONS],
+ # Output comment and list of tags supported by the script
+ m4_defun([_LT_LIBTOOL_TAGS],
+ [_LT_FORMAT_COMMENT([The names of the tagged configurations supported by this script])dnl
+-available_tags="_LT_TAGS"dnl
++available_tags='_LT_TAGS'dnl
+ ])
+ 
+ 
+@@ -474,7 +484,7 @@ m4_ifval([$2], [_$2])[]m4_popdef([_libtool_name])[]dnl
+ # _LT_LIBTOOL_CONFIG_VARS
+ # -----------------------
+ # Produce commented declarations of non-tagged libtool config variables
+-# suitable for insertion in the LIBTOOL CONFIG section of the `libtool'
++# suitable for insertion in the LIBTOOL CONFIG section of the 'libtool'
+ # script.  Tagged libtool config variables (even for the LIBTOOL CONFIG
+ # section) are produced by _LT_LIBTOOL_TAG_VARS.
+ m4_defun([_LT_LIBTOOL_CONFIG_VARS],
+@@ -500,8 +510,8 @@ m4_define([_LT_TAGVAR], [m4_ifval([$2], [$1_$2], [$1])])
+ # Send accumulated output to $CONFIG_STATUS.  Thanks to the lists of
+ # variables for single and double quote escaping we saved from calls
+ # to _LT_DECL, we can put quote escaped variables declarations
+-# into `config.status', and then the shell code to quote escape them in
+-# for loops in `config.status'.  Finally, any additional code accumulated
++# into 'config.status', and then the shell code to quote escape them in
++# for loops in 'config.status'.  Finally, any additional code accumulated
+ # from calls to _LT_CONFIG_LIBTOOL_INIT is expanded.
+ m4_defun([_LT_CONFIG_COMMANDS],
+ [AC_PROVIDE_IFELSE([LT_OUTPUT],
+@@ -547,7 +557,7 @@ for var in lt_decl_all_varnames([[ \
+ ]], lt_decl_quote_varnames); do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[[\\\\\\\`\\"\\\$]]*)
+-      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\""
++      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\"" ## exclude from sc_prohibit_nested_quotes
+       ;;
+     *)
+       eval "lt_\$var=\\\\\\"\\\$\$var\\\\\\""
+@@ -560,7 +570,7 @@ for var in lt_decl_all_varnames([[ \
+ ]], lt_decl_dquote_varnames); do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[[\\\\\\\`\\"\\\$]]*)
+-      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\""
++      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\"" ## exclude from sc_prohibit_nested_quotes
+       ;;
+     *)
+       eval "lt_\$var=\\\\\\"\\\$\$var\\\\\\""
+@@ -576,7 +586,7 @@ _LT_OUTPUT_LIBTOOL_INIT
+ # Generate a child script FILE with all initialization necessary to
+ # reuse the environment learned by the parent script, and make the
+ # file executable.  If COMMENT is supplied, it is inserted after the
+-# `#!' sequence but before initialization text begins.  After this
++# '#!' sequence but before initialization text begins.  After this
+ # macro, additional text can be appended to FILE to form the body of
+ # the child script.  The macro ends with non-zero status if the
+ # file could not be fully written (such as if the disk is full).
+@@ -598,7 +608,7 @@ AS_SHELL_SANITIZE
+ _AS_PREPARE
+ exec AS_MESSAGE_FD>&1
+ _ASEOF
+-test $lt_write_fail = 0 && chmod +x $1[]dnl
++test 0 = "$lt_write_fail" && chmod +x $1[]dnl
+ m4_popdef([AS_MESSAGE_LOG_FD])])])# _LT_GENERATED_FILE_INIT
+ 
+ # LT_OUTPUT
+@@ -621,7 +631,7 @@ exec AS_MESSAGE_LOG_FD>>config.log
+ } >&AS_MESSAGE_LOG_FD
+ 
+ lt_cl_help="\
+-\`$as_me' creates a local libtool stub from the current configuration,
++'$as_me' creates a local libtool stub from the current configuration,
+ for use in further configure time tests before the real libtool is
+ generated.
+ 
+@@ -643,7 +653,7 @@ Copyright (C) 2011 Free Software Foundation, Inc.
+ This config.lt script is free software; the Free Software Foundation
+ gives unlimited permision to copy, distribute and modify it."
+ 
+-while test $[#] != 0
++while test 0 != $[#]
+ do
+   case $[1] in
+     --version | --v* | -V )
+@@ -656,10 +666,10 @@ do
+       lt_cl_silent=: ;;
+ 
+     -*) AC_MSG_ERROR([unrecognized option: $[1]
+-Try \`$[0] --help' for more information.]) ;;
++Try '$[0] --help' for more information.]) ;;
+ 
+     *) AC_MSG_ERROR([unrecognized argument: $[1]
+-Try \`$[0] --help' for more information.]) ;;
++Try '$[0] --help' for more information.]) ;;
+   esac
+   shift
+ done
+@@ -685,7 +695,7 @@ chmod +x "$CONFIG_LT"
+ # open by configure.  Here we exec the FD to /dev/null, effectively closing
+ # config.log, so it can be properly (re)opened and appended to by config.lt.
+ lt_cl_success=:
+-test "$silent" = yes &&
++test yes = "$silent" &&
+   lt_config_lt_args="$lt_config_lt_args --quiet"
+ exec AS_MESSAGE_LOG_FD>/dev/null
+ $SHELL "$CONFIG_LT" $lt_config_lt_args || lt_cl_success=false
+@@ -705,27 +715,31 @@ m4_defun([_LT_CONFIG],
+ _LT_CONFIG_SAVE_COMMANDS([
+   m4_define([_LT_TAG], m4_if([$1], [], [C], [$1]))dnl
+   m4_if(_LT_TAG, [C], [
+-    # See if we are running on zsh, and set the options which allow our
++    # See if we are running on zsh, and set the options that allow our
+     # commands through without removal of \ escapes.
+-    if test -n "${ZSH_VERSION+set}" ; then
++    if test -n "${ZSH_VERSION+set}"; then
+       setopt NO_GLOB_SUBST
+     fi
+ 
+-    cfgfile="${ofile}T"
++    cfgfile=${ofile}T
+     trap "$RM \"$cfgfile\"; exit 1" 1 2 15
+     $RM "$cfgfile"
+ 
+     cat <<_LT_EOF >> "$cfgfile"
+ #! $SHELL
+-
+-# `$ECHO "$ofile" | sed 's%^.*/%%'` - Provide generalized library-building support services.
+-# Generated automatically by $as_me ($PACKAGE$TIMESTAMP) $VERSION
++# Generated automatically by $as_me ($PACKAGE) $VERSION
+ # Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
+ # NOTE: Changes made to this file will be lost: look at ltmain.sh.
+-#
++
++# Provide generalized library-building support services.
++# Written by Gordon Matzigkeit, 1996
++
+ _LT_COPYING
+ _LT_LIBTOOL_TAGS
+ 
++# Configured defaults for sys_lib_dlsearch_path munging.
++: \${LT_SYS_LIBRARY_PATH="$configure_time_lt_sys_library_path"}
++
+ # ### BEGIN LIBTOOL CONFIG
+ _LT_LIBTOOL_CONFIG_VARS
+ _LT_LIBTOOL_TAG_VARS
+@@ -733,13 +747,24 @@ _LT_LIBTOOL_TAG_VARS
+ 
+ _LT_EOF
+ 
++    cat <<'_LT_EOF' >> "$cfgfile"
++
++# ### BEGIN FUNCTIONS SHARED WITH CONFIGURE
++
++_LT_PREPARE_MUNGE_PATH_LIST
++_LT_PREPARE_CC_BASENAME
++
++# ### END FUNCTIONS SHARED WITH CONFIGURE
++
++_LT_EOF
++
+   case $host_os in
+   aix3*)
+     cat <<\_LT_EOF >> "$cfgfile"
+ # AIX sometimes has problems with the GCC collect2 program.  For some
+ # reason, if we set the COLLECT_NAMES environment variable, the problems
+ # vanish in a puff of smoke.
+-if test "X${COLLECT_NAMES+set}" != Xset; then
++if test set != "${COLLECT_NAMES+set}"; then
+   COLLECT_NAMES=
+   export COLLECT_NAMES
+ fi
+@@ -756,8 +781,6 @@ _LT_EOF
+   sed '$q' "$ltmain" >> "$cfgfile" \
+      || (rm -f "$cfgfile"; exit 1)
+ 
+-  _LT_PROG_REPLACE_SHELLFNS
+-
+    mv -f "$cfgfile" "$ofile" ||
+     (rm -f "$ofile" && cp "$cfgfile" "$ofile" && rm -f "$cfgfile")
+   chmod +x "$ofile"
+@@ -775,7 +798,6 @@ _LT_EOF
+ [m4_if([$1], [], [
+     PACKAGE='$PACKAGE'
+     VERSION='$VERSION'
+-    TIMESTAMP='$TIMESTAMP'
+     RM='$RM'
+     ofile='$ofile'], [])
+ ])dnl /_LT_CONFIG_SAVE_COMMANDS
+@@ -974,7 +996,7 @@ m4_defun_once([_LT_REQUIRED_DARWIN_CHECKS],[
+ 
+     AC_CACHE_CHECK([for -single_module linker flag],[lt_cv_apple_cc_single_mod],
+       [lt_cv_apple_cc_single_mod=no
+-      if test -z "${LT_MULTI_MODULE}"; then
++      if test -z "$LT_MULTI_MODULE"; then
+ 	# By default we will add the -single_module flag. You can override
+ 	# by either setting the environment variable LT_MULTI_MODULE
+ 	# non-empty at configure time, or by adding -multi_module to the
+@@ -992,7 +1014,7 @@ m4_defun_once([_LT_REQUIRED_DARWIN_CHECKS],[
+ 	  cat conftest.err >&AS_MESSAGE_LOG_FD
+ 	# Otherwise, if the output was created with a 0 exit code from
+ 	# the compiler, it worked.
+-	elif test -f libconftest.dylib && test $_lt_result -eq 0; then
++	elif test -f libconftest.dylib && test 0 = "$_lt_result"; then
+ 	  lt_cv_apple_cc_single_mod=yes
+ 	else
+ 	  cat conftest.err >&AS_MESSAGE_LOG_FD
+@@ -1010,7 +1032,7 @@ m4_defun_once([_LT_REQUIRED_DARWIN_CHECKS],[
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
+ 	[lt_cv_ld_exported_symbols_list=yes],
+ 	[lt_cv_ld_exported_symbols_list=no])
+-	LDFLAGS="$save_LDFLAGS"
++	LDFLAGS=$save_LDFLAGS
+     ])
+ 
+     AC_CACHE_CHECK([for -force_load linker flag],[lt_cv_ld_force_load],
+@@ -1020,8 +1042,8 @@ int forced_loaded() { return 2;}
+ _LT_EOF
+       echo "$LTCC $LTCFLAGS -c -o conftest.o conftest.c" >&AS_MESSAGE_LOG_FD
+       $LTCC $LTCFLAGS -c -o conftest.o conftest.c 2>&AS_MESSAGE_LOG_FD
+-      echo "$AR cru libconftest.a conftest.o" >&AS_MESSAGE_LOG_FD
+-      $AR cru libconftest.a conftest.o 2>&AS_MESSAGE_LOG_FD
++      echo "$AR $AR_FLAGS libconftest.a conftest.o" >&AS_MESSAGE_LOG_FD
++      $AR $AR_FLAGS libconftest.a conftest.o 2>&AS_MESSAGE_LOG_FD
+       echo "$RANLIB libconftest.a" >&AS_MESSAGE_LOG_FD
+       $RANLIB libconftest.a 2>&AS_MESSAGE_LOG_FD
+       cat > conftest.c << _LT_EOF
+@@ -1032,7 +1054,7 @@ _LT_EOF
+       _lt_result=$?
+       if test -s conftest.err && $GREP force_load conftest.err; then
+ 	cat conftest.err >&AS_MESSAGE_LOG_FD
+-      elif test -f conftest && test $_lt_result -eq 0 && $GREP forced_load conftest >/dev/null 2>&1 ; then
++      elif test -f conftest && test 0 = "$_lt_result" && $GREP forced_load conftest >/dev/null 2>&1; then
+ 	lt_cv_ld_force_load=yes
+       else
+ 	cat conftest.err >&AS_MESSAGE_LOG_FD
+@@ -1042,32 +1064,32 @@ _LT_EOF
+     ])
+     case $host_os in
+     rhapsody* | darwin1.[[012]])
+-      _lt_dar_allow_undefined='${wl}-undefined ${wl}suppress' ;;
++      _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+-      _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++      _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+     darwin*) # darwin 5.x on
+       # if running on 10.5 or later, the deployment target defaults
+       # to the OS version, if on x86, and 10.4, the deployment
+       # target defaults to 10.4. Don't you love it?
+       case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+ 	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
+-	10.[[012]]*)
+-	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
++	10.[[012]][[,.]]*)
++	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+ 	10.*)
+-	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
++	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;
+   esac
+-    if test "$lt_cv_apple_cc_single_mod" = "yes"; then
++    if test yes = "$lt_cv_apple_cc_single_mod"; then
+       _lt_dar_single_mod='$single_module'
+     fi
+-    if test "$lt_cv_ld_exported_symbols_list" = "yes"; then
+-      _lt_dar_export_syms=' ${wl}-exported_symbols_list,$output_objdir/${libname}-symbols.expsym'
++    if test yes = "$lt_cv_ld_exported_symbols_list"; then
++      _lt_dar_export_syms=' $wl-exported_symbols_list,$output_objdir/$libname-symbols.expsym'
+     else
+-      _lt_dar_export_syms='~$NMEDIT -s $output_objdir/${libname}-symbols.expsym ${lib}'
++      _lt_dar_export_syms='~$NMEDIT -s $output_objdir/$libname-symbols.expsym $lib'
+     fi
+-    if test "$DSYMUTIL" != ":" && test "$lt_cv_ld_force_load" = "no"; then
++    if test : != "$DSYMUTIL" && test no = "$lt_cv_ld_force_load"; then
+       _lt_dsymutil='~$DSYMUTIL $lib || :'
+     else
+       _lt_dsymutil=
+@@ -1087,29 +1109,29 @@ m4_defun([_LT_DARWIN_LINKER_FEATURES],
+   _LT_TAGVAR(hardcode_direct, $1)=no
+   _LT_TAGVAR(hardcode_automatic, $1)=yes
+   _LT_TAGVAR(hardcode_shlibpath_var, $1)=unsupported
+-  if test "$lt_cv_ld_force_load" = "yes"; then
+-    _LT_TAGVAR(whole_archive_flag_spec, $1)='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience ${wl}-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
++  if test yes = "$lt_cv_ld_force_load"; then
++    _LT_TAGVAR(whole_archive_flag_spec, $1)='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience $wl-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
+     m4_case([$1], [F77], [_LT_TAGVAR(compiler_needs_object, $1)=yes],
+                   [FC],  [_LT_TAGVAR(compiler_needs_object, $1)=yes])
+   else
+     _LT_TAGVAR(whole_archive_flag_spec, $1)=''
+   fi
+   _LT_TAGVAR(link_all_deplibs, $1)=yes
+-  _LT_TAGVAR(allow_undefined_flag, $1)="$_lt_dar_allow_undefined"
++  _LT_TAGVAR(allow_undefined_flag, $1)=$_lt_dar_allow_undefined
+   case $cc_basename in
+-     ifort*) _lt_dar_can_shared=yes ;;
++     ifort*|nagfor*) _lt_dar_can_shared=yes ;;
+      *) _lt_dar_can_shared=$GCC ;;
+   esac
+-  if test "$_lt_dar_can_shared" = "yes"; then
++  if test yes = "$_lt_dar_can_shared"; then
+     output_verbose_link_cmd=func_echo_all
+-    _LT_TAGVAR(archive_cmds, $1)="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod${_lt_dsymutil}"
+-    _LT_TAGVAR(module_cmds, $1)="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dsymutil}"
+-    _LT_TAGVAR(archive_expsym_cmds, $1)="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring ${_lt_dar_single_mod}${_lt_dar_export_syms}${_lt_dsymutil}"
+-    _LT_TAGVAR(module_expsym_cmds, $1)="sed -e 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dar_export_syms}${_lt_dsymutil}"
++    _LT_TAGVAR(archive_cmds, $1)="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dsymutil"
++    _LT_TAGVAR(module_cmds, $1)="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dsymutil"
++    _LT_TAGVAR(archive_expsym_cmds, $1)="sed 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod$_lt_dar_export_syms$_lt_dsymutil"
++    _LT_TAGVAR(module_expsym_cmds, $1)="sed -e 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags$_lt_dar_export_syms$_lt_dsymutil"
+     m4_if([$1], [CXX],
+-[   if test "$lt_cv_apple_cc_single_mod" != "yes"; then
+-      _LT_TAGVAR(archive_cmds, $1)="\$CC -r -keep_private_externs -nostdlib -o \${lib}-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \${lib}-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring${_lt_dsymutil}"
+-      _LT_TAGVAR(archive_expsym_cmds, $1)="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -r -keep_private_externs -nostdlib -o \${lib}-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \${lib}-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring${_lt_dar_export_syms}${_lt_dsymutil}"
++[   if test yes != "$lt_cv_apple_cc_single_mod"; then
++      _LT_TAGVAR(archive_cmds, $1)="\$CC -r -keep_private_externs -nostdlib -o \$lib-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$lib-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring$_lt_dsymutil"
++      _LT_TAGVAR(archive_expsym_cmds, $1)="sed 's|^|_|' < \$export_symbols > \$output_objdir/\$libname-symbols.expsym~\$CC -r -keep_private_externs -nostdlib -o \$lib-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$lib-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring$_lt_dar_export_syms$_lt_dsymutil"
+     fi
+ ],[])
+   else
+@@ -1129,7 +1151,7 @@ m4_defun([_LT_DARWIN_LINKER_FEATURES],
+ # Allow to override them for all tags through lt_cv_aix_libpath.
+ m4_defun([_LT_SYS_MODULE_PATH_AIX],
+ [m4_require([_LT_DECL_SED])dnl
+-if test "${lt_cv_aix_libpath+set}" = set; then
++if test set = "${lt_cv_aix_libpath+set}"; then
+   aix_libpath=$lt_cv_aix_libpath
+ else
+   AC_CACHE_VAL([_LT_TAGVAR([lt_cv_aix_libpath_], [$1])],
+@@ -1147,7 +1169,7 @@ else
+     _LT_TAGVAR([lt_cv_aix_libpath_], [$1])=`dump -HX64 conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
+   fi],[])
+   if test -z "$_LT_TAGVAR([lt_cv_aix_libpath_], [$1])"; then
+-    _LT_TAGVAR([lt_cv_aix_libpath_], [$1])="/usr/lib:/lib"
++    _LT_TAGVAR([lt_cv_aix_libpath_], [$1])=/usr/lib:/lib
+   fi
+   ])
+   aix_libpath=$_LT_TAGVAR([lt_cv_aix_libpath_], [$1])
+@@ -1167,8 +1189,8 @@ m4_define([_LT_SHELL_INIT],
+ # -----------------------
+ # Find how we can fake an echo command that does not interpret backslash.
+ # In particular, with Autoconf 2.60 or later we add some code to the start
+-# of the generated configure script which will find a shell with a builtin
+-# printf (which we can use as an echo command).
++# of the generated configure script that will find a shell with a builtin
++# printf (that we can use as an echo command).
+ m4_defun([_LT_PROG_ECHO_BACKSLASH],
+ [ECHO='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+ ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO
+@@ -1196,10 +1218,10 @@ fi
+ # Invoke $ECHO with all args, space-separated.
+ func_echo_all ()
+ {
+-    $ECHO "$*" 
++    $ECHO "$*"
+ }
+ 
+-case "$ECHO" in
++case $ECHO in
+   printf*) AC_MSG_RESULT([printf]) ;;
+   print*) AC_MSG_RESULT([print -r]) ;;
+   *) AC_MSG_RESULT([cat]) ;;
+@@ -1225,16 +1247,17 @@ _LT_DECL([], [ECHO], [1], [An echo program that protects backslashes])
+ AC_DEFUN([_LT_WITH_SYSROOT],
+ [AC_MSG_CHECKING([for sysroot])
+ AC_ARG_WITH([sysroot],
+-[  --with-sysroot[=DIR] Search for dependent libraries within DIR
+-                        (or the compiler's sysroot if not specified).],
++[AS_HELP_STRING([--with-sysroot@<:@=DIR@:>@],
++  [Search for dependent libraries within DIR (or the compiler's sysroot
++   if not specified).])],
+ [], [with_sysroot=no])
+ 
+ dnl lt_sysroot will always be passed unquoted.  We quote it here
+ dnl in case the user passed a directory name.
+ lt_sysroot=
+-case ${with_sysroot} in #(
++case $with_sysroot in #(
+  yes)
+-   if test "$GCC" = yes; then
++   if test yes = "$GCC"; then
+      lt_sysroot=`$CC --print-sysroot 2>/dev/null`
+    fi
+    ;; #(
+@@ -1244,14 +1267,14 @@ case ${with_sysroot} in #(
+  no|'')
+    ;; #(
+  *)
+-   AC_MSG_RESULT([${with_sysroot}])
++   AC_MSG_RESULT([$with_sysroot])
+    AC_MSG_ERROR([The sysroot must be an absolute path.])
+    ;;
+ esac
+ 
+  AC_MSG_RESULT([${lt_sysroot:-no}])
+ _LT_DECL([], [lt_sysroot], [0], [The root where to search for ]dnl
+-[dependent libraries, and in which our libraries should be installed.])])
++[dependent libraries, and where our libraries should be installed.])])
+ 
+ # _LT_ENABLE_LOCK
+ # ---------------
+@@ -1259,31 +1282,33 @@ m4_defun([_LT_ENABLE_LOCK],
+ [AC_ARG_ENABLE([libtool-lock],
+   [AS_HELP_STRING([--disable-libtool-lock],
+     [avoid locking (might break parallel builds)])])
+-test "x$enable_libtool_lock" != xno && enable_libtool_lock=yes
++test no = "$enable_libtool_lock" || enable_libtool_lock=yes
+ 
+ # Some flags need to be propagated to the compiler or linker for good
+ # libtool support.
+ case $host in
+ ia64-*-hpux*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set mode
++  # options accordingly.
+   echo 'int i;' > conftest.$ac_ext
+   if AC_TRY_EVAL(ac_compile); then
+     case `/usr/bin/file conftest.$ac_objext` in
+       *ELF-32*)
+-	HPUX_IA64_MODE="32"
++	HPUX_IA64_MODE=32
+ 	;;
+       *ELF-64*)
+-	HPUX_IA64_MODE="64"
++	HPUX_IA64_MODE=64
+ 	;;
+     esac
+   fi
+   rm -rf conftest*
+   ;;
+ *-*-irix6*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.
+   echo '[#]line '$LINENO' "configure"' > conftest.$ac_ext
+   if AC_TRY_EVAL(ac_compile); then
+-    if test "$lt_cv_prog_gnu_ld" = yes; then
++    if test yes = "$lt_cv_prog_gnu_ld"; then
+       case `/usr/bin/file conftest.$ac_objext` in
+ 	*32-bit*)
+ 	  LD="${LD-ld} -melf32bsmip"
+@@ -1312,9 +1337,46 @@ ia64-*-hpux*)
+   rm -rf conftest*
+   ;;
+ 
+-x86_64-*kfreebsd*-gnu|x86_64-*linux*|ppc*-*linux*|powerpc*-*linux*| \
++mips64*-*linux*)
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.
++  echo '[#]line '$LINENO' "configure"' > conftest.$ac_ext
++  if AC_TRY_EVAL(ac_compile); then
++    emul=elf
++    case `/usr/bin/file conftest.$ac_objext` in
++      *32-bit*)
++	emul="${emul}32"
++	;;
++      *64-bit*)
++	emul="${emul}64"
++	;;
++    esac
++    case `/usr/bin/file conftest.$ac_objext` in
++      *MSB*)
++	emul="${emul}btsmip"
++	;;
++      *LSB*)
++	emul="${emul}ltsmip"
++	;;
++    esac
++    case `/usr/bin/file conftest.$ac_objext` in
++      *N32*)
++	emul="${emul}n32"
++	;;
++    esac
++    LD="${LD-ld} -m $emul"
++  fi
++  rm -rf conftest*
++  ;;
++
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
+ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.  Note that the listed cases only cover the
++  # situations where additional linker options are needed (such as when
++  # doing 32-bit compilation for a host where ld defaults to 64-bit, or
++  # vice versa); the common cases where no linker options are needed do
++  # not appear in the list.
+   echo 'int i;' > conftest.$ac_ext
+   if AC_TRY_EVAL(ac_compile); then
+     case `/usr/bin/file conftest.o` in
+@@ -1324,9 +1386,19 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	    LD="${LD-ld} -m elf_i386_fbsd"
+ 	    ;;
+ 	  x86_64-*linux*)
+-	    LD="${LD-ld} -m elf_i386"
++	    case `/usr/bin/file conftest.o` in
++	      *x86-64*)
++		LD="${LD-ld} -m elf32_x86_64"
++		;;
++	      *)
++		LD="${LD-ld} -m elf_i386"
++		;;
++	    esac
++	    ;;
++	  powerpc64le-*linux*)
++	    LD="${LD-ld} -m elf32lppclinux"
+ 	    ;;
+-	  ppc64-*linux*|powerpc64-*linux*)
++	  powerpc64-*linux*)
+ 	    LD="${LD-ld} -m elf32ppclinux"
+ 	    ;;
+ 	  s390x-*linux*)
+@@ -1345,7 +1417,10 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 	  x86_64-*linux*)
+ 	    LD="${LD-ld} -m elf_x86_64"
+ 	    ;;
+-	  ppc*-*linux*|powerpc*-*linux*)
++	  powerpcle-*linux*)
++	    LD="${LD-ld} -m elf64lppc"
++	    ;;
++	  powerpc-*linux*)
+ 	    LD="${LD-ld} -m elf64ppc"
+ 	    ;;
+ 	  s390*-*linux*|s390*-*tpf*)
+@@ -1363,19 +1438,20 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+ 
+ *-*-sco3.2v5*)
+   # On SCO OpenServer 5, we need -belf to get full-featured binaries.
+-  SAVE_CFLAGS="$CFLAGS"
++  SAVE_CFLAGS=$CFLAGS
+   CFLAGS="$CFLAGS -belf"
+   AC_CACHE_CHECK([whether the C compiler needs -belf], lt_cv_cc_needs_belf,
+     [AC_LANG_PUSH(C)
+      AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],[[]])],[lt_cv_cc_needs_belf=yes],[lt_cv_cc_needs_belf=no])
+      AC_LANG_POP])
+-  if test x"$lt_cv_cc_needs_belf" != x"yes"; then
++  if test yes != "$lt_cv_cc_needs_belf"; then
+     # this is probably gcc 2.8.0, egcs 1.0 or newer; no need for -belf
+-    CFLAGS="$SAVE_CFLAGS"
++    CFLAGS=$SAVE_CFLAGS
+   fi
+   ;;
+ *-*solaris*)
+-  # Find out which ABI we are using.
++  # Find out what ABI is being produced by ac_compile, and set linker
++  # options accordingly.
+   echo 'int i;' > conftest.$ac_ext
+   if AC_TRY_EVAL(ac_compile); then
+     case `/usr/bin/file conftest.o` in
+@@ -1383,7 +1459,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+       case $lt_cv_prog_gnu_ld in
+       yes*)
+         case $host in
+-        i?86-*-solaris*)
++        i?86-*-solaris*|x86_64-*-solaris*)
+           LD="${LD-ld} -m elf_x86_64"
+           ;;
+         sparc*-*-solaris*)
+@@ -1392,7 +1468,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+         esac
+         # GNU ld 2.21 introduced _sol2 emulations.  Use them if available.
+         if ${LD-ld} -V | grep _sol2 >/dev/null 2>&1; then
+-          LD="${LD-ld}_sol2"
++          LD=${LD-ld}_sol2
+         fi
+         ;;
+       *)
+@@ -1408,7 +1484,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
+   ;;
+ esac
+ 
+-need_locks="$enable_libtool_lock"
++need_locks=$enable_libtool_lock
+ ])# _LT_ENABLE_LOCK
+ 
+ 
+@@ -1417,9 +1493,22 @@ need_locks="$enable_libtool_lock"
+ m4_defun([_LT_PROG_AR],
+ [AC_CHECK_TOOLS(AR, [ar], false)
+ : ${AR=ar}
+-: ${AR_FLAGS=cru}
+ _LT_DECL([], [AR], [1], [The archiver])
+-_LT_DECL([], [AR_FLAGS], [1], [Flags to create an archive])
++
++# Use ARFLAGS variable as AR's operation code to sync the variable naming with
++# Automake.  If both AR_FLAGS and ARFLAGS are specified, AR_FLAGS should have
++# higher priority because thats what people were doing historically (setting
++# ARFLAGS for automake and AR_FLAGS for libtool).  FIXME: Make the AR_FLAGS
++# variable obsoleted/removed.
++
++test ${AR_FLAGS+y} || AR_FLAGS=${ARFLAGS-cr}
++lt_ar_flags=$AR_FLAGS
++_LT_DECL([], [lt_ar_flags], [0], [Flags to create an archive (by configure)])
++
++# Make AR_FLAGS overridable by 'make ARFLAGS='.  Don't try to run-time override
++# by AR_FLAGS because that was never working and AR_FLAGS is about to die.
++_LT_DECL([], [AR_FLAGS], [\@S|@{ARFLAGS-"\@S|@lt_ar_flags"}],
++         [Flags to create an archive])
+ 
+ AC_CACHE_CHECK([for archiver @FILE support], [lt_cv_ar_at_file],
+   [lt_cv_ar_at_file=no
+@@ -1427,11 +1516,11 @@ AC_CACHE_CHECK([for archiver @FILE support], [lt_cv_ar_at_file],
+      [echo conftest.$ac_objext > conftest.lst
+       lt_ar_try='$AR $AR_FLAGS libconftest.a @conftest.lst >&AS_MESSAGE_LOG_FD'
+       AC_TRY_EVAL([lt_ar_try])
+-      if test "$ac_status" -eq 0; then
++      if test 0 -eq "$ac_status"; then
+ 	# Ensure the archiver fails upon bogus file names.
+ 	rm -f conftest.$ac_objext libconftest.a
+ 	AC_TRY_EVAL([lt_ar_try])
+-	if test "$ac_status" -ne 0; then
++	if test 0 -ne "$ac_status"; then
+           lt_cv_ar_at_file=@
+         fi
+       fi
+@@ -1439,7 +1528,7 @@ AC_CACHE_CHECK([for archiver @FILE support], [lt_cv_ar_at_file],
+      ])
+   ])
+ 
+-if test "x$lt_cv_ar_at_file" = xno; then
++if test no = "$lt_cv_ar_at_file"; then
+   archiver_list_spec=
+ else
+   archiver_list_spec=$lt_cv_ar_at_file
+@@ -1470,7 +1559,7 @@ old_postuninstall_cmds=
+ 
+ if test -n "$RANLIB"; then
+   case $host_os in
+-  openbsd*)
++  bitrig* | openbsd*)
+     old_postinstall_cmds="$old_postinstall_cmds~\$RANLIB -t \$tool_oldlib"
+     ;;
+   *)
+@@ -1506,7 +1595,7 @@ AC_CACHE_CHECK([$1], [$2],
+   [$2=no
+    m4_if([$4], , [ac_outfile=conftest.$ac_objext], [ac_outfile=$4])
+    echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-   lt_compiler_flag="$3"
++   lt_compiler_flag="$3"  ## exclude from sc_useless_quotes_in_assignment
+    # Insert the option either (1) after the last *FLAGS variable, or
+    # (2) before a word containing "conftest.", or (3) at the end.
+    # Note that $ac_compile itself does not contain backslashes and begins
+@@ -1533,7 +1622,7 @@ AC_CACHE_CHECK([$1], [$2],
+    $RM conftest*
+ ])
+ 
+-if test x"[$]$2" = xyes; then
++if test yes = "[$]$2"; then
+     m4_if([$5], , :, [$5])
+ else
+     m4_if([$6], , :, [$6])
+@@ -1555,7 +1644,7 @@ AC_DEFUN([_LT_LINKER_OPTION],
+ m4_require([_LT_DECL_SED])dnl
+ AC_CACHE_CHECK([$1], [$2],
+   [$2=no
+-   save_LDFLAGS="$LDFLAGS"
++   save_LDFLAGS=$LDFLAGS
+    LDFLAGS="$LDFLAGS $3"
+    echo "$lt_simple_link_test_code" > conftest.$ac_ext
+    if (eval $ac_link 2>conftest.err) && test -s conftest$ac_exeext; then
+@@ -1574,10 +1663,10 @@ AC_CACHE_CHECK([$1], [$2],
+      fi
+    fi
+    $RM -r conftest*
+-   LDFLAGS="$save_LDFLAGS"
++   LDFLAGS=$save_LDFLAGS
+ ])
+ 
+-if test x"[$]$2" = xyes; then
++if test yes = "[$]$2"; then
+     m4_if([$4], , :, [$4])
+ else
+     m4_if([$5], , :, [$5])
+@@ -1598,7 +1687,7 @@ AC_DEFUN([LT_CMD_MAX_LEN],
+ AC_MSG_CHECKING([the maximum length of command line arguments])
+ AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
+   i=0
+-  teststring="ABCD"
++  teststring=ABCD
+ 
+   case $build_os in
+   msdosdjgpp*)
+@@ -1638,7 +1727,7 @@ AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
+     lt_cv_sys_max_cmd_len=8192;
+     ;;
+ 
+-  netbsd* | freebsd* | openbsd* | darwin* | dragonfly*)
++  bitrig* | darwin* | dragonfly* | freebsd* | netbsd* | openbsd*)
+     # This has been around since 386BSD, at least.  Likely further.
+     if test -x /sbin/sysctl; then
+       lt_cv_sys_max_cmd_len=`/sbin/sysctl -n kern.argmax`
+@@ -1688,22 +1777,23 @@ AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
+     ;;
+   *)
+     lt_cv_sys_max_cmd_len=`(getconf ARG_MAX) 2> /dev/null`
+-    if test -n "$lt_cv_sys_max_cmd_len"; then
++    if test -n "$lt_cv_sys_max_cmd_len" && \
++       test undefined != "$lt_cv_sys_max_cmd_len"; then
+       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 4`
+       lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \* 3`
+     else
+       # Make teststring a little bigger before we do anything with it.
+       # a 1K string should be a reasonable start.
+-      for i in 1 2 3 4 5 6 7 8 ; do
++      for i in 1 2 3 4 5 6 7 8; do
+         teststring=$teststring$teststring
+       done
+       SHELL=${SHELL-${CONFIG_SHELL-/bin/sh}}
+       # If test is not a shell built-in, we'll probably end up computing a
+       # maximum length that is only half of the actual maximum length, but
+       # we can't tell.
+-      while { test "X"`env echo "$teststring$teststring" 2>/dev/null` \
++      while { test X`env echo "$teststring$teststring" 2>/dev/null` \
+ 	         = "X$teststring$teststring"; } >/dev/null 2>&1 &&
+-	      test $i != 17 # 1/2 MB should be enough
++	      test 17 != "$i" # 1/2 MB should be enough
+       do
+         i=`expr $i + 1`
+         teststring=$teststring$teststring
+@@ -1719,7 +1809,7 @@ AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
+     ;;
+   esac
+ ])
+-if test -n $lt_cv_sys_max_cmd_len ; then
++if test -n "$lt_cv_sys_max_cmd_len"; then
+   AC_MSG_RESULT($lt_cv_sys_max_cmd_len)
+ else
+   AC_MSG_RESULT(none)
+@@ -1747,7 +1837,7 @@ m4_defun([_LT_HEADER_DLFCN],
+ # ----------------------------------------------------------------
+ m4_defun([_LT_TRY_DLOPEN_SELF],
+ [m4_require([_LT_HEADER_DLFCN])dnl
+-if test "$cross_compiling" = yes; then :
++if test yes = "$cross_compiling"; then :
+   [$4]
+ else
+   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
+@@ -1794,9 +1884,9 @@ else
+ #  endif
+ #endif
+ 
+-/* When -fvisbility=hidden is used, assume the code has been annotated
++/* When -fvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+-#if defined(__GNUC__) && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
++#if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+ #endif
+ 
+@@ -1822,7 +1912,7 @@ int main ()
+   return status;
+ }]
+ _LT_EOF
+-  if AC_TRY_EVAL(ac_link) && test -s conftest${ac_exeext} 2>/dev/null; then
++  if AC_TRY_EVAL(ac_link) && test -s "conftest$ac_exeext" 2>/dev/null; then
+     (./conftest; exit; ) >&AS_MESSAGE_LOG_FD 2>/dev/null
+     lt_status=$?
+     case x$lt_status in
+@@ -1843,7 +1933,7 @@ rm -fr conftest*
+ # ------------------
+ AC_DEFUN([LT_SYS_DLOPEN_SELF],
+ [m4_require([_LT_HEADER_DLFCN])dnl
+-if test "x$enable_dlopen" != xyes; then
++if test yes != "$enable_dlopen"; then
+   enable_dlopen=unknown
+   enable_dlopen_self=unknown
+   enable_dlopen_self_static=unknown
+@@ -1853,44 +1943,52 @@ else
+ 
+   case $host_os in
+   beos*)
+-    lt_cv_dlopen="load_add_on"
++    lt_cv_dlopen=load_add_on
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+     ;;
+ 
+   mingw* | pw32* | cegcc*)
+-    lt_cv_dlopen="LoadLibrary"
++    lt_cv_dlopen=LoadLibrary
+     lt_cv_dlopen_libs=
+     ;;
+ 
+   cygwin*)
+-    lt_cv_dlopen="dlopen"
++    lt_cv_dlopen=dlopen
+     lt_cv_dlopen_libs=
+     ;;
+ 
+   darwin*)
+-  # if libdl is installed we need to link against it
++    # if libdl is installed we need to link against it
+     AC_CHECK_LIB([dl], [dlopen],
+-		[lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-ldl"],[
+-    lt_cv_dlopen="dyld"
++		[lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-ldl],[
++    lt_cv_dlopen=dyld
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+     ])
+     ;;
+ 
++  tpf*)
++    # Don't try to run any link tests for TPF.  We know it's impossible
++    # because TPF is a cross-compiler, and we know how we open DSOs.
++    lt_cv_dlopen=dlopen
++    lt_cv_dlopen_libs=
++    lt_cv_dlopen_self=no
++    ;;
++
+   *)
+     AC_CHECK_FUNC([shl_load],
+-	  [lt_cv_dlopen="shl_load"],
++	  [lt_cv_dlopen=shl_load],
+       [AC_CHECK_LIB([dld], [shl_load],
+-	    [lt_cv_dlopen="shl_load" lt_cv_dlopen_libs="-ldld"],
++	    [lt_cv_dlopen=shl_load lt_cv_dlopen_libs=-ldld],
+ 	[AC_CHECK_FUNC([dlopen],
+-	      [lt_cv_dlopen="dlopen"],
++	      [lt_cv_dlopen=dlopen],
+ 	  [AC_CHECK_LIB([dl], [dlopen],
+-		[lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-ldl"],
++		[lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-ldl],
+ 	    [AC_CHECK_LIB([svld], [dlopen],
+-		  [lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-lsvld"],
++		  [lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-lsvld],
+ 	      [AC_CHECK_LIB([dld], [dld_link],
+-		    [lt_cv_dlopen="dld_link" lt_cv_dlopen_libs="-ldld"])
++		    [lt_cv_dlopen=dld_link lt_cv_dlopen_libs=-ldld])
+ 	      ])
+ 	    ])
+ 	  ])
+@@ -1899,21 +1997,21 @@ else
+     ;;
+   esac
+ 
+-  if test "x$lt_cv_dlopen" != xno; then
+-    enable_dlopen=yes
+-  else
++  if test no = "$lt_cv_dlopen"; then
+     enable_dlopen=no
++  else
++    enable_dlopen=yes
+   fi
+ 
+   case $lt_cv_dlopen in
+   dlopen)
+-    save_CPPFLAGS="$CPPFLAGS"
+-    test "x$ac_cv_header_dlfcn_h" = xyes && CPPFLAGS="$CPPFLAGS -DHAVE_DLFCN_H"
++    save_CPPFLAGS=$CPPFLAGS
++    test yes = "$ac_cv_header_dlfcn_h" && CPPFLAGS="$CPPFLAGS -DHAVE_DLFCN_H"
+ 
+-    save_LDFLAGS="$LDFLAGS"
++    save_LDFLAGS=$LDFLAGS
+     wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $export_dynamic_flag_spec\"
+ 
+-    save_LIBS="$LIBS"
++    save_LIBS=$LIBS
+     LIBS="$lt_cv_dlopen_libs $LIBS"
+ 
+     AC_CACHE_CHECK([whether a program can dlopen itself],
+@@ -1923,7 +2021,7 @@ else
+ 	    lt_cv_dlopen_self=no, lt_cv_dlopen_self=cross)
+     ])
+ 
+-    if test "x$lt_cv_dlopen_self" = xyes; then
++    if test yes = "$lt_cv_dlopen_self"; then
+       wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $lt_prog_compiler_static\"
+       AC_CACHE_CHECK([whether a statically linked program can dlopen itself],
+ 	  lt_cv_dlopen_self_static, [dnl
+@@ -1933,9 +2031,9 @@ else
+       ])
+     fi
+ 
+-    CPPFLAGS="$save_CPPFLAGS"
+-    LDFLAGS="$save_LDFLAGS"
+-    LIBS="$save_LIBS"
++    CPPFLAGS=$save_CPPFLAGS
++    LDFLAGS=$save_LDFLAGS
++    LIBS=$save_LIBS
+     ;;
+   esac
+ 
+@@ -2027,8 +2125,8 @@ m4_defun([_LT_COMPILER_FILE_LOCKS],
+ m4_require([_LT_FILEUTILS_DEFAULTS])dnl
+ _LT_COMPILER_C_O([$1])
+ 
+-hard_links="nottested"
+-if test "$_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)" = no && test "$need_locks" != no; then
++hard_links=nottested
++if test no = "$_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)" && test no != "$need_locks"; then
+   # do not overwrite the value of need_locks provided by the user
+   AC_MSG_CHECKING([if we can lock with hard links])
+   hard_links=yes
+@@ -2038,8 +2136,8 @@ if test "$_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)" = no && test "$need_locks" !=
+   ln conftest.a conftest.b 2>&5 || hard_links=no
+   ln conftest.a conftest.b 2>/dev/null && hard_links=no
+   AC_MSG_RESULT([$hard_links])
+-  if test "$hard_links" = no; then
+-    AC_MSG_WARN([`$CC' does not support `-c -o', so `make -j' may be unsafe])
++  if test no = "$hard_links"; then
++    AC_MSG_WARN(['$CC' does not support '-c -o', so 'make -j' may be unsafe])
+     need_locks=warn
+   fi
+ else
+@@ -2066,8 +2164,8 @@ objdir=$lt_cv_objdir
+ _LT_DECL([], [objdir], [0],
+          [The name of the directory that contains temporary libtool files])dnl
+ m4_pattern_allow([LT_OBJDIR])dnl
+-AC_DEFINE_UNQUOTED(LT_OBJDIR, "$lt_cv_objdir/",
+-  [Define to the sub-directory in which libtool stores uninstalled libraries.])
++AC_DEFINE_UNQUOTED([LT_OBJDIR], "$lt_cv_objdir/",
++  [Define to the sub-directory where libtool stores uninstalled libraries.])
+ ])# _LT_CHECK_OBJDIR
+ 
+ 
+@@ -2079,15 +2177,15 @@ m4_defun([_LT_LINKER_HARDCODE_LIBPATH],
+ _LT_TAGVAR(hardcode_action, $1)=
+ if test -n "$_LT_TAGVAR(hardcode_libdir_flag_spec, $1)" ||
+    test -n "$_LT_TAGVAR(runpath_var, $1)" ||
+-   test "X$_LT_TAGVAR(hardcode_automatic, $1)" = "Xyes" ; then
++   test yes = "$_LT_TAGVAR(hardcode_automatic, $1)"; then
+ 
+   # We can hardcode non-existent directories.
+-  if test "$_LT_TAGVAR(hardcode_direct, $1)" != no &&
++  if test no != "$_LT_TAGVAR(hardcode_direct, $1)" &&
+      # If the only mechanism to avoid hardcoding is shlibpath_var, we
+      # have to relink, otherwise we might link with an installed library
+      # when we should be linking with a yet-to-be-installed one
+-     ## test "$_LT_TAGVAR(hardcode_shlibpath_var, $1)" != no &&
+-     test "$_LT_TAGVAR(hardcode_minus_L, $1)" != no; then
++     ## test no != "$_LT_TAGVAR(hardcode_shlibpath_var, $1)" &&
++     test no != "$_LT_TAGVAR(hardcode_minus_L, $1)"; then
+     # Linking always hardcodes the temporary library directory.
+     _LT_TAGVAR(hardcode_action, $1)=relink
+   else
+@@ -2101,12 +2199,12 @@ else
+ fi
+ AC_MSG_RESULT([$_LT_TAGVAR(hardcode_action, $1)])
+ 
+-if test "$_LT_TAGVAR(hardcode_action, $1)" = relink ||
+-   test "$_LT_TAGVAR(inherit_rpath, $1)" = yes; then
++if test relink = "$_LT_TAGVAR(hardcode_action, $1)" ||
++   test yes = "$_LT_TAGVAR(inherit_rpath, $1)"; then
+   # Fast installation is not supported
+   enable_fast_install=no
+-elif test "$shlibpath_overrides_runpath" = yes ||
+-     test "$enable_shared" = no; then
++elif test yes = "$shlibpath_overrides_runpath" ||
++     test no = "$enable_shared"; then
+   # Fast installation is not necessary
+   enable_fast_install=needless
+ fi
+@@ -2122,32 +2220,82 @@ m4_defun([_LT_CMD_STRIPLIB],
+ striplib=
+ old_striplib=
+ AC_MSG_CHECKING([whether stripping libraries is possible])
+-if test -n "$STRIP" && $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
+-  test -z "$old_striplib" && old_striplib="$STRIP --strip-debug"
+-  test -z "$striplib" && striplib="$STRIP --strip-unneeded"
+-  AC_MSG_RESULT([yes])
++if test -z "$STRIP"; then
++  AC_MSG_RESULT([no])
+ else
+-# FIXME - insert some real tests, host_os isn't really good enough
+-  case $host_os in
+-  darwin*)
+-    if test -n "$STRIP" ; then
++  if $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
++    old_striplib="$STRIP --strip-debug"
++    striplib="$STRIP --strip-unneeded"
++    AC_MSG_RESULT([yes])
++  else
++    case $host_os in
++    darwin*)
++      # FIXME - insert some real tests, host_os isn't really good enough
+       striplib="$STRIP -x"
+       old_striplib="$STRIP -S"
+       AC_MSG_RESULT([yes])
+-    else
++      ;;
++    freebsd*)
++      if $STRIP -V 2>&1 | $GREP "elftoolchain" >/dev/null; then
++        old_striplib="$STRIP --strip-debug"
++        striplib="$STRIP --strip-unneeded"
++        AC_MSG_RESULT([yes])
++      else
++        AC_MSG_RESULT([no])
++      fi
++      ;;
++    *)
+       AC_MSG_RESULT([no])
+-    fi
+-    ;;
+-  *)
+-    AC_MSG_RESULT([no])
+-    ;;
+-  esac
++      ;;
++    esac
++  fi
+ fi
+ _LT_DECL([], [old_striplib], [1], [Commands to strip libraries])
+ _LT_DECL([], [striplib], [1])
+ ])# _LT_CMD_STRIPLIB
+ 
+ 
++# _LT_PREPARE_MUNGE_PATH_LIST
++# ---------------------------
++# Make sure func_munge_path_list() is defined correctly.
++m4_defun([_LT_PREPARE_MUNGE_PATH_LIST],
++[[# func_munge_path_list VARIABLE PATH
++# -----------------------------------
++# VARIABLE is name of variable containing _space_ separated list of
++# directories to be munged by the contents of PATH, which is string
++# having a format:
++# "DIR[:DIR]:"
++#       string "DIR[ DIR]" will be prepended to VARIABLE
++# ":DIR[:DIR]"
++#       string "DIR[ DIR]" will be appended to VARIABLE
++# "DIRP[:DIRP]::[DIRA:]DIRA"
++#       string "DIRP[ DIRP]" will be prepended to VARIABLE and string
++#       "DIRA[ DIRA]" will be appended to VARIABLE
++# "DIR[:DIR]"
++#       VARIABLE will be replaced by "DIR[ DIR]"
++func_munge_path_list ()
++{
++    case x@S|@2 in
++    x)
++        ;;
++    *:)
++        eval @S|@1=\"`$ECHO @S|@2 | $SED 's/:/ /g'` \@S|@@S|@1\"
++        ;;
++    x:*)
++        eval @S|@1=\"\@S|@@S|@1 `$ECHO @S|@2 | $SED 's/:/ /g'`\"
++        ;;
++    *::*)
++        eval @S|@1=\"\@S|@@S|@1\ `$ECHO @S|@2 | $SED -e 's/.*:://' -e 's/:/ /g'`\"
++        eval @S|@1=\"`$ECHO @S|@2 | $SED -e 's/::.*//' -e 's/:/ /g'`\ \@S|@@S|@1\"
++        ;;
++    *)
++        eval @S|@1=\"`$ECHO @S|@2 | $SED 's/:/ /g'`\"
++        ;;
++    esac
++}
++]])# _LT_PREPARE_PATH_LIST
++
++
+ # _LT_SYS_DYNAMIC_LINKER([TAG])
+ # -----------------------------
+ # PORTME Fill in your ld.so characteristics
+@@ -2158,17 +2306,18 @@ m4_require([_LT_FILEUTILS_DEFAULTS])dnl
+ m4_require([_LT_DECL_OBJDUMP])dnl
+ m4_require([_LT_DECL_SED])dnl
+ m4_require([_LT_CHECK_SHELL_FEATURES])dnl
++m4_require([_LT_PREPARE_MUNGE_PATH_LIST])dnl
+ AC_MSG_CHECKING([dynamic linker characteristics])
+ m4_if([$1],
+ 	[], [
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   case $host_os in
+-    darwin*) lt_awk_arg="/^libraries:/,/LR/" ;;
+-    *) lt_awk_arg="/^libraries:/" ;;
++    darwin*) lt_awk_arg='/^libraries:/,/LR/' ;;
++    *) lt_awk_arg='/^libraries:/' ;;
+   esac
+   case $host_os in
+-    mingw* | cegcc*) lt_sed_strip_eq="s,=\([[A-Za-z]]:\),\1,g" ;;
+-    *) lt_sed_strip_eq="s,=/,/,g" ;;
++    mingw* | cegcc*) lt_sed_strip_eq='s|=\([[A-Za-z]]:\)|\1|g' ;;
++    *) lt_sed_strip_eq='s|=/|/|g' ;;
+   esac
+   lt_search_path_spec=`$CC -print-search-dirs | awk $lt_awk_arg | $SED -e "s/^libraries://" -e $lt_sed_strip_eq`
+   case $lt_search_path_spec in
+@@ -2184,28 +2333,35 @@ if test "$GCC" = yes; then
+     ;;
+   esac
+   # Ok, now we have the path, separated by spaces, we can step through it
+-  # and add multilib dir if necessary.
++  # and add multilib dir if necessary...
+   lt_tmp_lt_search_path_spec=
+-  lt_multi_os_dir=`$CC $CPPFLAGS $CFLAGS $LDFLAGS -print-multi-os-directory 2>/dev/null`
++  lt_multi_os_dir=/`$CC $CPPFLAGS $CFLAGS $LDFLAGS -print-multi-os-directory 2>/dev/null`
++  # ...but if some path component already ends with the multilib dir we assume
++  # that all is fine and trust -print-search-dirs as is (GCC 4.2? or newer).
++  case "$lt_multi_os_dir; $lt_search_path_spec " in
++  "/; "* | "/.; "* | "/./; "* | *"$lt_multi_os_dir "* | *"$lt_multi_os_dir/ "*)
++    lt_multi_os_dir=
++    ;;
++  esac
+   for lt_sys_path in $lt_search_path_spec; do
+-    if test -d "$lt_sys_path/$lt_multi_os_dir"; then
+-      lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path/$lt_multi_os_dir"
+-    else
++    if test -d "$lt_sys_path$lt_multi_os_dir"; then
++      lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path$lt_multi_os_dir"
++    elif test -n "$lt_multi_os_dir"; then
+       test -d "$lt_sys_path" && \
+ 	lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path"
+     fi
+   done
+   lt_search_path_spec=`$ECHO "$lt_tmp_lt_search_path_spec" | awk '
+-BEGIN {RS=" "; FS="/|\n";} {
+-  lt_foo="";
+-  lt_count=0;
++BEGIN {RS = " "; FS = "/|\n";} {
++  lt_foo = "";
++  lt_count = 0;
+   for (lt_i = NF; lt_i > 0; lt_i--) {
+     if ($lt_i != "" && $lt_i != ".") {
+       if ($lt_i == "..") {
+         lt_count++;
+       } else {
+         if (lt_count == 0) {
+-          lt_foo="/" $lt_i lt_foo;
++          lt_foo = "/" $lt_i lt_foo;
+         } else {
+           lt_count--;
+         }
+@@ -2219,7 +2375,7 @@ BEGIN {RS=" "; FS="/|\n";} {
+   # for these hosts.
+   case $host_os in
+     mingw* | cegcc*) lt_search_path_spec=`$ECHO "$lt_search_path_spec" |\
+-      $SED 's,/\([[A-Za-z]]:\),\1,g'` ;;
++      $SED 's|/\([[A-Za-z]]:\)|\1|g'` ;;
+   esac
+   sys_lib_search_path_spec=`$ECHO "$lt_search_path_spec" | $lt_NL2SP`
+ else
+@@ -2228,7 +2384,7 @@ fi])
+ library_names_spec=
+ libname_spec='lib$name'
+ soname_spec=
+-shrext_cmds=".so"
++shrext_cmds=.so
+ postinstall_cmds=
+ postuninstall_cmds=
+ finish_cmds=
+@@ -2245,14 +2401,17 @@ hardcode_into_libs=no
+ # flags to be left without arguments
+ need_version=unknown
+ 
++AC_ARG_VAR([LT_SYS_LIBRARY_PATH],
++[User-defined run-time library search path.])
++
+ case $host_os in
+ aix3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix $libname.a'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname.a'
+   shlibpath_var=LIBPATH
+ 
+   # AIX 3 has no versioning support, so we append a major version to the name.
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  soname_spec='$libname$release$shared_ext$major'
+   ;;
+ 
+ aix[[4-9]]*)
+@@ -2260,41 +2419,91 @@ aix[[4-9]]*)
+   need_lib_prefix=no
+   need_version=no
+   hardcode_into_libs=yes
+-  if test "$host_cpu" = ia64; then
++  if test ia64 = "$host_cpu"; then
+     # AIX 5 supports IA64
+-    library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
++    library_names_spec='$libname$release$shared_ext$major $libname$release$shared_ext$versuffix $libname$shared_ext'
+     shlibpath_var=LD_LIBRARY_PATH
+   else
+     # With GCC up to 2.95.x, collect2 would create an import file
+     # for dependence libraries.  The import file would start with
+-    # the line `#! .'.  This would cause the generated library to
+-    # depend on `.', always an invalid library.  This was fixed in
++    # the line '#! .'.  This would cause the generated library to
++    # depend on '.', always an invalid library.  This was fixed in
+     # development snapshots of GCC prior to 3.0.
+     case $host_os in
+       aix4 | aix4.[[01]] | aix4.[[01]].*)
+       if { echo '#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 97)'
+ 	   echo ' yes '
+-	   echo '#endif'; } | ${CC} -E - | $GREP yes > /dev/null; then
++	   echo '#endif'; } | $CC -E - | $GREP yes > /dev/null; then
+ 	:
+       else
+ 	can_build_shared=no
+       fi
+       ;;
+     esac
+-    # AIX (on Power*) has no versioning support, so currently we can not hardcode correct
++    # Using Import Files as archive members, it is possible to support
++    # filename-based versioning of shared library archives on AIX. While
++    # this would work for both with and without runtime linking, it will
++    # prevent static linking of such archives. So we do filename-based
++    # shared library versioning with .so extension only, which is used
++    # when both runtime linking and shared linking is enabled.
++    # Unfortunately, runtime linking may impact performance, so we do
++    # not want this to be the default eventually. Also, we use the
++    # versioned .so libs for executables only if there is the -brtl
++    # linker flag in LDFLAGS as well, or --with-aix-soname=svr4 only.
++    # To allow for filename-based versioning support, we need to create
++    # libNAME.so.V as an archive file, containing:
++    # *) an Import File, referring to the versioned filename of the
++    #    archive as well as the shared archive member, telling the
++    #    bitwidth (32 or 64) of that shared object, and providing the
++    #    list of exported symbols of that shared object, eventually
++    #    decorated with the 'weak' keyword
++    # *) the shared object with the F_LOADONLY flag set, to really avoid
++    #    it being seen by the linker.
++    # At run time we better use the real file rather than another symlink,
++    # but for link time we create the symlink libNAME.so -> libNAME.so.V
++
++    case $with_aix_soname,$aix_use_runtimelinking in
++    # AIX (on Power*) has no versioning support, so currently we cannot hardcode correct
+     # soname into executable. Probably we can add versioning support to
+     # collect2, so additional links can be useful in future.
+-    if test "$aix_use_runtimelinking" = yes; then
++    aix,yes) # traditional libtool
++      dynamic_linker='AIX unversionable lib.so'
+       # If using run time linking (on AIX 4.2 or later) use lib<name>.so
+       # instead of lib<name>.a to let people know that these are not
+       # typical AIX shared libraries.
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    else
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++      ;;
++    aix,no) # traditional AIX only
++      dynamic_linker='AIX lib.a[(]lib.so.V[)]'
+       # We preserve .a as extension for shared libraries through AIX4.2
+       # and later when we are not doing run time linking.
+-      library_names_spec='${libname}${release}.a $libname.a'
+-      soname_spec='${libname}${release}${shared_ext}$major'
+-    fi
++      library_names_spec='$libname$release.a $libname.a'
++      soname_spec='$libname$release$shared_ext$major'
++      ;;
++    svr4,*) # full svr4 only
++      dynamic_linker="AIX lib.so.V[(]$shared_archive_member_spec.o[)]"
++      library_names_spec='$libname$release$shared_ext$major $libname$shared_ext'
++      # We do not specify a path in Import Files, so LIBPATH fires.
++      shlibpath_overrides_runpath=yes
++      ;;
++    *,yes) # both, prefer svr4
++      dynamic_linker="AIX lib.so.V[(]$shared_archive_member_spec.o[)], lib.a[(]lib.so.V[)]"
++      library_names_spec='$libname$release$shared_ext$major $libname$shared_ext'
++      # unpreferred sharedlib libNAME.a needs extra handling
++      postinstall_cmds='test -n "$linkname" || linkname="$realname"~func_stripname "" ".so" "$linkname"~$install_shared_prog "$dir/$func_stripname_result.$libext" "$destdir/$func_stripname_result.$libext"~test -z "$tstripme" || test -z "$striplib" || $striplib "$destdir/$func_stripname_result.$libext"'
++      postuninstall_cmds='for n in $library_names $old_library; do :; done~func_stripname "" ".so" "$n"~test "$func_stripname_result" = "$n" || func_append rmfiles " $odir/$func_stripname_result.$libext"'
++      # We do not specify a path in Import Files, so LIBPATH fires.
++      shlibpath_overrides_runpath=yes
++      ;;
++    *,no) # both, prefer aix
++      dynamic_linker="AIX lib.a[(]lib.so.V[)], lib.so.V[(]$shared_archive_member_spec.o[)]"
++      library_names_spec='$libname$release.a $libname.a'
++      soname_spec='$libname$release$shared_ext$major'
++      # unpreferred sharedlib libNAME.so.V and symlink libNAME.so need extra handling
++      postinstall_cmds='test -z "$dlname" || $install_shared_prog $dir/$dlname $destdir/$dlname~test -z "$tstripme" || test -z "$striplib" || $striplib $destdir/$dlname~test -n "$linkname" || linkname=$realname~func_stripname "" ".a" "$linkname"~(cd "$destdir" && $LN_S -f $dlname $func_stripname_result.so)'
++      postuninstall_cmds='test -z "$dlname" || func_append rmfiles " $odir/$dlname"~for n in $old_library $library_names; do :; done~func_stripname "" ".a" "$n"~func_append rmfiles " $odir/$func_stripname_result.so"'
++      ;;
++    esac
+     shlibpath_var=LIBPATH
+   fi
+   ;;
+@@ -2304,18 +2513,18 @@ amigaos*)
+   powerpc)
+     # Since July 2007 AmigaOS4 officially supports .so libraries.
+     # When compiling the executable, add -use-dynld -Lsobjs: to the compileline.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+     ;;
+   m68k)
+     library_names_spec='$libname.ixlibrary $libname.a'
+     # Create ${libname}_ixlibrary.a entries in /sys/libs.
+-    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([[^/]]*\)\.ixlibrary$%\1%'\''`; test $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
++    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([[^/]]*\)\.ixlibrary$%\1%'\''`; $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
+     ;;
+   esac
+   ;;
+ 
+ beos*)
+-  library_names_spec='${libname}${shared_ext}'
++  library_names_spec='$libname$shared_ext'
+   dynamic_linker="$host_os ld.so"
+   shlibpath_var=LIBRARY_PATH
+   ;;
+@@ -2323,8 +2532,8 @@ beos*)
+ bsdi[[45]]*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   sys_lib_search_path_spec="/shlib /usr/lib /usr/X11/lib /usr/contrib/lib /lib /usr/local/lib"
+@@ -2336,7 +2545,7 @@ bsdi[[45]]*)
+ 
+ cygwin* | mingw* | pw32* | cegcc*)
+   version_type=windows
+-  shrext_cmds=".dll"
++  shrext_cmds=.dll
+   need_version=no
+   need_lib_prefix=no
+ 
+@@ -2345,8 +2554,8 @@ cygwin* | mingw* | pw32* | cegcc*)
+     # gcc
+     library_names_spec='$libname.dll.a'
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++    postinstall_cmds='base_file=`basename \$file`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; echo \$dlname'\''`~
+       dldir=$destdir/`dirname \$dlpath`~
+       test -d \$dldir || mkdir -p \$dldir~
+       $install_prog $dir/$dlname \$dldir/$dlname~
+@@ -2362,17 +2571,17 @@ cygwin* | mingw* | pw32* | cegcc*)
+     case $host_os in
+     cygwin*)
+       # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++      soname_spec='`echo $libname | sed -e 's/^lib/cyg/'``echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
+ m4_if([$1], [],[
+       sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
+       ;;
+     mingw* | cegcc*)
+       # MinGW DLLs use traditional 'lib' prefix
+-      soname_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++      soname_spec='$libname`echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
+       ;;
+     pw32*)
+       # pw32 DLLs use 'pw' prefix rather than 'lib'
+-      library_names_spec='`echo ${libname} | sed -e 's/^lib/pw/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++      library_names_spec='`echo $libname | sed -e 's/^lib/pw/'``echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
+       ;;
+     esac
+     dynamic_linker='Win32 ld.exe'
+@@ -2381,8 +2590,8 @@ m4_if([$1], [],[
+   *,cl*)
+     # Native MSVC
+     libname_spec='$name'
+-    soname_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
+-    library_names_spec='${libname}.dll.lib'
++    soname_spec='$libname`echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext'
++    library_names_spec='$libname.dll.lib'
+ 
+     case $build_os in
+     mingw*)
+@@ -2409,7 +2618,7 @@ m4_if([$1], [],[
+       sys_lib_search_path_spec=`cygpath --path --unix "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
+       ;;
+     *)
+-      sys_lib_search_path_spec="$LIB"
++      sys_lib_search_path_spec=$LIB
+       if $ECHO "$sys_lib_search_path_spec" | [$GREP ';[c-zC-Z]:/' >/dev/null]; then
+         # It is most probably a Windows format PATH.
+         sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e 's/;/ /g'`
+@@ -2422,8 +2631,8 @@ m4_if([$1], [],[
+     esac
+ 
+     # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++    postinstall_cmds='base_file=`basename \$file`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; echo \$dlname'\''`~
+       dldir=$destdir/`dirname \$dlpath`~
+       test -d \$dldir || mkdir -p \$dldir~
+       $install_prog $dir/$dlname \$dldir/$dlname'
+@@ -2436,7 +2645,7 @@ m4_if([$1], [],[
+ 
+   *)
+     # Assume MSVC wrapper
+-    library_names_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext} $libname.lib'
++    library_names_spec='$libname`echo $release | $SED -e 's/[[.]]/-/g'`$versuffix$shared_ext $libname.lib'
+     dynamic_linker='Win32 ld.exe'
+     ;;
+   esac
+@@ -2449,8 +2658,8 @@ darwin* | rhapsody*)
+   version_type=darwin
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${major}$shared_ext ${libname}$shared_ext'
+-  soname_spec='${libname}${release}${major}$shared_ext'
++  library_names_spec='$libname$release$major$shared_ext $libname$shared_ext'
++  soname_spec='$libname$release$major$shared_ext'
+   shlibpath_overrides_runpath=yes
+   shlibpath_var=DYLD_LIBRARY_PATH
+   shrext_cmds='`test .$module = .yes && echo .so || echo .dylib`'
+@@ -2463,8 +2672,8 @@ dgux*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname$shared_ext'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
+@@ -2482,12 +2691,13 @@ freebsd* | dragonfly*)
+   version_type=freebsd-$objformat
+   case $version_type in
+     freebsd-elf*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++      soname_spec='$libname$release$shared_ext$major'
+       need_version=no
+       need_lib_prefix=no
+       ;;
+     freebsd-*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix $libname${shared_ext}$versuffix'
++      library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+       need_version=yes
+       ;;
+   esac
+@@ -2512,26 +2722,15 @@ freebsd* | dragonfly*)
+   esac
+   ;;
+ 
+-gnu*)
+-  version_type=linux # correct to gnu/linux during the next big refactor
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
+-  ;;
+-
+ haiku*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+   dynamic_linker="$host_os runtime_loader"
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
++  shlibpath_overrides_runpath=no
+   sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+   hardcode_into_libs=yes
+   ;;
+@@ -2549,14 +2748,15 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.so"
+     shlibpath_var=LD_LIBRARY_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    if test "X$HPUX_IA64_MODE" = X32; then
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
++    if test 32 = "$HPUX_IA64_MODE"; then
+       sys_lib_search_path_spec="/usr/lib/hpux32 /usr/local/lib/hpux32 /usr/local/lib"
++      sys_lib_dlsearch_path_spec=/usr/lib/hpux32
+     else
+       sys_lib_search_path_spec="/usr/lib/hpux64 /usr/local/lib/hpux64"
++      sys_lib_dlsearch_path_spec=/usr/lib/hpux64
+     fi
+-    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+     ;;
+   hppa*64*)
+     shrext_cmds='.sl'
+@@ -2564,8 +2764,8 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+     shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     sys_lib_search_path_spec="/usr/lib/pa20_64 /usr/ccs/lib/pa20_64"
+     sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+     ;;
+@@ -2574,8 +2774,8 @@ hpux9* | hpux10* | hpux11*)
+     dynamic_linker="$host_os dld.sl"
+     shlibpath_var=SHLIB_PATH
+     shlibpath_overrides_runpath=no # +s is required to enable SHLIB_PATH
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     ;;
+   esac
+   # HP-UX runs *really* slowly unless shared libraries are mode 555, ...
+@@ -2588,8 +2788,8 @@ interix[[3-9]]*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+@@ -2600,7 +2800,7 @@ irix5* | irix6* | nonstopux*)
+   case $host_os in
+     nonstopux*) version_type=nonstopux ;;
+     *)
+-	if test "$lt_cv_prog_gnu_ld" = yes; then
++	if test yes = "$lt_cv_prog_gnu_ld"; then
+ 		version_type=linux # correct to gnu/linux during the next big refactor
+ 	else
+ 		version_type=irix
+@@ -2608,8 +2808,8 @@ irix5* | irix6* | nonstopux*)
+   esac
+   need_lib_prefix=no
+   need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext} $libname${shared_ext}'
++  soname_spec='$libname$release$shared_ext$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$release$shared_ext $libname$shared_ext'
+   case $host_os in
+   irix5* | nonstopux*)
+     libsuff= shlibsuff=
+@@ -2628,8 +2828,8 @@ irix5* | irix6* | nonstopux*)
+   esac
+   shlibpath_var=LD_LIBRARY${shlibsuff}_PATH
+   shlibpath_overrides_runpath=no
+-  sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+-  sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
++  sys_lib_search_path_spec="/usr/lib$libsuff /lib$libsuff /usr/local/lib$libsuff"
++  sys_lib_dlsearch_path_spec="/usr/lib$libsuff /lib$libsuff"
+   hardcode_into_libs=yes
+   ;;
+ 
+@@ -2638,13 +2838,33 @@ linux*oldld* | linux*aout* | linux*coff*)
+   dynamic_linker=no
+   ;;
+ 
++linux*android*)
++  version_type=none # Android doesn't support versioned libraries.
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='$libname$release$shared_ext'
++  soname_spec='$libname$release$shared_ext'
++  finish_cmds=
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++
++  # This implies no fast_install, which is unacceptable.
++  # Some rework will be needed to allow for fast_install
++  # before this can be enabled.
++  hardcode_into_libs=yes
++
++  dynamic_linker='Android linker'
++  # Don't embed -rpath directories since the linker doesn't support them.
++  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++  ;;
++
+ # This must be glibc/ELF.
+-linux* | k*bsd*-gnu | kopensolaris*-gnu)
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+@@ -2669,14 +2889,15 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu)
+   # before this can be enabled.
+   hardcode_into_libs=yes
+ 
+-  # Add ABI-specific directories to the system library path.
+-  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+-
+-  # Append ld.so.conf contents to the search path
++  # Ideally, we could use ldconfig to report *all* directores which are
++  # searched for libraries, however this is still not possible.  Aside from not
++  # being certain /sbin/ldconfig is available, command
++  # 'ldconfig -N -X -v | grep ^/' on 64bit Fedora does not report /usr/lib64,
++  # even though it is searched at run-time.  Try to do the best guess by
++  # appending ld.so.conf contents (and includes) to the search path.
+   if test -f /etc/ld.so.conf; then
+     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \[$]2)); skip = 1; } { if (!skip) print \[$]0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
+-    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
+-
++    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+   fi
+ 
+   # We used to test for /lib/ld.so.1 and disable shared libraries on
+@@ -2693,12 +2914,12 @@ netbsd*)
+   need_lib_prefix=no
+   need_version=no
+   if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+     finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+     dynamic_linker='NetBSD (a.out) ld.so'
+   else
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
++    library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++    soname_spec='$libname$release$shared_ext$major'
+     dynamic_linker='NetBSD ld.elf_so'
+   fi
+   shlibpath_var=LD_LIBRARY_PATH
+@@ -2708,7 +2929,7 @@ netbsd*)
+ 
+ newsos6)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   ;;
+@@ -2717,58 +2938,68 @@ newsos6)
+   version_type=qnx
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+   hardcode_into_libs=yes
+   dynamic_linker='ldqnx.so'
+   ;;
+ 
+-openbsd*)
++openbsd* | bitrig*)
+   version_type=sunos
+-  sys_lib_dlsearch_path_spec="/usr/lib"
++  sys_lib_dlsearch_path_spec=/usr/lib
+   need_lib_prefix=no
+-  # Some older versions of OpenBSD (3.3 at least) *do* need versioned libs.
+-  case $host_os in
+-    openbsd3.3 | openbsd3.3.*)	need_version=yes ;;
+-    *)				need_version=no  ;;
+-  esac
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-    case $host_os in
+-      openbsd2.[[89]] | openbsd2.[[89]].*)
+-	shlibpath_overrides_runpath=no
+-	;;
+-      *)
+-	shlibpath_overrides_runpath=yes
+-	;;
+-      esac
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
++    need_version=no
+   else
+-    shlibpath_overrides_runpath=yes
++    need_version=yes
+   fi
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
++  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
+   ;;
+ 
+ os2*)
+   libname_spec='$name'
+-  shrext_cmds=".dll"
++  version_type=windows
++  shrext_cmds=.dll
++  need_version=no
+   need_lib_prefix=no
+-  library_names_spec='$libname${shared_ext} $libname.a'
++  # OS/2 can only load a DLL with a base name of 8 characters or less.
++  soname_spec='`test -n "$os2dllname" && libname="$os2dllname";
++    v=$($ECHO $release$versuffix | tr -d .-);
++    n=$($ECHO $libname | cut -b -$((8 - ${#v})) | tr . _);
++    $ECHO $n$v`$shared_ext'
++  library_names_spec='${libname}_dll.$libext'
+   dynamic_linker='OS/2 ld.exe'
+-  shlibpath_var=LIBPATH
++  shlibpath_var=BEGINLIBPATH
++  sys_lib_search_path_spec="/lib /usr/lib /usr/local/lib"
++  sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
++  postinstall_cmds='base_file=`basename \$file`~
++    dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\$base_file'\''i; $ECHO \$dlname'\''`~
++    dldir=$destdir/`dirname \$dlpath`~
++    test -d \$dldir || mkdir -p \$dldir~
++    $install_prog $dir/$dlname \$dldir/$dlname~
++    chmod a+x \$dldir/$dlname~
++    if test -n '\''$stripme'\'' && test -n '\''$striplib'\''; then
++      eval '\''$striplib \$dldir/$dlname'\'' || exit \$?;
++    fi'
++  postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; $ECHO \$dlname'\''`~
++    dlpath=$dir/\$dldll~
++    $RM \$dlpath'
+   ;;
+ 
+ osf3* | osf4* | osf5*)
+   version_type=osf
+   need_lib_prefix=no
+   need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='$libname$release$shared_ext$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   sys_lib_search_path_spec="/usr/shlib /usr/ccs/lib /usr/lib/cmplrs/cc /usr/lib /usr/local/lib /var/shlib"
+-  sys_lib_dlsearch_path_spec="$sys_lib_search_path_spec"
++  sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+   ;;
+ 
+ rdos*)
+@@ -2779,8 +3010,8 @@ solaris*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   hardcode_into_libs=yes
+@@ -2790,11 +3021,11 @@ solaris*)
+ 
+ sunos4*)
+   version_type=sunos
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$shared_ext$versuffix'
+   finish_cmds='PATH="\$PATH:/usr/etc" ldconfig $libdir'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     need_lib_prefix=no
+   fi
+   need_version=yes
+@@ -2802,8 +3033,8 @@ sunos4*)
+ 
+ sysv4 | sysv4.3*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   case $host_vendor in
+     sni)
+@@ -2824,24 +3055,24 @@ sysv4 | sysv4.3*)
+   ;;
+ 
+ sysv4*MP*)
+-  if test -d /usr/nec ;then
++  if test -d /usr/nec; then
+     version_type=linux # correct to gnu/linux during the next big refactor
+-    library_names_spec='$libname${shared_ext}.$versuffix $libname${shared_ext}.$major $libname${shared_ext}'
+-    soname_spec='$libname${shared_ext}.$major'
++    library_names_spec='$libname$shared_ext.$versuffix $libname$shared_ext.$major $libname$shared_ext'
++    soname_spec='$libname$shared_ext.$major'
+     shlibpath_var=LD_LIBRARY_PATH
+   fi
+   ;;
+ 
+ sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
+-  version_type=freebsd-elf
++  version_type=sco
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+   hardcode_into_libs=yes
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+   else
+     sys_lib_search_path_spec='/usr/ccs/lib /usr/lib'
+@@ -2859,7 +3090,7 @@ tpf*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+   need_lib_prefix=no
+   need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+   hardcode_into_libs=yes
+@@ -2867,8 +3098,8 @@ tpf*)
+ 
+ uts4*)
+   version_type=linux # correct to gnu/linux during the next big refactor
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
++  soname_spec='$libname$release$shared_ext$major'
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
+@@ -2877,20 +3108,30 @@ uts4*)
+   ;;
+ esac
+ AC_MSG_RESULT([$dynamic_linker])
+-test "$dynamic_linker" = no && can_build_shared=no
++test no = "$dynamic_linker" && can_build_shared=no
+ 
+ variables_saved_for_relink="PATH $shlibpath_var $runpath_var"
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   variables_saved_for_relink="$variables_saved_for_relink GCC_EXEC_PREFIX COMPILER_PATH LIBRARY_PATH"
+ fi
+ 
+-if test "${lt_cv_sys_lib_search_path_spec+set}" = set; then
+-  sys_lib_search_path_spec="$lt_cv_sys_lib_search_path_spec"
++if test set = "${lt_cv_sys_lib_search_path_spec+set}"; then
++  sys_lib_search_path_spec=$lt_cv_sys_lib_search_path_spec
+ fi
+-if test "${lt_cv_sys_lib_dlsearch_path_spec+set}" = set; then
+-  sys_lib_dlsearch_path_spec="$lt_cv_sys_lib_dlsearch_path_spec"
++
++if test set = "${lt_cv_sys_lib_dlsearch_path_spec+set}"; then
++  sys_lib_dlsearch_path_spec=$lt_cv_sys_lib_dlsearch_path_spec
+ fi
+ 
++# remember unaugmented sys_lib_dlsearch_path content for libtool script decls...
++configure_time_dlsearch_path=$sys_lib_dlsearch_path_spec
++
++# ... but it needs LT_SYS_LIBRARY_PATH munging for other configure-time code
++func_munge_path_list sys_lib_dlsearch_path_spec "$LT_SYS_LIBRARY_PATH"
++
++# to be used as default LT_SYS_LIBRARY_PATH value in generated libtool
++configure_time_lt_sys_library_path=$LT_SYS_LIBRARY_PATH
++
+ _LT_DECL([], [variables_saved_for_relink], [1],
+     [Variables whose values should be saved in libtool wrapper scripts and
+     restored at link time])
+@@ -2923,39 +3164,41 @@ _LT_DECL([], [hardcode_into_libs], [0],
+     [Whether we should hardcode library paths into libraries])
+ _LT_DECL([], [sys_lib_search_path_spec], [2],
+     [Compile-time system search path for libraries])
+-_LT_DECL([], [sys_lib_dlsearch_path_spec], [2],
+-    [Run-time system search path for libraries])
++_LT_DECL([sys_lib_dlsearch_path_spec], [configure_time_dlsearch_path], [2],
++    [Detected run-time system search path for libraries])
++_LT_DECL([], [configure_time_lt_sys_library_path], [2],
++    [Explicit LT_SYS_LIBRARY_PATH set during ./configure time])
+ ])# _LT_SYS_DYNAMIC_LINKER
+ 
+ 
+ # _LT_PATH_TOOL_PREFIX(TOOL)
+ # --------------------------
+-# find a file program which can recognize shared library
++# find a file program that can recognize shared library
+ AC_DEFUN([_LT_PATH_TOOL_PREFIX],
+ [m4_require([_LT_DECL_EGREP])dnl
+ AC_MSG_CHECKING([for $1])
+ AC_CACHE_VAL(lt_cv_path_MAGIC_CMD,
+ [case $MAGIC_CMD in
+ [[\\/*] |  ?:[\\/]*])
+-  lt_cv_path_MAGIC_CMD="$MAGIC_CMD" # Let the user override the test with a path.
++  lt_cv_path_MAGIC_CMD=$MAGIC_CMD # Let the user override the test with a path.
+   ;;
+ *)
+-  lt_save_MAGIC_CMD="$MAGIC_CMD"
+-  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  lt_save_MAGIC_CMD=$MAGIC_CMD
++  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+ dnl $ac_dummy forces splitting on constant user-supplied paths.
+ dnl POSIX.2 word splitting is done only on the output of word expansions,
+ dnl not every word.  This closes a longstanding sh security hole.
+   ac_dummy="m4_if([$2], , $PATH, [$2])"
+   for ac_dir in $ac_dummy; do
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+     test -z "$ac_dir" && ac_dir=.
+-    if test -f $ac_dir/$1; then
+-      lt_cv_path_MAGIC_CMD="$ac_dir/$1"
++    if test -f "$ac_dir/$1"; then
++      lt_cv_path_MAGIC_CMD=$ac_dir/"$1"
+       if test -n "$file_magic_test_file"; then
+ 	case $deplibs_check_method in
+ 	"file_magic "*)
+ 	  file_magic_regex=`expr "$deplibs_check_method" : "file_magic \(.*\)"`
+-	  MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++	  MAGIC_CMD=$lt_cv_path_MAGIC_CMD
+ 	  if eval $file_magic_cmd \$file_magic_test_file 2> /dev/null |
+ 	    $EGREP "$file_magic_regex" > /dev/null; then
+ 	    :
+@@ -2978,11 +3221,11 @@ _LT_EOF
+       break
+     fi
+   done
+-  IFS="$lt_save_ifs"
+-  MAGIC_CMD="$lt_save_MAGIC_CMD"
++  IFS=$lt_save_ifs
++  MAGIC_CMD=$lt_save_MAGIC_CMD
+   ;;
+ esac])
+-MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++MAGIC_CMD=$lt_cv_path_MAGIC_CMD
+ if test -n "$MAGIC_CMD"; then
+   AC_MSG_RESULT($MAGIC_CMD)
+ else
+@@ -3000,7 +3243,7 @@ dnl AC_DEFUN([AC_PATH_TOOL_PREFIX], [])
+ 
+ # _LT_PATH_MAGIC
+ # --------------
+-# find a file program which can recognize a shared library
++# find a file program that can recognize a shared library
+ m4_defun([_LT_PATH_MAGIC],
+ [_LT_PATH_TOOL_PREFIX(${ac_tool_prefix}file, /usr/bin$PATH_SEPARATOR$PATH)
+ if test -z "$lt_cv_path_MAGIC_CMD"; then
+@@ -3027,16 +3270,16 @@ m4_require([_LT_PROG_ECHO_BACKSLASH])dnl
+ AC_ARG_WITH([gnu-ld],
+     [AS_HELP_STRING([--with-gnu-ld],
+ 	[assume the C compiler uses GNU ld @<:@default=no@:>@])],
+-    [test "$withval" = no || with_gnu_ld=yes],
++    [test no = "$withval" || with_gnu_ld=yes],
+     [with_gnu_ld=no])dnl
+ 
+ ac_prog=ld
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   # Check if gcc -print-prog-name=ld gives a path.
+   AC_MSG_CHECKING([for ld used by $CC])
+   case $host in
+   *-*-mingw*)
+-    # gcc leaves a trailing carriage return which upsets mingw
++    # gcc leaves a trailing carriage return, which upsets mingw
+     ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
+   *)
+     ac_prog=`($CC -print-prog-name=ld) 2>&5` ;;
+@@ -3050,7 +3293,7 @@ if test "$GCC" = yes; then
+       while $ECHO "$ac_prog" | $GREP "$re_direlt" > /dev/null 2>&1; do
+ 	ac_prog=`$ECHO $ac_prog| $SED "s%$re_direlt%/%"`
+       done
+-      test -z "$LD" && LD="$ac_prog"
++      test -z "$LD" && LD=$ac_prog
+       ;;
+   "")
+     # If it fails, then pretend we aren't using GCC.
+@@ -3061,37 +3304,37 @@ if test "$GCC" = yes; then
+     with_gnu_ld=unknown
+     ;;
+   esac
+-elif test "$with_gnu_ld" = yes; then
++elif test yes = "$with_gnu_ld"; then
+   AC_MSG_CHECKING([for GNU ld])
+ else
+   AC_MSG_CHECKING([for non-GNU ld])
+ fi
+ AC_CACHE_VAL(lt_cv_path_LD,
+ [if test -z "$LD"; then
+-  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+   for ac_dir in $PATH; do
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+     test -z "$ac_dir" && ac_dir=.
+     if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
+-      lt_cv_path_LD="$ac_dir/$ac_prog"
++      lt_cv_path_LD=$ac_dir/$ac_prog
+       # Check to see if the program is GNU ld.  I'd rather use --version,
+       # but apparently some variants of GNU ld only accept -v.
+       # Break only if it was the GNU/non-GNU ld that we prefer.
+       case `"$lt_cv_path_LD" -v 2>&1 </dev/null` in
+       *GNU* | *'with BFD'*)
+-	test "$with_gnu_ld" != no && break
++	test no != "$with_gnu_ld" && break
+ 	;;
+       *)
+-	test "$with_gnu_ld" != yes && break
++	test yes != "$with_gnu_ld" && break
+ 	;;
+       esac
+     fi
+   done
+-  IFS="$lt_save_ifs"
++  IFS=$lt_save_ifs
+ else
+-  lt_cv_path_LD="$LD" # Let the user override the test with a path.
++  lt_cv_path_LD=$LD # Let the user override the test with a path.
+ fi])
+-LD="$lt_cv_path_LD"
++LD=$lt_cv_path_LD
+ if test -n "$LD"; then
+   AC_MSG_RESULT($LD)
+ else
+@@ -3145,13 +3388,13 @@ esac
+ reload_cmds='$LD$reload_flag -o $output$reload_objs'
+ case $host_os in
+   cygwin* | mingw* | pw32* | cegcc*)
+-    if test "$GCC" != yes; then
++    if test yes != "$GCC"; then
+       reload_cmds=false
+     fi
+     ;;
+   darwin*)
+-    if test "$GCC" = yes; then
+-      reload_cmds='$LTCC $LTCFLAGS -nostdlib ${wl}-r -o $output$reload_objs'
++    if test yes = "$GCC"; then
++      reload_cmds='$LTCC $LTCFLAGS -nostdlib $wl-r -o $output$reload_objs'
+     else
+       reload_cmds='$LD$reload_flag -o $output$reload_objs'
+     fi
+@@ -3162,6 +3405,43 @@ _LT_TAGDECL([], [reload_cmds], [2])dnl
+ ])# _LT_CMD_RELOAD
+ 
+ 
++# _LT_PATH_DD
++# -----------
++# find a working dd
++m4_defun([_LT_PATH_DD],
++[AC_CACHE_CHECK([for a working dd], [ac_cv_path_lt_DD],
++[printf 0123456789abcdef0123456789abcdef >conftest.i
++cat conftest.i conftest.i >conftest2.i
++: ${lt_DD:=$DD}
++AC_PATH_PROGS_FEATURE_CHECK([lt_DD], [dd],
++[if "$ac_path_lt_DD" bs=32 count=1 <conftest2.i >conftest.out 2>/dev/null; then
++  cmp -s conftest.i conftest.out \
++  && ac_cv_path_lt_DD="$ac_path_lt_DD" ac_path_lt_DD_found=:
++fi])
++rm -f conftest.i conftest2.i conftest.out])
++])# _LT_PATH_DD
++
++
++# _LT_CMD_TRUNCATE
++# ----------------
++# find command to truncate a binary pipe
++m4_defun([_LT_CMD_TRUNCATE],
++[m4_require([_LT_PATH_DD])
++AC_CACHE_CHECK([how to truncate binary pipes], [lt_cv_truncate_bin],
++[printf 0123456789abcdef0123456789abcdef >conftest.i
++cat conftest.i conftest.i >conftest2.i
++lt_cv_truncate_bin=
++if "$ac_cv_path_lt_DD" bs=32 count=1 <conftest2.i >conftest.out 2>/dev/null; then
++  cmp -s conftest.i conftest.out \
++  && lt_cv_truncate_bin="$ac_cv_path_lt_DD bs=4096 count=1"
++fi
++rm -f conftest.i conftest2.i conftest.out
++test -z "$lt_cv_truncate_bin" && lt_cv_truncate_bin="$SED -e 4q"])
++_LT_DECL([lt_truncate_bin], [lt_cv_truncate_bin], [1],
++  [Command to truncate a binary pipe])
++])# _LT_CMD_TRUNCATE
++
++
+ # _LT_CHECK_MAGIC_METHOD
+ # ----------------------
+ # how to check for library dependencies
+@@ -3177,13 +3457,13 @@ lt_cv_deplibs_check_method='unknown'
+ # Need to set the preceding variable on all platforms that support
+ # interlibrary dependencies.
+ # 'none' -- dependencies not supported.
+-# `unknown' -- same as none, but documents that we really don't know.
++# 'unknown' -- same as none, but documents that we really don't know.
+ # 'pass_all' -- all dependencies passed with no checks.
+ # 'test_compile' -- check by making test program.
+ # 'file_magic [[regex]]' -- check by looking for files in library path
+-# which responds to the $file_magic_cmd with a given extended regex.
+-# If you have `file' or equivalent on your system and you're not sure
+-# whether `pass_all' will *always* work, you probably want this one.
++# that responds to the $file_magic_cmd with a given extended regex.
++# If you have 'file' or equivalent on your system and you're not sure
++# whether 'pass_all' will *always* work, you probably want this one.
+ 
+ case $host_os in
+ aix[[4-9]]*)
+@@ -3210,8 +3490,7 @@ mingw* | pw32*)
+   # Base MSYS/MinGW do not provide the 'file' command needed by
+   # func_win32_libid shell function, so use a weaker test based on 'objdump',
+   # unless we find 'file', for example because we are cross-compiling.
+-  # func_win32_libid assumes BSD nm, so disallow it if using MS dumpbin.
+-  if ( test "$lt_cv_nm_interface" = "BSD nm" && file / ) >/dev/null 2>&1; then
++  if ( file / ) >/dev/null 2>&1; then
+     lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
+     lt_cv_file_magic_cmd='func_win32_libid'
+   else
+@@ -3247,10 +3526,6 @@ freebsd* | dragonfly*)
+   fi
+   ;;
+ 
+-gnu*)
+-  lt_cv_deplibs_check_method=pass_all
+-  ;;
+-
+ haiku*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+@@ -3289,7 +3564,7 @@ irix5* | irix6* | nonstopux*)
+   ;;
+ 
+ # This must be glibc/ELF.
+-linux* | k*bsd*-gnu | kopensolaris*-gnu)
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
+@@ -3311,8 +3586,8 @@ newos6*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
+ 
+-openbsd*)
+-  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++openbsd* | bitrig*)
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
+     lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|\.so|_pic\.a)$'
+   else
+     lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
+@@ -3365,6 +3640,9 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++os2*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ ])
+ 
+@@ -3405,33 +3683,38 @@ AC_DEFUN([LT_PATH_NM],
+ AC_CACHE_CHECK([for BSD- or MS-compatible name lister (nm)], lt_cv_path_NM,
+ [if test -n "$NM"; then
+   # Let the user override the test.
+-  lt_cv_path_NM="$NM"
++  lt_cv_path_NM=$NM
+ else
+-  lt_nm_to_check="${ac_tool_prefix}nm"
++  lt_nm_to_check=${ac_tool_prefix}nm
+   if test -n "$ac_tool_prefix" && test "$build" = "$host"; then
+     lt_nm_to_check="$lt_nm_to_check nm"
+   fi
+   for lt_tmp_nm in $lt_nm_to_check; do
+-    lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++    lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+     for ac_dir in $PATH /usr/ccs/bin/elf /usr/ccs/bin /usr/ucb /bin; do
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       test -z "$ac_dir" && ac_dir=.
+-      tmp_nm="$ac_dir/$lt_tmp_nm"
+-      if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext" ; then
++      tmp_nm=$ac_dir/$lt_tmp_nm
++      if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext"; then
+ 	# Check to see if the nm accepts a BSD-compat flag.
+-	# Adding the `sed 1q' prevents false positives on HP-UX, which says:
++	# Adding the 'sed 1q' prevents false positives on HP-UX, which says:
+ 	#   nm: unknown option "B" ignored
+ 	# Tru64's nm complains that /dev/null is an invalid object file
+-	case `"$tmp_nm" -B /dev/null 2>&1 | sed '1q'` in
+-	*/dev/null* | *'Invalid file or object type'*)
++	# MSYS converts /dev/null to NUL, MinGW nm treats NUL as empty
++	case $build_os in
++	mingw*) lt_bad_file=conftest.nm/nofile ;;
++	*) lt_bad_file=/dev/null ;;
++	esac
++	case `"$tmp_nm" -B $lt_bad_file 2>&1 | sed '1q'` in
++	*$lt_bad_file* | *'Invalid file or object type'*)
+ 	  lt_cv_path_NM="$tmp_nm -B"
+-	  break
++	  break 2
+ 	  ;;
+ 	*)
+ 	  case `"$tmp_nm" -p /dev/null 2>&1 | sed '1q'` in
+ 	  */dev/null*)
+ 	    lt_cv_path_NM="$tmp_nm -p"
+-	    break
++	    break 2
+ 	    ;;
+ 	  *)
+ 	    lt_cv_path_NM=${lt_cv_path_NM="$tmp_nm"} # keep the first match, but
+@@ -3442,21 +3725,21 @@ else
+ 	esac
+       fi
+     done
+-    IFS="$lt_save_ifs"
++    IFS=$lt_save_ifs
+   done
+   : ${lt_cv_path_NM=no}
+ fi])
+-if test "$lt_cv_path_NM" != "no"; then
+-  NM="$lt_cv_path_NM"
++if test no != "$lt_cv_path_NM"; then
++  NM=$lt_cv_path_NM
+ else
+   # Didn't find any BSD compatible name lister, look for dumpbin.
+   if test -n "$DUMPBIN"; then :
+     # Let the user override the test.
+   else
+     AC_CHECK_TOOLS(DUMPBIN, [dumpbin "link -dump"], :)
+-    case `$DUMPBIN -symbols /dev/null 2>&1 | sed '1q'` in
++    case `$DUMPBIN -symbols -headers /dev/null 2>&1 | sed '1q'` in
+     *COFF*)
+-      DUMPBIN="$DUMPBIN -symbols"
++      DUMPBIN="$DUMPBIN -symbols -headers"
+       ;;
+     *)
+       DUMPBIN=:
+@@ -3464,8 +3747,8 @@ else
+     esac
+   fi
+   AC_SUBST([DUMPBIN])
+-  if test "$DUMPBIN" != ":"; then
+-    NM="$DUMPBIN"
++  if test : != "$DUMPBIN"; then
++    NM=$DUMPBIN
+   fi
+ fi
+ test -z "$NM" && NM=nm
+@@ -3511,8 +3794,8 @@ lt_cv_sharedlib_from_linklib_cmd,
+ 
+ case $host_os in
+ cygwin* | mingw* | pw32* | cegcc*)
+-  # two different shell functions defined in ltmain.sh
+-  # decide which to use based on capabilities of $DLLTOOL
++  # two different shell functions defined in ltmain.sh;
++  # decide which one to use based on capabilities of $DLLTOOL
+   case `$DLLTOOL --help 2>&1` in
+   *--identify-strict*)
+     lt_cv_sharedlib_from_linklib_cmd=func_cygming_dll_for_implib
+@@ -3524,7 +3807,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+   ;;
+ *)
+   # fallback: assume linklib IS sharedlib
+-  lt_cv_sharedlib_from_linklib_cmd="$ECHO"
++  lt_cv_sharedlib_from_linklib_cmd=$ECHO
+   ;;
+ esac
+ ])
+@@ -3551,13 +3834,28 @@ AC_CACHE_CHECK([if $MANIFEST_TOOL is a manifest tool], [lt_cv_path_mainfest_tool
+     lt_cv_path_mainfest_tool=yes
+   fi
+   rm -f conftest*])
+-if test "x$lt_cv_path_mainfest_tool" != xyes; then
++if test yes != "$lt_cv_path_mainfest_tool"; then
+   MANIFEST_TOOL=:
+ fi
+ _LT_DECL([], [MANIFEST_TOOL], [1], [Manifest tool])dnl
+ ])# _LT_PATH_MANIFEST_TOOL
+ 
+ 
++# _LT_DLL_DEF_P([FILE])
++# ---------------------
++# True iff FILE is a Windows DLL '.def' file.
++# Keep in sync with func_dll_def_p in the libtool script
++AC_DEFUN([_LT_DLL_DEF_P],
++[dnl
++  test DEF = "`$SED -n dnl
++    -e '\''s/^[[	 ]]*//'\'' dnl Strip leading whitespace
++    -e '\''/^\(;.*\)*$/d'\'' dnl      Delete empty lines and comments
++    -e '\''s/^\(EXPORTS\|LIBRARY\)\([[	 ]].*\)*$/DEF/p'\'' dnl
++    -e q dnl                          Only consider the first "real" line
++    $1`" dnl
++])# _LT_DLL_DEF_P
++
++
+ # LT_LIB_M
+ # --------
+ # check for math library
+@@ -3569,11 +3867,11 @@ case $host in
+   # These system don't have libm, or don't need it
+   ;;
+ *-ncr-sysv4.3*)
+-  AC_CHECK_LIB(mw, _mwvalidcheckl, LIBM="-lmw")
++  AC_CHECK_LIB(mw, _mwvalidcheckl, LIBM=-lmw)
+   AC_CHECK_LIB(m, cos, LIBM="$LIBM -lm")
+   ;;
+ *)
+-  AC_CHECK_LIB(m, cos, LIBM="-lm")
++  AC_CHECK_LIB(m, cos, LIBM=-lm)
+   ;;
+ esac
+ AC_SUBST([LIBM])
+@@ -3592,7 +3890,7 @@ m4_defun([_LT_COMPILER_NO_RTTI],
+ 
+ _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=
+ 
+-if test "$GCC" = yes; then
++if test yes = "$GCC"; then
+   case $cc_basename in
+   nvcc*)
+     _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=' -Xcompiler -fno-builtin' ;;
+@@ -3644,7 +3942,7 @@ cygwin* | mingw* | pw32* | cegcc*)
+   symcode='[[ABCDGISTW]]'
+   ;;
+ hpux*)
+-  if test "$host_cpu" = ia64; then
++  if test ia64 = "$host_cpu"; then
+     symcode='[[ABCDEGRST]]'
+   fi
+   ;;
+@@ -3677,14 +3975,44 @@ case `$NM -V 2>&1` in
+   symcode='[[ABCDGIRSTW]]' ;;
+ esac
+ 
++if test "$lt_cv_nm_interface" = "MS dumpbin"; then
++  # Gets list of data symbols to import.
++  lt_cv_sys_global_symbol_to_import="sed -n -e 's/^I .* \(.*\)$/\1/p'"
++  # Adjust the below global symbol transforms to fixup imported variables.
++  lt_cdecl_hook=" -e 's/^I .* \(.*\)$/extern __declspec(dllimport) char \1;/p'"
++  lt_c_name_hook=" -e 's/^I .* \(.*\)$/  {\"\1\", (void *) 0},/p'"
++  lt_c_name_lib_hook="\
++  -e 's/^I .* \(lib.*\)$/  {\"\1\", (void *) 0},/p'\
++  -e 's/^I .* \(.*\)$/  {\"lib\1\", (void *) 0},/p'"
++else
++  # Disable hooks by default.
++  lt_cv_sys_global_symbol_to_import=
++  lt_cdecl_hook=
++  lt_c_name_hook=
++  lt_c_name_lib_hook=
++fi
++
+ # Transform an extracted symbol line into a proper C declaration.
+ # Some systems (esp. on ia64) link data and code symbols differently,
+ # so use this general approach.
+-lt_cv_sys_global_symbol_to_cdecl="sed -n -e 's/^T .* \(.*\)$/extern int \1();/p' -e 's/^$symcode* .* \(.*\)$/extern char \1;/p'"
++lt_cv_sys_global_symbol_to_cdecl="sed -n"\
++$lt_cdecl_hook\
++" -e 's/^T .* \(.*\)$/extern int \1();/p'"\
++" -e 's/^$symcode$symcode* .* \(.*\)$/extern char \1;/p'"
+ 
+ # Transform an extracted symbol line into symbol name and symbol address
+-lt_cv_sys_global_symbol_to_c_name_address="sed -n -e 's/^: \([[^ ]]*\)[[ ]]*$/  {\\\"\1\\\", (void *) 0},/p' -e 's/^$symcode* \([[^ ]]*\) \([[^ ]]*\)$/  {\"\2\", (void *) \&\2},/p'"
+-lt_cv_sys_global_symbol_to_c_name_address_lib_prefix="sed -n -e 's/^: \([[^ ]]*\)[[ ]]*$/  {\\\"\1\\\", (void *) 0},/p' -e 's/^$symcode* \([[^ ]]*\) \(lib[[^ ]]*\)$/  {\"\2\", (void *) \&\2},/p' -e 's/^$symcode* \([[^ ]]*\) \([[^ ]]*\)$/  {\"lib\2\", (void *) \&\2},/p'"
++lt_cv_sys_global_symbol_to_c_name_address="sed -n"\
++$lt_c_name_hook\
++" -e 's/^: \(.*\) .*$/  {\"\1\", (void *) 0},/p'"\
++" -e 's/^$symcode$symcode* .* \(.*\)$/  {\"\1\", (void *) \&\1},/p'"
++
++# Transform an extracted symbol line into symbol name with lib prefix and
++# symbol address.
++lt_cv_sys_global_symbol_to_c_name_address_lib_prefix="sed -n"\
++$lt_c_name_lib_hook\
++" -e 's/^: \(.*\) .*$/  {\"\1\", (void *) 0},/p'"\
++" -e 's/^$symcode$symcode* .* \(lib.*\)$/  {\"\1\", (void *) \&\1},/p'"\
++" -e 's/^$symcode$symcode* .* \(.*\)$/  {\"lib\1\", (void *) \&\1},/p'"
+ 
+ # Handle CRLF in mingw tool chain
+ opt_cr=
+@@ -3702,21 +4030,24 @@ for ac_symprfx in "" "_"; do
+ 
+   # Write the raw and C identifiers.
+   if test "$lt_cv_nm_interface" = "MS dumpbin"; then
+-    # Fake it for dumpbin and say T for any non-static function
+-    # and D for any global variable.
++    # Fake it for dumpbin and say T for any non-static function,
++    # D for any global variable and I for any imported variable.
+     # Also find C++ and __fastcall symbols from MSVC++,
+     # which start with @ or ?.
+     lt_cv_sys_global_symbol_pipe="$AWK ['"\
+ "     {last_section=section; section=\$ 3};"\
+ "     /^COFF SYMBOL TABLE/{for(i in hide) delete hide[i]};"\
+ "     /Section length .*#relocs.*(pick any)/{hide[last_section]=1};"\
++"     /^ *Symbol name *: /{split(\$ 0,sn,\":\"); si=substr(sn[2],2)};"\
++"     /^ *Type *: code/{print \"T\",si,substr(si,length(prfx))};"\
++"     /^ *Type *: data/{print \"I\",si,substr(si,length(prfx))};"\
+ "     \$ 0!~/External *\|/{next};"\
+ "     / 0+ UNDEF /{next}; / UNDEF \([^|]\)*()/{next};"\
+ "     {if(hide[section]) next};"\
+-"     {f=0}; \$ 0~/\(\).*\|/{f=1}; {printf f ? \"T \" : \"D \"};"\
+-"     {split(\$ 0, a, /\||\r/); split(a[2], s)};"\
+-"     s[1]~/^[@?]/{print s[1], s[1]; next};"\
+-"     s[1]~prfx {split(s[1],t,\"@\"); print t[1], substr(t[1],length(prfx))}"\
++"     {f=\"D\"}; \$ 0~/\(\).*\|/{f=\"T\"};"\
++"     {split(\$ 0,a,/\||\r/); split(a[2],s)};"\
++"     s[1]~/^[@?]/{print f,s[1],s[1]; next};"\
++"     s[1]~prfx {split(s[1],t,\"@\"); print f,t[1],substr(t[1],length(prfx))}"\
+ "     ' prfx=^$ac_symprfx]"
+   else
+     lt_cv_sys_global_symbol_pipe="sed -n -e 's/^.*[[	 ]]\($symcode$symcode*\)[[	 ]][[	 ]]*$ac_symprfx$sympat$opt_cr$/$symxfrm/p'"
+@@ -3756,11 +4087,11 @@ _LT_EOF
+ 	if $GREP ' nm_test_func$' "$nlist" >/dev/null; then
+ 	  cat <<_LT_EOF > conftest.$ac_ext
+ /* Keep this code in sync between libtool.m4, ltmain, lt_system.h, and tests.  */
+-#if defined(_WIN32) || defined(__CYGWIN__) || defined(_WIN32_WCE)
+-/* DATA imports from DLLs on WIN32 con't be const, because runtime
++#if defined _WIN32 || defined __CYGWIN__ || defined _WIN32_WCE
++/* DATA imports from DLLs on WIN32 can't be const, because runtime
+    relocations are performed -- see ld's documentation on pseudo-relocs.  */
+ # define LT@&t@_DLSYM_CONST
+-#elif defined(__osf__)
++#elif defined __osf__
+ /* This system does not cope well with relocations in const data.  */
+ # define LT@&t@_DLSYM_CONST
+ #else
+@@ -3786,7 +4117,7 @@ lt__PROGRAM__LTX_preloaded_symbols[[]] =
+ {
+   { "@PROGRAM@", (void *) 0 },
+ _LT_EOF
+-	  $SED "s/^$symcode$symcode* \(.*\) \(.*\)$/  {\"\2\", (void *) \&\2},/" < "$nlist" | $GREP -v main >> conftest.$ac_ext
++	  $SED "s/^$symcode$symcode* .* \(.*\)$/  {\"\1\", (void *) \&\1},/" < "$nlist" | $GREP -v main >> conftest.$ac_ext
+ 	  cat <<\_LT_EOF >> conftest.$ac_ext
+   {0, (void *) 0}
+ };
+@@ -3806,9 +4137,9 @@ _LT_EOF
+ 	  mv conftest.$ac_objext conftstm.$ac_objext
+ 	  lt_globsym_save_LIBS=$LIBS
+ 	  lt_globsym_save_CFLAGS=$CFLAGS
+-	  LIBS="conftstm.$ac_objext"
++	  LIBS=conftstm.$ac_objext
+ 	  CFLAGS="$CFLAGS$_LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)"
+-	  if AC_TRY_EVAL(ac_link) && test -s conftest${ac_exeext}; then
++	  if AC_TRY_EVAL(ac_link) && test -s conftest$ac_exeext; then
+ 	    pipe_works=yes
+ 	  fi
+ 	  LIBS=$lt_globsym_save_LIBS
+@@ -3829,7 +4160,7 @@ _LT_EOF
+   rm -rf conftest* conftst*
+ 
+   # Do not use the global_symbol_pipe unless it works.
+-  if test "$pipe_works" = yes; then
++  if test yes = "$pipe_works"; then
+     break
+   else
+     lt_cv_sys_global_symbol_pipe=
+@@ -3856,12 +4187,16 @@ _LT_DECL([global_symbol_pipe], [lt_cv_sys_global_symbol_pipe], [1],
+     [Take the output of nm and produce a listing of raw symbols and C names])
+ _LT_DECL([global_symbol_to_cdecl], [lt_cv_sys_global_symbol_to_cdecl], [1],
+     [Transform the output of nm in a proper C declaration])
++_LT_DECL([global_symbol_to_import], [lt_cv_sys_global_symbol_to_import], [1],
++    [Transform the output of nm into a list of symbols to manually relocate])
+ _LT_DECL([global_symbol_to_c_name_address],
+     [lt_cv_sys_global_symbol_to_c_name_address], [1],
+     [Transform the output of nm in a C name address pair])
+ _LT_DECL([global_symbol_to_c_name_address_lib_prefix],
+     [lt_cv_sys_global_symbol_to_c_name_address_lib_prefix], [1],
+     [Transform the output of nm in a C name address pair when lib prefix is needed])
++_LT_DECL([nm_interface], [lt_cv_nm_interface], [1],
++    [The name lister interface])
+ _LT_DECL([], [nm_file_list_spec], [1],
+     [Specify filename containing input files for $NM])
+ ]) # _LT_CMD_GLOBAL_SYMBOLS
+@@ -3877,17 +4212,18 @@ _LT_TAGVAR(lt_prog_compiler_static, $1)=
+ 
+ m4_if([$1], [CXX], [
+   # C++ specific cases for pic, static, wl, etc.
+-  if test "$GXX" = yes; then
++  if test yes = "$GXX"; then
+     _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+     _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+ 
+     case $host_os in
+     aix*)
+       # All AIX code is PIC.
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+       fi
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
+       ;;
+ 
+     amigaos*)
+@@ -3898,8 +4234,8 @@ m4_if([$1], [CXX], [
+         ;;
+       m68k)
+             # FIXME: we need at least 68020 code to build shared libraries, but
+-            # adding the `-m68020' flag to GCC prevents building anything better,
+-            # like `-m68040'.
++            # adding the '-m68020' flag to GCC prevents building anything better,
++            # like '-m68040'.
+             _LT_TAGVAR(lt_prog_compiler_pic, $1)='-m68020 -resident32 -malways-restore-a4'
+         ;;
+       esac
+@@ -3915,6 +4251,11 @@ m4_if([$1], [CXX], [
+       # (--disable-auto-import) libraries
+       m4_if([$1], [GCJ], [],
+ 	[_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++      case $host_os in
++      os2*)
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='$wl-static'
++	;;
++      esac
+       ;;
+     darwin* | rhapsody*)
+       # PIC is the default on this platform
+@@ -3964,7 +4305,7 @@ m4_if([$1], [CXX], [
+     case $host_os in
+       aix[[4-9]]*)
+ 	# All AIX code is PIC.
+-	if test "$host_cpu" = ia64; then
++	if test ia64 = "$host_cpu"; then
+ 	  # AIX 5 now supports IA64 processor
+ 	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+ 	else
+@@ -4005,14 +4346,14 @@ m4_if([$1], [CXX], [
+ 	case $cc_basename in
+ 	  CC*)
+ 	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+-	    _LT_TAGVAR(lt_prog_compiler_static, $1)='${wl}-a ${wl}archive'
+-	    if test "$host_cpu" != ia64; then
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='$wl-a ${wl}archive'
++	    if test ia64 != "$host_cpu"; then
+ 	      _LT_TAGVAR(lt_prog_compiler_pic, $1)='+Z'
+ 	    fi
+ 	    ;;
+ 	  aCC*)
+ 	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+-	    _LT_TAGVAR(lt_prog_compiler_static, $1)='${wl}-a ${wl}archive'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='$wl-a ${wl}archive'
+ 	    case $host_cpu in
+ 	    hppa*64*|ia64*)
+ 	      # +Z the default
+@@ -4041,7 +4382,7 @@ m4_if([$1], [CXX], [
+ 	    ;;
+ 	esac
+ 	;;
+-      linux* | k*bsd*-gnu | kopensolaris*-gnu)
++      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+ 	case $cc_basename in
+ 	  KCC*)
+ 	    # KAI C++ Compiler
+@@ -4049,7 +4390,7 @@ m4_if([$1], [CXX], [
+ 	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
+ 	    ;;
+ 	  ecpc* )
+-	    # old Intel C++ for x86_64 which still supported -KPIC.
++	    # old Intel C++ for x86_64, which still supported -KPIC.
+ 	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+ 	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
+ 	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+@@ -4194,17 +4535,18 @@ m4_if([$1], [CXX], [
+   fi
+ ],
+ [
+-  if test "$GCC" = yes; then
++  if test yes = "$GCC"; then
+     _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+     _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+ 
+     case $host_os in
+       aix*)
+       # All AIX code is PIC.
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+       fi
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
+       ;;
+ 
+     amigaos*)
+@@ -4215,8 +4557,8 @@ m4_if([$1], [CXX], [
+         ;;
+       m68k)
+             # FIXME: we need at least 68020 code to build shared libraries, but
+-            # adding the `-m68020' flag to GCC prevents building anything better,
+-            # like `-m68040'.
++            # adding the '-m68020' flag to GCC prevents building anything better,
++            # like '-m68040'.
+             _LT_TAGVAR(lt_prog_compiler_pic, $1)='-m68020 -resident32 -malways-restore-a4'
+         ;;
+       esac
+@@ -4233,6 +4575,11 @@ m4_if([$1], [CXX], [
+       # (--disable-auto-import) libraries
+       m4_if([$1], [GCJ], [],
+ 	[_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++      case $host_os in
++      os2*)
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='$wl-static'
++	;;
++      esac
+       ;;
+ 
+     darwin* | rhapsody*)
+@@ -4303,7 +4650,7 @@ m4_if([$1], [CXX], [
+     case $host_os in
+     aix*)
+       _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# AIX 5 now supports IA64 processor
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+       else
+@@ -4311,11 +4658,30 @@ m4_if([$1], [CXX], [
+       fi
+       ;;
+ 
++    darwin* | rhapsody*)
++      # PIC is the default on this platform
++      # Common symbols not allowed in MH_DYLIB files
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fno-common'
++      case $cc_basename in
++      nagfor*)
++        # NAG Fortran compiler
++        _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,-Wl,,'
++        _LT_TAGVAR(lt_prog_compiler_pic, $1)='-PIC'
++        _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++        ;;
++      esac
++      ;;
++
+     mingw* | cygwin* | pw32* | os2* | cegcc*)
+       # This hack is so that the source file can tell whether it is being
+       # built for inclusion in a dll (and should export symbols for example).
+       m4_if([$1], [GCJ], [],
+ 	[_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++      case $host_os in
++      os2*)
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='$wl-static'
++	;;
++      esac
+       ;;
+ 
+     hpux9* | hpux10* | hpux11*)
+@@ -4331,7 +4697,7 @@ m4_if([$1], [CXX], [
+ 	;;
+       esac
+       # Is there a better lt_prog_compiler_static that works with the bundled CC?
+-      _LT_TAGVAR(lt_prog_compiler_static, $1)='${wl}-a ${wl}archive'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='$wl-a ${wl}archive'
+       ;;
+ 
+     irix5* | irix6* | nonstopux*)
+@@ -4340,9 +4706,9 @@ m4_if([$1], [CXX], [
+       _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
+       ;;
+ 
+-    linux* | k*bsd*-gnu | kopensolaris*-gnu)
++    linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+       case $cc_basename in
+-      # old Intel for x86_64 which still supported -KPIC.
++      # old Intel for x86_64, which still supported -KPIC.
+       ecc*)
+ 	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
+ 	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
+@@ -4367,6 +4733,12 @@ m4_if([$1], [CXX], [
+ 	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-PIC'
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+ 	;;
++      tcc*)
++	# Fabrice Bellard et al's Tiny C Compiler
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++	;;
+       pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)
+         # Portland Group compilers (*not* the Pentium gcc compiler,
+ 	# which looks to be a dead project)
+@@ -4464,7 +4836,7 @@ m4_if([$1], [CXX], [
+       ;;
+ 
+     sysv4*MP*)
+-      if test -d /usr/nec ;then
++      if test -d /usr/nec; then
+ 	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-Kconform_pic'
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+       fi
+@@ -4493,7 +4865,7 @@ m4_if([$1], [CXX], [
+   fi
+ ])
+ case $host_os in
+-  # For platforms which do not support PIC, -DPIC is meaningless:
++  # For platforms that do not support PIC, -DPIC is meaningless:
+   *djgpp*)
+     _LT_TAGVAR(lt_prog_compiler_pic, $1)=
+     ;;
+@@ -4559,17 +4931,21 @@ m4_if([$1], [CXX], [
+   case $host_os in
+   aix[[4-9]]*)
+     # If we're using GNU nm, then we don't want the "-C" option.
+-    # -C means demangle to AIX nm, but means don't demangle with GNU nm
+-    # Also, AIX nm treats weak defined symbols like other global defined
+-    # symbols, whereas GNU nm marks them as "W".
++    # -C means demangle to GNU nm, but means don't demangle to AIX nm.
++    # Without the "-l" option, or with the "-B" option, AIX nm treats
++    # weak defined symbols like other global defined symbols, whereas
++    # GNU nm marks them as "W".
++    # While the 'weak' keyword is ignored in the Export File, we need
++    # it in the Import File for the 'aix-soname' feature, so we have
++    # to replace the "-B" option with "-P" for AIX nm.
+     if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
+-      _LT_TAGVAR(export_symbols_cmds, $1)='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++      _LT_TAGVAR(export_symbols_cmds, $1)='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && ([substr](\$ 3,1,1) != ".")) { if (\$ 2 == "W") { print \$ 3 " weak" } else { print \$ 3 } } }'\'' | sort -u > $export_symbols'
+     else
+-      _LT_TAGVAR(export_symbols_cmds, $1)='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++      _LT_TAGVAR(export_symbols_cmds, $1)='`func_echo_all $NM | $SED -e '\''s/B\([[^B]]*\)$/P\1/'\''` -PCpgl $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "L") || (\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) && ([substr](\$ 1,1,1) != ".")) { if ((\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) { print \$ 1 " weak" } else { print \$ 1 } } }'\'' | sort -u > $export_symbols'
+     fi
+     ;;
+   pw32*)
+-    _LT_TAGVAR(export_symbols_cmds, $1)="$ltdll_cmds"
++    _LT_TAGVAR(export_symbols_cmds, $1)=$ltdll_cmds
+     ;;
+   cygwin* | mingw* | cegcc*)
+     case $cc_basename in
+@@ -4615,9 +4991,9 @@ m4_if([$1], [CXX], [
+   # included in the symbol list
+   _LT_TAGVAR(include_expsyms, $1)=
+   # exclude_expsyms can be an extended regexp of symbols to exclude
+-  # it will be wrapped by ` (' and `)$', so one must not match beginning or
+-  # end of line.  Example: `a|bc|.*d.*' will exclude the symbols `a' and `bc',
+-  # as well as any symbol that contains `d'.
++  # it will be wrapped by ' (' and ')$', so one must not match beginning or
++  # end of line.  Example: 'a|bc|.*d.*' will exclude the symbols 'a' and 'bc',
++  # as well as any symbol that contains 'd'.
+   _LT_TAGVAR(exclude_expsyms, $1)=['_GLOBAL_OFFSET_TABLE_|_GLOBAL__F[ID]_.*']
+   # Although _GLOBAL_OFFSET_TABLE_ is a valid symbol C name, most a.out
+   # platforms (ab)use it in PIC code, but their linkers get confused if
+@@ -4633,7 +5009,7 @@ dnl Note also adjust exclude_expsyms for C++ above.
+     # FIXME: the MSVC++ port hasn't been tested in a loooong time
+     # When not using gcc, we currently assume that we are using
+     # Microsoft Visual C++.
+-    if test "$GCC" != yes; then
++    if test yes != "$GCC"; then
+       with_gnu_ld=no
+     fi
+     ;;
+@@ -4641,7 +5017,7 @@ dnl Note also adjust exclude_expsyms for C++ above.
+     # we just hope/assume this is gcc and not c89 (= MSVC++)
+     with_gnu_ld=yes
+     ;;
+-  openbsd*)
++  openbsd* | bitrig*)
+     with_gnu_ld=no
+     ;;
+   esac
+@@ -4651,7 +5027,7 @@ dnl Note also adjust exclude_expsyms for C++ above.
+   # On some targets, GNU ld is compatible enough with the native linker
+   # that we're better off using the native interface for both.
+   lt_use_gnu_ld_interface=no
+-  if test "$with_gnu_ld" = yes; then
++  if test yes = "$with_gnu_ld"; then
+     case $host_os in
+       aix*)
+ 	# The AIX port of GNU ld has always aspired to compatibility
+@@ -4673,24 +5049,24 @@ dnl Note also adjust exclude_expsyms for C++ above.
+     esac
+   fi
+ 
+-  if test "$lt_use_gnu_ld_interface" = yes; then
++  if test yes = "$lt_use_gnu_ld_interface"; then
+     # If archive_cmds runs LD, not CC, wlarc should be empty
+-    wlarc='${wl}'
++    wlarc='$wl'
+ 
+     # Set some defaults for GNU ld with shared library support. These
+     # are reset later if shared libraries are not supported. Putting them
+     # here allows them to be overridden if necessary.
+     runpath_var=LD_RUN_PATH
+-    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
+-    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
+     # ancient GNU ld didn't support --whole-archive et. al.
+     if $LD --help 2>&1 | $GREP 'no-whole-archive' > /dev/null; then
+-      _LT_TAGVAR(whole_archive_flag_spec, $1)="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++      _LT_TAGVAR(whole_archive_flag_spec, $1)=$wlarc'--whole-archive$convenience '$wlarc'--no-whole-archive'
+     else
+       _LT_TAGVAR(whole_archive_flag_spec, $1)=
+     fi
+     supports_anon_versioning=no
+-    case `$LD -v 2>&1` in
++    case `$LD -v | $SED -e 's/([^)]\+)\s\+//' 2>&1` in
+       *GNU\ gold*) supports_anon_versioning=yes ;;
+       *\ [[01]].* | *\ 2.[[0-9]].* | *\ 2.10.*) ;; # catch versions < 2.11
+       *\ 2.11.93.0.2\ *) supports_anon_versioning=yes ;; # RH7.3 ...
+@@ -4703,7 +5079,7 @@ dnl Note also adjust exclude_expsyms for C++ above.
+     case $host_os in
+     aix[[3-9]]*)
+       # On AIX/PPC, the GNU linker is very broken
+-      if test "$host_cpu" != ia64; then
++      if test ia64 != "$host_cpu"; then
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+ 	cat <<_LT_EOF 1>&2
+ 
+@@ -4722,7 +5098,7 @@ _LT_EOF
+       case $host_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+-            _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++            _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+             _LT_TAGVAR(archive_expsym_cmds, $1)=''
+         ;;
+       m68k)
+@@ -4738,7 +5114,7 @@ _LT_EOF
+ 	_LT_TAGVAR(allow_undefined_flag, $1)=unsupported
+ 	# Joseph Beckenbach <jrb3@best.com> says some releases of gcc
+ 	# support --undefined.  This deserves some investigation.  FIXME
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -nostart $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+       else
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+       fi
+@@ -4748,7 +5124,7 @@ _LT_EOF
+       # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
+       # as there is no search path for DLLs.
+       _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
+-      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-all-symbols'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-all-symbols'
+       _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
+       _LT_TAGVAR(always_export_symbols, $1)=no
+       _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
+@@ -4756,61 +5132,90 @@ _LT_EOF
+       _LT_TAGVAR(exclude_expsyms, $1)=['[_]+GLOBAL_OFFSET_TABLE_|[_]+GLOBAL__[FID]_.*|[_]+head_[A-Za-z0-9_]+_dll|[A-Za-z0-9_]+_dll_iname']
+ 
+       if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+-        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-	# If the export-symbols file already is a .def file (1st line
+-	# is EXPORTS), use it as is; otherwise, prepend...
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	  cp $export_symbols $output_objdir/$soname.def;
+-	else
+-	  echo EXPORTS > $output_objdir/$soname.def;
+-	  cat $export_symbols >> $output_objdir/$soname.def;
+-	fi~
+-	$CC -shared $output_objdir/$soname.def $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	# If the export-symbols file already is a .def file, use it as
++	# is; otherwise, prepend EXPORTS...
++	_LT_TAGVAR(archive_expsym_cmds, $1)='if _LT_DLL_DEF_P([$export_symbols]); then
++          cp $export_symbols $output_objdir/$soname.def;
++        else
++          echo EXPORTS > $output_objdir/$soname.def;
++          cat $export_symbols >> $output_objdir/$soname.def;
++        fi~
++        $CC -shared $output_objdir/$soname.def $libobjs $deplibs $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+       else
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+       fi
+       ;;
+ 
+     haiku*)
+-      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+       _LT_TAGVAR(link_all_deplibs, $1)=yes
+       ;;
+ 
++    os2*)
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++      _LT_TAGVAR(hardcode_minus_L, $1)=yes
++      _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++      shrext_cmds=.dll
++      _LT_TAGVAR(archive_cmds, $1)='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	emxexp $libobjs | $SED /"_DLL_InitTerm"/d >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      _LT_TAGVAR(archive_expsym_cmds, $1)='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	prefix_cmds="$SED"~
++	if test EXPORTS = "`$SED 1q $export_symbols`"; then
++	  prefix_cmds="$prefix_cmds -e 1d";
++	fi~
++	prefix_cmds="$prefix_cmds -e \"s/^\(.*\)$/_\1/g\""~
++	cat $export_symbols | $prefix_cmds >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      _LT_TAGVAR(old_archive_From_new_cmds, $1)='emximp -o $output_objdir/${libname}_dll.a $output_objdir/$libname.def'
++      _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++      _LT_TAGVAR(file_list_spec, $1)='@'
++      ;;
++
+     interix[[3-9]]*)
+       _LT_TAGVAR(hardcode_direct, $1)=no
+       _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+-      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+       # Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
+       # Instead, shared libraries are loaded at an image base (0x10000000 by
+       # default) and relocated if they conflict, which is a slow very memory
+       # consuming and fragmenting process.  To avoid this, we pick a random,
+       # 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
+       # time.  Moving up from 0x10000000 also allows more sbrk(2) space.
+-      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+-      _LT_TAGVAR(archive_expsym_cmds, $1)='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++      _LT_TAGVAR(archive_expsym_cmds, $1)='sed "s|^|_|" $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--retain-symbols-file,$output_objdir/$soname.expsym $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+       ;;
+ 
+     gnu* | linux* | tpf* | k*bsd*-gnu | kopensolaris*-gnu)
+       tmp_diet=no
+-      if test "$host_os" = linux-dietlibc; then
++      if test linux-dietlibc = "$host_os"; then
+ 	case $cc_basename in
+ 	  diet\ *) tmp_diet=yes;;	# linux-dietlibc with static linking (!diet-dyn)
+ 	esac
+       fi
+       if $LD --help 2>&1 | $EGREP ': supported targets:.* elf' > /dev/null \
+-	 && test "$tmp_diet" = no
++	 && test no = "$tmp_diet"
+       then
+ 	tmp_addflag=' $pic_flag'
+ 	tmp_sharedflag='-shared'
+ 	case $cc_basename,$host_cpu in
+         pgcc*)				# Portland Group C compiler
+-	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag'
+ 	  ;;
+ 	pgf77* | pgf90* | pgf95* | pgfortran*)
+ 					# Portland Group f77 and f90 compilers
+-	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  tmp_addflag=' $pic_flag -Mnomain' ;;
+ 	ecc*,ia64* | icc*,ia64*)	# Intel C compiler on ia64
+ 	  tmp_addflag=' -i_dynamic' ;;
+@@ -4821,42 +5226,47 @@ _LT_EOF
+ 	lf95*)				# Lahey Fortran 8.1
+ 	  _LT_TAGVAR(whole_archive_flag_spec, $1)=
+ 	  tmp_sharedflag='--shared' ;;
++        nagfor*)                        # NAGFOR 5.3
++          tmp_sharedflag='-Wl,-shared' ;;
+ 	xl[[cC]]* | bgxl[[cC]]* | mpixl[[cC]]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+ 	  tmp_sharedflag='-qmkshrobj'
+ 	  tmp_addflag= ;;
+ 	nvcc*)	# Cuda Compiler Driver 2.2
+-	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  _LT_TAGVAR(compiler_needs_object, $1)=yes
+ 	  ;;
+ 	esac
+ 	case `$CC -V 2>&1 | sed 5q` in
+ 	*Sun\ C*)			# Sun C 5.9
+-	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  _LT_TAGVAR(compiler_needs_object, $1)=yes
+ 	  tmp_sharedflag='-G' ;;
+ 	*Sun\ F*)			# Sun Fortran 8.3
+ 	  tmp_sharedflag='-G' ;;
+ 	esac
+-	_LT_TAGVAR(archive_cmds, $1)='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+ 
+-        if test "x$supports_anon_versioning" = xyes; then
++        if test yes = "$supports_anon_versioning"; then
+           _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
+-	    cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-	    echo "local: *; };" >> $output_objdir/$libname.ver~
+-	    $CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
++            cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++            echo "local: *; };" >> $output_objdir/$libname.ver~
++            $CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-version-script $wl$output_objdir/$libname.ver -o $lib'
+         fi
+ 
+ 	case $cc_basename in
++	tcc*)
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='-rdynamic'
++	  ;;
+ 	xlf* | bgf* | bgxlf* | mpixlf*)
+ 	  # IBM XL Fortran 10.1 on PPC cannot create shared libs itself
+ 	  _LT_TAGVAR(whole_archive_flag_spec, $1)='--whole-archive$convenience --no-whole-archive'
+-	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+ 	  _LT_TAGVAR(archive_cmds, $1)='$LD -shared $libobjs $deplibs $linker_flags -soname $soname -o $lib'
+-	  if test "x$supports_anon_versioning" = xyes; then
++	  if test yes = "$supports_anon_versioning"; then
+ 	    _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
+-	      cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-	      echo "local: *; };" >> $output_objdir/$libname.ver~
+-	      $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
++              cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++              echo "local: *; };" >> $output_objdir/$libname.ver~
++              $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
+ 	  fi
+ 	  ;;
+ 	esac
+@@ -4870,8 +5280,8 @@ _LT_EOF
+ 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
+ 	wlarc=
+       else
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+       fi
+       ;;
+ 
+@@ -4889,8 +5299,8 @@ _LT_EOF
+ 
+ _LT_EOF
+       elif $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+       else
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+       fi
+@@ -4902,7 +5312,7 @@ _LT_EOF
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+ 	cat <<_LT_EOF 1>&2
+ 
+-*** Warning: Releases of the GNU linker prior to 2.16.91.0.3 can not
++*** Warning: Releases of the GNU linker prior to 2.16.91.0.3 cannot
+ *** reliably create shared libraries on SCO systems.  Therefore, libtool
+ *** is disabling shared libraries support.  We urge you to upgrade GNU
+ *** binutils to release 2.16.91.0.3 or newer.  Another option is to modify
+@@ -4917,9 +5327,9 @@ _LT_EOF
+ 	  # DT_RUNPATH tag from executables and libraries.  But doing so
+ 	  # requires that you compile everything twice, which is a pain.
+ 	  if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	  else
+ 	    _LT_TAGVAR(ld_shlibs, $1)=no
+ 	  fi
+@@ -4936,15 +5346,15 @@ _LT_EOF
+ 
+     *)
+       if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+       else
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+       fi
+       ;;
+     esac
+ 
+-    if test "$_LT_TAGVAR(ld_shlibs, $1)" = no; then
++    if test no = "$_LT_TAGVAR(ld_shlibs, $1)"; then
+       runpath_var=
+       _LT_TAGVAR(hardcode_libdir_flag_spec, $1)=
+       _LT_TAGVAR(export_dynamic_flag_spec, $1)=
+@@ -4960,7 +5370,7 @@ _LT_EOF
+       # Note: this linker hardcodes the directories in LIBPATH if there
+       # are no directories specified by -L.
+       _LT_TAGVAR(hardcode_minus_L, $1)=yes
+-      if test "$GCC" = yes && test -z "$lt_prog_compiler_static"; then
++      if test yes = "$GCC" && test -z "$lt_prog_compiler_static"; then
+ 	# Neither direct hardcoding nor static linking is supported with a
+ 	# broken collect2.
+ 	_LT_TAGVAR(hardcode_direct, $1)=unsupported
+@@ -4968,34 +5378,57 @@ _LT_EOF
+       ;;
+ 
+     aix[[4-9]]*)
+-      if test "$host_cpu" = ia64; then
++      if test ia64 = "$host_cpu"; then
+ 	# On IA64, the linker does run time linking by default, so we don't
+ 	# have to do anything special.
+ 	aix_use_runtimelinking=no
+ 	exp_sym_flag='-Bexport'
+-	no_entry_flag=""
++	no_entry_flag=
+       else
+ 	# If we're using GNU nm, then we don't want the "-C" option.
+-	# -C means demangle to AIX nm, but means don't demangle with GNU nm
+-	# Also, AIX nm treats weak defined symbols like other global
+-	# defined symbols, whereas GNU nm marks them as "W".
++	# -C means demangle to GNU nm, but means don't demangle to AIX nm.
++	# Without the "-l" option, or with the "-B" option, AIX nm treats
++	# weak defined symbols like other global defined symbols, whereas
++	# GNU nm marks them as "W".
++	# While the 'weak' keyword is ignored in the Export File, we need
++	# it in the Import File for the 'aix-soname' feature, so we have
++	# to replace the "-B" option with "-P" for AIX nm.
+ 	if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
+-	  _LT_TAGVAR(export_symbols_cmds, $1)='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++	  _LT_TAGVAR(export_symbols_cmds, $1)='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && ([substr](\$ 3,1,1) != ".")) { if (\$ 2 == "W") { print \$ 3 " weak" } else { print \$ 3 } } }'\'' | sort -u > $export_symbols'
+ 	else
+-	  _LT_TAGVAR(export_symbols_cmds, $1)='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++	  _LT_TAGVAR(export_symbols_cmds, $1)='`func_echo_all $NM | $SED -e '\''s/B\([[^B]]*\)$/P\1/'\''` -PCpgl $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "L") || (\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) && ([substr](\$ 1,1,1) != ".")) { if ((\$ 2 == "W") || (\$ 2 == "V") || (\$ 2 == "Z")) { print \$ 1 " weak" } else { print \$ 1 } } }'\'' | sort -u > $export_symbols'
+ 	fi
+ 	aix_use_runtimelinking=no
+ 
+ 	# Test if we are trying to use run time linking or normal
+ 	# AIX style linking. If -brtl is somewhere in LDFLAGS, we
+-	# need to do runtime linking.
++	# have runtime linking enabled, and use it for executables.
++	# For shared libraries, we enable/disable runtime linking
++	# depending on the kind of the shared library created -
++	# when "with_aix_soname,aix_use_runtimelinking" is:
++	# "aix,no"   lib.a(lib.so.V) shared, rtl:no,  for executables
++	# "aix,yes"  lib.so          shared, rtl:yes, for executables
++	#            lib.a           static archive
++	# "both,no"  lib.so.V(shr.o) shared, rtl:yes
++	#            lib.a(lib.so.V) shared, rtl:no,  for executables
++	# "both,yes" lib.so.V(shr.o) shared, rtl:yes, for executables
++	#            lib.a(lib.so.V) shared, rtl:no
++	# "svr4,*"   lib.so.V(shr.o) shared, rtl:yes, for executables
++	#            lib.a           static archive
+ 	case $host_os in aix4.[[23]]|aix4.[[23]].*|aix[[5-9]]*)
+ 	  for ld_flag in $LDFLAGS; do
+-	  if (test $ld_flag = "-brtl" || test $ld_flag = "-Wl,-brtl"); then
++	  if (test x-brtl = "x$ld_flag" || test x-Wl,-brtl = "x$ld_flag"); then
+ 	    aix_use_runtimelinking=yes
+ 	    break
+ 	  fi
+ 	  done
++	  if test svr4,no = "$with_aix_soname,$aix_use_runtimelinking"; then
++	    # With aix-soname=svr4, we create the lib.so.V shared archives only,
++	    # so we don't have lib.a shared libs to link our executables.
++	    # We have to force runtime linking in this case.
++	    aix_use_runtimelinking=yes
++	    LDFLAGS="$LDFLAGS -Wl,-brtl"
++	  fi
+ 	  ;;
+ 	esac
+ 
+@@ -5014,13 +5447,21 @@ _LT_EOF
+       _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
+       _LT_TAGVAR(hardcode_libdir_separator, $1)=':'
+       _LT_TAGVAR(link_all_deplibs, $1)=yes
+-      _LT_TAGVAR(file_list_spec, $1)='${wl}-f,'
++      _LT_TAGVAR(file_list_spec, $1)='$wl-f,'
++      case $with_aix_soname,$aix_use_runtimelinking in
++      aix,*) ;; # traditional, no import file
++      svr4,* | *,yes) # use import file
++	# The Import File defines what to hardcode.
++	_LT_TAGVAR(hardcode_direct, $1)=no
++	_LT_TAGVAR(hardcode_direct_absolute, $1)=no
++	;;
++      esac
+ 
+-      if test "$GCC" = yes; then
++      if test yes = "$GCC"; then
+ 	case $host_os in aix4.[[012]]|aix4.[[012]].*)
+ 	# We only want to do this on AIX 4.2 and lower, the check
+ 	# below for broken collect2 doesn't work under 4.3+
+-	  collect2name=`${CC} -print-prog-name=collect2`
++	  collect2name=`$CC -print-prog-name=collect2`
+ 	  if test -f "$collect2name" &&
+ 	   strings "$collect2name" | $GREP resolve_lib_name >/dev/null
+ 	  then
+@@ -5039,61 +5480,80 @@ _LT_EOF
+ 	  ;;
+ 	esac
+ 	shared_flag='-shared'
+-	if test "$aix_use_runtimelinking" = yes; then
+-	  shared_flag="$shared_flag "'${wl}-G'
++	if test yes = "$aix_use_runtimelinking"; then
++	  shared_flag="$shared_flag "'$wl-G'
+ 	fi
++	# Need to ensure runtime linking is disabled for the traditional
++	# shared library, or the linker may eventually find shared libraries
++	# /with/ Import File - we do not want to mix them.
++	shared_flag_aix='-shared'
++	shared_flag_svr4='-shared $wl-G'
+       else
+ 	# not using gcc
+-	if test "$host_cpu" = ia64; then
++	if test ia64 = "$host_cpu"; then
+ 	# VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
+ 	# chokes on -Wl,-G. The following line is correct:
+ 	  shared_flag='-G'
+ 	else
+-	  if test "$aix_use_runtimelinking" = yes; then
+-	    shared_flag='${wl}-G'
++	  if test yes = "$aix_use_runtimelinking"; then
++	    shared_flag='$wl-G'
+ 	  else
+-	    shared_flag='${wl}-bM:SRE'
++	    shared_flag='$wl-bM:SRE'
+ 	  fi
++	  shared_flag_aix='$wl-bM:SRE'
++	  shared_flag_svr4='$wl-G'
+ 	fi
+       fi
+ 
+-      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-bexpall'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-bexpall'
+       # It seems that -bexpall does not export symbols beginning with
+       # underscore (_), so it is better to generate a list of symbols to export.
+       _LT_TAGVAR(always_export_symbols, $1)=yes
+-      if test "$aix_use_runtimelinking" = yes; then
++      if test aix,yes = "$with_aix_soname,$aix_use_runtimelinking"; then
+ 	# Warning - without using the other runtime loading flags (-brtl),
+ 	# -berok will link without error, but may produce a broken library.
+ 	_LT_TAGVAR(allow_undefined_flag, $1)='-berok'
+         # Determine the default libpath from the value encoded in an
+         # empty executable.
+         _LT_SYS_MODULE_PATH_AIX([$1])
+-        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
+-        _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-blibpath:$libdir:'"$aix_libpath"
++        _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $deplibs $wl'$no_entry_flag' $compiler_flags `if test -n "$allow_undefined_flag"; then func_echo_all "$wl$allow_undefined_flag"; else :; fi` $wl'$exp_sym_flag:\$export_symbols' '$shared_flag
+       else
+-	if test "$host_cpu" = ia64; then
+-	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R $libdir:/usr/lib:/lib'
++	if test ia64 = "$host_cpu"; then
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-R $libdir:/usr/lib:/lib'
+ 	  _LT_TAGVAR(allow_undefined_flag, $1)="-z nodefs"
+-	  _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
++	  _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\$wl$no_entry_flag"' $compiler_flags $wl$allow_undefined_flag '"\$wl$exp_sym_flag:\$export_symbols"
+ 	else
+ 	 # Determine the default libpath from the value encoded in an
+ 	 # empty executable.
+ 	 _LT_SYS_MODULE_PATH_AIX([$1])
+-	 _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++	 _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-blibpath:$libdir:'"$aix_libpath"
+ 	  # Warning - without using the other run time loading flags,
+ 	  # -berok will link without error, but may produce a broken library.
+-	  _LT_TAGVAR(no_undefined_flag, $1)=' ${wl}-bernotok'
+-	  _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-berok'
+-	  if test "$with_gnu_ld" = yes; then
++	  _LT_TAGVAR(no_undefined_flag, $1)=' $wl-bernotok'
++	  _LT_TAGVAR(allow_undefined_flag, $1)=' $wl-berok'
++	  if test yes = "$with_gnu_ld"; then
+ 	    # We only use this code for GNU lds that support --whole-archive.
+-	    _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	  else
+ 	    # Exported symbols can be pulled into shared objects from archives
+ 	    _LT_TAGVAR(whole_archive_flag_spec, $1)='$convenience'
+ 	  fi
+ 	  _LT_TAGVAR(archive_cmds_need_lc, $1)=yes
+-	  # This is similar to how AIX traditionally builds its shared libraries.
+-	  _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$RM -r $output_objdir/$realname.d~$MKDIR $output_objdir/$realname.d'
++	  # -brtl affects multiple linker settings, -berok does not and is overridden later
++	  compiler_flags_filtered='`func_echo_all "$compiler_flags " | $SED -e "s%-brtl\\([[, ]]\\)%-berok\\1%g"`'
++	  if test svr4 != "$with_aix_soname"; then
++	    # This is similar to how AIX traditionally builds its shared libraries.
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$CC '$shared_flag_aix' -o $output_objdir/$realname.d/$soname $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$realname.d/$soname'
++	  fi
++	  if test aix != "$with_aix_soname"; then
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$CC '$shared_flag_svr4' -o $output_objdir/$realname.d/$shared_archive_member_spec.o $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$STRIP -e $output_objdir/$realname.d/$shared_archive_member_spec.o~( func_echo_all "#! $soname($shared_archive_member_spec.o)"; if test shr_64 = "$shared_archive_member_spec"; then func_echo_all "# 64"; else func_echo_all "# 32"; fi; cat $export_symbols ) > $output_objdir/$realname.d/$shared_archive_member_spec.imp~$AR $AR_FLAGS $output_objdir/$soname $output_objdir/$realname.d/$shared_archive_member_spec.o $output_objdir/$realname.d/$shared_archive_member_spec.imp'
++	  else
++	    # used by -dlpreopen to get the symbols
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$MV  $output_objdir/$realname.d/$soname $output_objdir'
++	  fi
++	  _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$RM -r $output_objdir/$realname.d'
+ 	fi
+       fi
+       ;;
+@@ -5102,7 +5562,7 @@ _LT_EOF
+       case $host_cpu in
+       powerpc)
+             # see comment about AmigaOS4 .so support
+-            _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++            _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+             _LT_TAGVAR(archive_expsym_cmds, $1)=''
+         ;;
+       m68k)
+@@ -5132,16 +5592,17 @@ _LT_EOF
+ 	# Tell ltmain to make .lib files, not .a files.
+ 	libext=lib
+ 	# Tell ltmain to make .dll files, not .so files.
+-	shrext_cmds=".dll"
++	shrext_cmds=.dll
+ 	# FIXME: Setting linknames here is a bad hack.
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	    sed -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
+-	  else
+-	    sed -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
+-	  fi~
+-	  $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
+-	  linknames='
++	_LT_TAGVAR(archive_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~linknames='
++	_LT_TAGVAR(archive_expsym_cmds, $1)='if _LT_DLL_DEF_P([$export_symbols]); then
++            cp "$export_symbols" "$output_objdir/$soname.def";
++            echo "$tool_output_objdir$soname.def" > "$output_objdir/$soname.exp";
++          else
++            $SED -e '\''s/^/-link -EXPORT:/'\'' < $export_symbols > $output_objdir/$soname.exp;
++          fi~
++          $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
++          linknames='
+ 	# The linker will not automatically build a static lib if we build a DLL.
+ 	# _LT_TAGVAR(old_archive_from_new_cmds, $1)='true'
+ 	_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
+@@ -5150,18 +5611,18 @@ _LT_EOF
+ 	# Don't use ranlib
+ 	_LT_TAGVAR(old_postinstall_cmds, $1)='chmod 644 $oldlib'
+ 	_LT_TAGVAR(postlink_cmds, $1)='lt_outputfile="@OUTPUT@"~
+-	  lt_tool_outputfile="@TOOL_OUTPUT@"~
+-	  case $lt_outputfile in
+-	    *.exe|*.EXE) ;;
+-	    *)
+-	      lt_outputfile="$lt_outputfile.exe"
+-	      lt_tool_outputfile="$lt_tool_outputfile.exe"
+-	      ;;
+-	  esac~
+-	  if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
+-	    $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
+-	    $RM "$lt_outputfile.manifest";
+-	  fi'
++          lt_tool_outputfile="@TOOL_OUTPUT@"~
++          case $lt_outputfile in
++            *.exe|*.EXE) ;;
++            *)
++              lt_outputfile=$lt_outputfile.exe
++              lt_tool_outputfile=$lt_tool_outputfile.exe
++              ;;
++          esac~
++          if test : != "$MANIFEST_TOOL" && test -f "$lt_outputfile.manifest"; then
++            $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
++            $RM "$lt_outputfile.manifest";
++          fi'
+ 	;;
+       *)
+ 	# Assume MSVC wrapper
+@@ -5170,7 +5631,7 @@ _LT_EOF
+ 	# Tell ltmain to make .lib files, not .a files.
+ 	libext=lib
+ 	# Tell ltmain to make .dll files, not .so files.
+-	shrext_cmds=".dll"
++	shrext_cmds=.dll
+ 	# FIXME: Setting linknames here is a bad hack.
+ 	_LT_TAGVAR(archive_cmds, $1)='$CC -o $lib $libobjs $compiler_flags `func_echo_all "$deplibs" | $SED '\''s/ -lc$//'\''` -link -dll~linknames='
+ 	# The linker will automatically build a .lib file if we build a DLL.
+@@ -5220,33 +5681,33 @@ _LT_EOF
+       ;;
+ 
+     hpux9*)
+-      if test "$GCC" = yes; then
+-	_LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -shared $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $libobjs $deplibs $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++      if test yes = "$GCC"; then
++	_LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -shared $pic_flag $wl+b $wl$install_libdir -o $output_objdir/$soname $libobjs $deplibs $compiler_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+       else
+-	_LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$LD -b +b $install_libdir -o $output_objdir/$soname $libobjs $deplibs $linker_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$LD -b +b $install_libdir -o $output_objdir/$soname $libobjs $deplibs $linker_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+       fi
+-      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl+b $wl$libdir'
+       _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+       _LT_TAGVAR(hardcode_direct, $1)=yes
+ 
+       # hardcode_minus_L: Not really in the search PATH,
+       # but as the default location of the library.
+       _LT_TAGVAR(hardcode_minus_L, $1)=yes
+-      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+       ;;
+ 
+     hpux10*)
+-      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes,no = "$GCC,$with_gnu_ld"; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+       else
+ 	_LT_TAGVAR(archive_cmds, $1)='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'
+       fi
+-      if test "$with_gnu_ld" = no; then
+-	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++      if test no = "$with_gnu_ld"; then
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl+b $wl$libdir'
+ 	_LT_TAGVAR(hardcode_libdir_separator, $1)=:
+ 	_LT_TAGVAR(hardcode_direct, $1)=yes
+ 	_LT_TAGVAR(hardcode_direct_absolute, $1)=yes
+-	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+ 	# hardcode_minus_L: Not really in the search PATH,
+ 	# but as the default location of the library.
+ 	_LT_TAGVAR(hardcode_minus_L, $1)=yes
+@@ -5254,25 +5715,25 @@ _LT_EOF
+       ;;
+ 
+     hpux11*)
+-      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
++      if test yes,no = "$GCC,$with_gnu_ld"; then
+ 	case $host_cpu in
+ 	hppa*64*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $wl+h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	ia64*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $wl+h $wl$soname $wl+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	esac
+       else
+ 	case $host_cpu in
+ 	hppa*64*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	ia64*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname $wl+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	*)
+ 	m4_if($1, [], [
+@@ -5280,14 +5741,14 @@ _LT_EOF
+ 	  # (HP92453-01 A.11.01.20 doesn't, HP92453-01 B.11.X.35175-35176.GP does)
+ 	  _LT_LINKER_OPTION([if $CC understands -b],
+ 	    _LT_TAGVAR(lt_cv_prog_compiler__b, $1), [-b],
+-	    [_LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'],
++	    [_LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'],
+ 	    [_LT_TAGVAR(archive_cmds, $1)='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'])],
+-	  [_LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'])
++	  [_LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'])
+ 	  ;;
+ 	esac
+       fi
+-      if test "$with_gnu_ld" = no; then
+-	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++      if test no = "$with_gnu_ld"; then
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl+b $wl$libdir'
+ 	_LT_TAGVAR(hardcode_libdir_separator, $1)=:
+ 
+ 	case $host_cpu in
+@@ -5298,7 +5759,7 @@ _LT_EOF
+ 	*)
+ 	  _LT_TAGVAR(hardcode_direct, $1)=yes
+ 	  _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
+-	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+ 
+ 	  # hardcode_minus_L: Not really in the search PATH,
+ 	  # but as the default location of the library.
+@@ -5309,16 +5770,16 @@ _LT_EOF
+       ;;
+ 
+     irix5* | irix6* | nonstopux*)
+-      if test "$GCC" = yes; then
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++      if test yes = "$GCC"; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 	# Try to use the -exported_symbol ld option, if it does not
+ 	# work, assume that -exports_file does not work either and
+ 	# implicitly export all symbols.
+ 	# This should be the same for all languages, so no per-tag cache variable.
+ 	AC_CACHE_CHECK([whether the $host_os linker accepts -exported_symbol],
+ 	  [lt_cv_irix_exported_symbol],
+-	  [save_LDFLAGS="$LDFLAGS"
+-	   LDFLAGS="$LDFLAGS -shared ${wl}-exported_symbol ${wl}foo ${wl}-update_registry ${wl}/dev/null"
++	  [save_LDFLAGS=$LDFLAGS
++	   LDFLAGS="$LDFLAGS -shared $wl-exported_symbol ${wl}foo $wl-update_registry $wl/dev/null"
+ 	   AC_LINK_IFELSE(
+ 	     [AC_LANG_SOURCE(
+ 	        [AC_LANG_CASE([C], [[int foo (void) { return 0; }]],
+@@ -5331,21 +5792,31 @@ _LT_EOF
+       end]])])],
+ 	      [lt_cv_irix_exported_symbol=yes],
+ 	      [lt_cv_irix_exported_symbol=no])
+-           LDFLAGS="$save_LDFLAGS"])
+-	if test "$lt_cv_irix_exported_symbol" = yes; then
+-          _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations ${wl}-exports_file ${wl}$export_symbols -o $lib'
++           LDFLAGS=$save_LDFLAGS])
++	if test yes = "$lt_cv_irix_exported_symbol"; then
++          _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations $wl-exports_file $wl$export_symbols -o $lib'
+ 	fi
+       else
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -exports_file $export_symbols -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -exports_file $export_symbols -o $lib'
+       fi
+       _LT_TAGVAR(archive_cmds_need_lc, $1)='no'
+-      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+       _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+       _LT_TAGVAR(inherit_rpath, $1)=yes
+       _LT_TAGVAR(link_all_deplibs, $1)=yes
+       ;;
+ 
++    linux*)
++      case $cc_basename in
++      tcc*)
++	# Fabrice Bellard et al's Tiny C Compiler
++	_LT_TAGVAR(ld_shlibs, $1)=yes
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++	;;
++      esac
++      ;;
++
+     netbsd*)
+       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+ 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
+@@ -5360,7 +5831,7 @@ _LT_EOF
+     newsos6)
+       _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+       _LT_TAGVAR(hardcode_direct, $1)=yes
+-      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+       _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+       _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+       ;;
+@@ -5368,27 +5839,19 @@ _LT_EOF
+     *nto* | *qnx*)
+       ;;
+ 
+-    openbsd*)
++    openbsd* | bitrig*)
+       if test -f /usr/libexec/ld.so; then
+ 	_LT_TAGVAR(hardcode_direct, $1)=yes
+ 	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+ 	_LT_TAGVAR(hardcode_direct_absolute, $1)=yes
+-	if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++	if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`"; then
+ 	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags ${wl}-retain-symbols-file,$export_symbols'
+-	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags $wl-retain-symbols-file,$export_symbols'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+ 	else
+-	  case $host_os in
+-	   openbsd[[01]].* | openbsd2.[[0-7]] | openbsd2.[[0-7]].*)
+-	     _LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
+-	     _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
+-	     ;;
+-	   *)
+-	     _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-	     _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-	     ;;
+-	  esac
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
+ 	fi
+       else
+ 	_LT_TAGVAR(ld_shlibs, $1)=no
+@@ -5399,33 +5862,54 @@ _LT_EOF
+       _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
+       _LT_TAGVAR(hardcode_minus_L, $1)=yes
+       _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
+-      _LT_TAGVAR(archive_cmds, $1)='$ECHO "LIBRARY $libname INITINSTANCE" > $output_objdir/$libname.def~$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~echo DATA >> $output_objdir/$libname.def~echo " SINGLE NONSHARED" >> $output_objdir/$libname.def~echo EXPORTS >> $output_objdir/$libname.def~emxexp $libobjs >> $output_objdir/$libname.def~$CC -Zdll -Zcrtdll -o $lib $libobjs $deplibs $compiler_flags $output_objdir/$libname.def'
+-      _LT_TAGVAR(old_archive_from_new_cmds, $1)='emximp -o $output_objdir/$libname.a $output_objdir/$libname.def'
++      shrext_cmds=.dll
++      _LT_TAGVAR(archive_cmds, $1)='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	emxexp $libobjs | $SED /"_DLL_InitTerm"/d >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      _LT_TAGVAR(archive_expsym_cmds, $1)='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	$ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	$ECHO EXPORTS >> $output_objdir/$libname.def~
++	prefix_cmds="$SED"~
++	if test EXPORTS = "`$SED 1q $export_symbols`"; then
++	  prefix_cmds="$prefix_cmds -e 1d";
++	fi~
++	prefix_cmds="$prefix_cmds -e \"s/^\(.*\)$/_\1/g\""~
++	cat $export_symbols | $prefix_cmds >> $output_objdir/$libname.def~
++	$CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	emximp -o $lib $output_objdir/$libname.def'
++      _LT_TAGVAR(old_archive_From_new_cmds, $1)='emximp -o $output_objdir/${libname}_dll.a $output_objdir/$libname.def'
++      _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++      _LT_TAGVAR(file_list_spec, $1)='@'
+       ;;
+ 
+     osf3*)
+-      if test "$GCC" = yes; then
+-	_LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++      if test yes = "$GCC"; then
++	_LT_TAGVAR(allow_undefined_flag, $1)=' $wl-expect_unresolved $wl\*'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared$allow_undefined_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+       else
+ 	_LT_TAGVAR(allow_undefined_flag, $1)=' -expect_unresolved \*'
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared$allow_undefined_flag $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+       fi
+       _LT_TAGVAR(archive_cmds_need_lc, $1)='no'
+-      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+       _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+       ;;
+ 
+     osf4* | osf5*)	# as osf3* with the addition of -msym flag
+-      if test "$GCC" = yes; then
+-	_LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $pic_flag $libobjs $deplibs $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
+-	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      if test yes = "$GCC"; then
++	_LT_TAGVAR(allow_undefined_flag, $1)=' $wl-expect_unresolved $wl\*'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared$allow_undefined_flag $pic_flag $libobjs $deplibs $compiler_flags $wl-msym $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+       else
+ 	_LT_TAGVAR(allow_undefined_flag, $1)=' -expect_unresolved \*'
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared$allow_undefined_flag $libobjs $deplibs $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+ 	_LT_TAGVAR(archive_expsym_cmds, $1)='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done; printf "%s\\n" "-hidden">> $lib.exp~
+-	$CC -shared${allow_undefined_flag} ${wl}-input ${wl}$lib.exp $compiler_flags $libobjs $deplibs -soname $soname `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~$RM $lib.exp'
++          $CC -shared$allow_undefined_flag $wl-input $wl$lib.exp $compiler_flags $libobjs $deplibs -soname $soname `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib~$RM $lib.exp'
+ 
+ 	# Both c and cxx compiler support -rpath directly
+ 	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-rpath $libdir'
+@@ -5436,24 +5920,24 @@ _LT_EOF
+ 
+     solaris*)
+       _LT_TAGVAR(no_undefined_flag, $1)=' -z defs'
+-      if test "$GCC" = yes; then
+-	wlarc='${wl}'
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes = "$GCC"; then
++	wlarc='$wl'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $wl-z ${wl}text $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	_LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-M ${wl}$lib.exp ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++          $CC -shared $pic_flag $wl-z ${wl}text $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+       else
+ 	case `$CC -V 2>&1` in
+ 	*"Compilers 5.0"*)
+ 	  wlarc=''
+-	  _LT_TAGVAR(archive_cmds, $1)='$LD -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $linker_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -G$allow_undefined_flag -h $soname -o $lib $libobjs $deplibs $linker_flags'
+ 	  _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $LD -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $linker_flags~$RM $lib.exp'
++            $LD -G$allow_undefined_flag -M $lib.exp -h $soname -o $lib $libobjs $deplibs $linker_flags~$RM $lib.exp'
+ 	  ;;
+ 	*)
+-	  wlarc='${wl}'
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $compiler_flags'
++	  wlarc='$wl'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -G$allow_undefined_flag -h $soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $CC -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++            $CC -G$allow_undefined_flag -M $lib.exp -h $soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+ 	  ;;
+ 	esac
+       fi
+@@ -5463,11 +5947,11 @@ _LT_EOF
+       solaris2.[[0-5]] | solaris2.[[0-5]].*) ;;
+       *)
+ 	# The compiler driver will combine and reorder linker options,
+-	# but understands `-z linker_flag'.  GCC discards it without `$wl',
++	# but understands '-z linker_flag'.  GCC discards it without '$wl',
+ 	# but is careful enough not to reorder.
+ 	# Supported since Solaris 2.6 (maybe 2.5.1?)
+-	if test "$GCC" = yes; then
+-	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
++	if test yes = "$GCC"; then
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl-z ${wl}allextract$convenience $wl-z ${wl}defaultextract'
+ 	else
+ 	  _LT_TAGVAR(whole_archive_flag_spec, $1)='-z allextract$convenience -z defaultextract'
+ 	fi
+@@ -5477,10 +5961,10 @@ _LT_EOF
+       ;;
+ 
+     sunos4*)
+-      if test "x$host_vendor" = xsequent; then
++      if test sequent = "$host_vendor"; then
+ 	# Use $CC to link under sequent, because it throws in some extra .o
+ 	# files that make .init and .fini sections work.
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h $soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -G $wl-h $soname -o $lib $libobjs $deplibs $compiler_flags'
+       else
+ 	_LT_TAGVAR(archive_cmds, $1)='$LD -assert pure-text -Bstatic -o $lib $libobjs $deplibs $linker_flags'
+       fi
+@@ -5529,43 +6013,43 @@ _LT_EOF
+       ;;
+ 
+     sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[[01]].[[10]]* | unixware7* | sco3.2v5.0.[[024]]*)
+-      _LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
++      _LT_TAGVAR(no_undefined_flag, $1)='$wl-z,text'
+       _LT_TAGVAR(archive_cmds_need_lc, $1)=no
+       _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+       runpath_var='LD_RUN_PATH'
+ 
+-      if test "$GCC" = yes; then
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes = "$GCC"; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       else
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       fi
+       ;;
+ 
+     sysv5* | sco3.2v5* | sco5v6*)
+-      # Note: We can NOT use -z defs as we might desire, because we do not
++      # Note: We CANNOT use -z defs as we might desire, because we do not
+       # link with -lc, and that would cause any symbols used from libc to
+       # always be unresolved, which means just about no library would
+       # ever link correctly.  If we're not using GNU ld we use -z text
+       # though, which does catch some bad symbols but isn't as heavy-handed
+       # as -z defs.
+-      _LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
+-      _LT_TAGVAR(allow_undefined_flag, $1)='${wl}-z,nodefs'
++      _LT_TAGVAR(no_undefined_flag, $1)='$wl-z,text'
++      _LT_TAGVAR(allow_undefined_flag, $1)='$wl-z,nodefs'
+       _LT_TAGVAR(archive_cmds_need_lc, $1)=no
+       _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+-      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R,$libdir'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-R,$libdir'
+       _LT_TAGVAR(hardcode_libdir_separator, $1)=':'
+       _LT_TAGVAR(link_all_deplibs, $1)=yes
+-      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-Bexport'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-Bexport'
+       runpath_var='LD_RUN_PATH'
+ 
+-      if test "$GCC" = yes; then
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      if test yes = "$GCC"; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       else
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+       fi
+       ;;
+ 
+@@ -5580,17 +6064,17 @@ _LT_EOF
+       ;;
+     esac
+ 
+-    if test x$host_vendor = xsni; then
++    if test sni = "$host_vendor"; then
+       case $host in
+       sysv4 | sysv4.2uw2* | sysv4.3* | sysv5*)
+-	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-Blargedynsym'
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-Blargedynsym'
+ 	;;
+       esac
+     fi
+   fi
+ ])
+ AC_MSG_RESULT([$_LT_TAGVAR(ld_shlibs, $1)])
+-test "$_LT_TAGVAR(ld_shlibs, $1)" = no && can_build_shared=no
++test no = "$_LT_TAGVAR(ld_shlibs, $1)" && can_build_shared=no
+ 
+ _LT_TAGVAR(with_gnu_ld, $1)=$with_gnu_ld
+ 
+@@ -5607,7 +6091,7 @@ x|xyes)
+   # Assume -lc should be added
+   _LT_TAGVAR(archive_cmds_need_lc, $1)=yes
+ 
+-  if test "$enable_shared" = yes && test "$GCC" = yes; then
++  if test yes,yes = "$GCC,$enable_shared"; then
+     case $_LT_TAGVAR(archive_cmds, $1) in
+     *'~'*)
+       # FIXME: we may have to deal with multi-command sequences.
+@@ -5687,12 +6171,12 @@ _LT_TAGDECL([], [hardcode_libdir_flag_spec], [1],
+ _LT_TAGDECL([], [hardcode_libdir_separator], [1],
+     [Whether we need a single "-rpath" flag with a separated argument])
+ _LT_TAGDECL([], [hardcode_direct], [0],
+-    [Set to "yes" if using DIR/libNAME${shared_ext} during linking hardcodes
++    [Set to "yes" if using DIR/libNAME$shared_ext during linking hardcodes
+     DIR into the resulting binary])
+ _LT_TAGDECL([], [hardcode_direct_absolute], [0],
+-    [Set to "yes" if using DIR/libNAME${shared_ext} during linking hardcodes
++    [Set to "yes" if using DIR/libNAME$shared_ext during linking hardcodes
+     DIR into the resulting binary and the resulting library dependency is
+-    "absolute", i.e impossible to change by setting ${shlibpath_var} if the
++    "absolute", i.e impossible to change by setting $shlibpath_var if the
+     library is relocated])
+ _LT_TAGDECL([], [hardcode_minus_L], [0],
+     [Set to "yes" if using the -LDIR flag during linking hardcodes DIR
+@@ -5733,10 +6217,10 @@ dnl    [Compiler flag to generate thread safe objects])
+ # ------------------------
+ # Ensure that the configuration variables for a C compiler are suitably
+ # defined.  These variables are subsequently used by _LT_CONFIG to write
+-# the compiler configuration to `libtool'.
++# the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_C_CONFIG],
+ [m4_require([_LT_DECL_EGREP])dnl
+-lt_save_CC="$CC"
++lt_save_CC=$CC
+ AC_LANG_PUSH(C)
+ 
+ # Source file extension for C test sources.
+@@ -5776,18 +6260,18 @@ if test -n "$compiler"; then
+   LT_SYS_DLOPEN_SELF
+   _LT_CMD_STRIPLIB
+ 
+-  # Report which library types will actually be built
++  # Report what library types will actually be built
+   AC_MSG_CHECKING([if libtool supports shared libraries])
+   AC_MSG_RESULT([$can_build_shared])
+ 
+   AC_MSG_CHECKING([whether to build shared libraries])
+-  test "$can_build_shared" = "no" && enable_shared=no
++  test no = "$can_build_shared" && enable_shared=no
+ 
+   # On AIX, shared libraries and static libraries use the same namespace, and
+   # are all built from PIC.
+   case $host_os in
+   aix3*)
+-    test "$enable_shared" = yes && enable_static=no
++    test yes = "$enable_shared" && enable_static=no
+     if test -n "$RANLIB"; then
+       archive_cmds="$archive_cmds~\$RANLIB \$lib"
+       postinstall_cmds='$RANLIB $lib'
+@@ -5795,8 +6279,12 @@ if test -n "$compiler"; then
+     ;;
+ 
+   aix[[4-9]]*)
+-    if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
+-      test "$enable_shared" = yes && enable_static=no
++    if test ia64 != "$host_cpu"; then
++      case $enable_shared,$with_aix_soname,$aix_use_runtimelinking in
++      yes,aix,yes) ;;			# shared object as lib.so file only
++      yes,svr4,*) ;;			# shared object as lib.so archive member only
++      yes,*) enable_static=no ;;	# shared object in lib.a archive as well
++      esac
+     fi
+     ;;
+   esac
+@@ -5804,13 +6292,13 @@ if test -n "$compiler"; then
+ 
+   AC_MSG_CHECKING([whether to build static libraries])
+   # Make sure either enable_shared or enable_static is yes.
+-  test "$enable_shared" = yes || enable_static=yes
++  test yes = "$enable_shared" || enable_static=yes
+   AC_MSG_RESULT([$enable_static])
+ 
+   _LT_CONFIG($1)
+ fi
+ AC_LANG_POP
+-CC="$lt_save_CC"
++CC=$lt_save_CC
+ ])# _LT_LANG_C_CONFIG
+ 
+ 
+@@ -5818,14 +6306,14 @@ CC="$lt_save_CC"
+ # --------------------------
+ # Ensure that the configuration variables for a C++ compiler are suitably
+ # defined.  These variables are subsequently used by _LT_CONFIG to write
+-# the compiler configuration to `libtool'.
++# the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_CXX_CONFIG],
+ [m4_require([_LT_FILEUTILS_DEFAULTS])dnl
+ m4_require([_LT_DECL_EGREP])dnl
+ m4_require([_LT_PATH_MANIFEST_TOOL])dnl
+-if test -n "$CXX" && ( test "X$CXX" != "Xno" &&
+-    ( (test "X$CXX" = "Xg++" && `g++ -v >/dev/null 2>&1` ) ||
+-    (test "X$CXX" != "Xg++"))) ; then
++if test -n "$CXX" && ( test no != "$CXX" &&
++    ( (test g++ = "$CXX" && `g++ -v >/dev/null 2>&1` ) ||
++    (test g++ != "$CXX"))); then
+   AC_PROG_CXXCPP
+ else
+   _lt_caught_CXX_error=yes
+@@ -5867,7 +6355,7 @@ _LT_TAGVAR(objext, $1)=$objext
+ # the CXX compiler isn't working.  Some variables (like enable_shared)
+ # are currently assumed to apply to all compilers on this platform,
+ # and will be corrupted by setting them based on a non-working compiler.
+-if test "$_lt_caught_CXX_error" != yes; then
++if test yes != "$_lt_caught_CXX_error"; then
+   # Code to be used in simple compile tests
+   lt_simple_compile_test_code="int some_variable = 0;"
+ 
+@@ -5909,35 +6397,35 @@ if test "$_lt_caught_CXX_error" != yes; then
+   if test -n "$compiler"; then
+     # We don't want -fno-exception when compiling C++ code, so set the
+     # no_builtin_flag separately
+-    if test "$GXX" = yes; then
++    if test yes = "$GXX"; then
+       _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=' -fno-builtin'
+     else
+       _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=
+     fi
+ 
+-    if test "$GXX" = yes; then
++    if test yes = "$GXX"; then
+       # Set up default GNU C++ configuration
+ 
+       LT_PATH_LD
+ 
+       # Check if GNU C++ uses GNU ld as the underlying linker, since the
+       # archiving commands below assume that GNU ld is being used.
+-      if test "$with_gnu_ld" = yes; then
+-        _LT_TAGVAR(archive_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-        _LT_TAGVAR(archive_expsym_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++      if test yes = "$with_gnu_ld"; then
++        _LT_TAGVAR(archive_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++        _LT_TAGVAR(archive_expsym_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 
+-        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
+-        _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++        _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
+ 
+         # If archive_cmds runs LD, not CC, wlarc should be empty
+         # XXX I think wlarc can be eliminated in ltcf-cxx, but I need to
+         #     investigate it a little bit more. (MM)
+-        wlarc='${wl}'
++        wlarc='$wl'
+ 
+         # ancient GNU ld didn't support --whole-archive et. al.
+         if eval "`$CC -print-prog-name=ld` --help 2>&1" |
+ 	  $GREP 'no-whole-archive' > /dev/null; then
+-          _LT_TAGVAR(whole_archive_flag_spec, $1)="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++          _LT_TAGVAR(whole_archive_flag_spec, $1)=$wlarc'--whole-archive$convenience '$wlarc'--no-whole-archive'
+         else
+           _LT_TAGVAR(whole_archive_flag_spec, $1)=
+         fi
+@@ -5973,18 +6461,30 @@ if test "$_lt_caught_CXX_error" != yes; then
+         _LT_TAGVAR(ld_shlibs, $1)=no
+         ;;
+       aix[[4-9]]*)
+-        if test "$host_cpu" = ia64; then
++        if test ia64 = "$host_cpu"; then
+           # On IA64, the linker does run time linking by default, so we don't
+           # have to do anything special.
+           aix_use_runtimelinking=no
+           exp_sym_flag='-Bexport'
+-          no_entry_flag=""
++          no_entry_flag=
+         else
+           aix_use_runtimelinking=no
+ 
+           # Test if we are trying to use run time linking or normal
+           # AIX style linking. If -brtl is somewhere in LDFLAGS, we
+-          # need to do runtime linking.
++          # have runtime linking enabled, and use it for executables.
++          # For shared libraries, we enable/disable runtime linking
++          # depending on the kind of the shared library created -
++          # when "with_aix_soname,aix_use_runtimelinking" is:
++          # "aix,no"   lib.a(lib.so.V) shared, rtl:no,  for executables
++          # "aix,yes"  lib.so          shared, rtl:yes, for executables
++          #            lib.a           static archive
++          # "both,no"  lib.so.V(shr.o) shared, rtl:yes
++          #            lib.a(lib.so.V) shared, rtl:no,  for executables
++          # "both,yes" lib.so.V(shr.o) shared, rtl:yes, for executables
++          #            lib.a(lib.so.V) shared, rtl:no
++          # "svr4,*"   lib.so.V(shr.o) shared, rtl:yes, for executables
++          #            lib.a           static archive
+           case $host_os in aix4.[[23]]|aix4.[[23]].*|aix[[5-9]]*)
+ 	    for ld_flag in $LDFLAGS; do
+ 	      case $ld_flag in
+@@ -5994,6 +6494,13 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	        ;;
+ 	      esac
+ 	    done
++	    if test svr4,no = "$with_aix_soname,$aix_use_runtimelinking"; then
++	      # With aix-soname=svr4, we create the lib.so.V shared archives only,
++	      # so we don't have lib.a shared libs to link our executables.
++	      # We have to force runtime linking in this case.
++	      aix_use_runtimelinking=yes
++	      LDFLAGS="$LDFLAGS -Wl,-brtl"
++	    fi
+ 	    ;;
+           esac
+ 
+@@ -6012,13 +6519,21 @@ if test "$_lt_caught_CXX_error" != yes; then
+         _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
+         _LT_TAGVAR(hardcode_libdir_separator, $1)=':'
+         _LT_TAGVAR(link_all_deplibs, $1)=yes
+-        _LT_TAGVAR(file_list_spec, $1)='${wl}-f,'
++        _LT_TAGVAR(file_list_spec, $1)='$wl-f,'
++        case $with_aix_soname,$aix_use_runtimelinking in
++        aix,*) ;;	# no import file
++        svr4,* | *,yes) # use import file
++          # The Import File defines what to hardcode.
++          _LT_TAGVAR(hardcode_direct, $1)=no
++          _LT_TAGVAR(hardcode_direct_absolute, $1)=no
++          ;;
++        esac
+ 
+-        if test "$GXX" = yes; then
++        if test yes = "$GXX"; then
+           case $host_os in aix4.[[012]]|aix4.[[012]].*)
+           # We only want to do this on AIX 4.2 and lower, the check
+           # below for broken collect2 doesn't work under 4.3+
+-	  collect2name=`${CC} -print-prog-name=collect2`
++	  collect2name=`$CC -print-prog-name=collect2`
+ 	  if test -f "$collect2name" &&
+ 	     strings "$collect2name" | $GREP resolve_lib_name >/dev/null
+ 	  then
+@@ -6036,64 +6551,84 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	  fi
+           esac
+           shared_flag='-shared'
+-	  if test "$aix_use_runtimelinking" = yes; then
+-	    shared_flag="$shared_flag "'${wl}-G'
++	  if test yes = "$aix_use_runtimelinking"; then
++	    shared_flag=$shared_flag' $wl-G'
+ 	  fi
++	  # Need to ensure runtime linking is disabled for the traditional
++	  # shared library, or the linker may eventually find shared libraries
++	  # /with/ Import File - we do not want to mix them.
++	  shared_flag_aix='-shared'
++	  shared_flag_svr4='-shared $wl-G'
+         else
+           # not using gcc
+-          if test "$host_cpu" = ia64; then
++          if test ia64 = "$host_cpu"; then
+ 	  # VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
+ 	  # chokes on -Wl,-G. The following line is correct:
+ 	  shared_flag='-G'
+           else
+-	    if test "$aix_use_runtimelinking" = yes; then
+-	      shared_flag='${wl}-G'
++	    if test yes = "$aix_use_runtimelinking"; then
++	      shared_flag='$wl-G'
+ 	    else
+-	      shared_flag='${wl}-bM:SRE'
++	      shared_flag='$wl-bM:SRE'
+ 	    fi
++	    shared_flag_aix='$wl-bM:SRE'
++	    shared_flag_svr4='$wl-G'
+           fi
+         fi
+ 
+-        _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-bexpall'
++        _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-bexpall'
+         # It seems that -bexpall does not export symbols beginning with
+         # underscore (_), so it is better to generate a list of symbols to
+ 	# export.
+         _LT_TAGVAR(always_export_symbols, $1)=yes
+-        if test "$aix_use_runtimelinking" = yes; then
++	if test aix,yes = "$with_aix_soname,$aix_use_runtimelinking"; then
+           # Warning - without using the other runtime loading flags (-brtl),
+           # -berok will link without error, but may produce a broken library.
+-          _LT_TAGVAR(allow_undefined_flag, $1)='-berok'
++          # The "-G" linker flag allows undefined symbols.
++          _LT_TAGVAR(no_undefined_flag, $1)='-bernotok'
+           # Determine the default libpath from the value encoded in an empty
+           # executable.
+           _LT_SYS_MODULE_PATH_AIX([$1])
+-          _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++          _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-blibpath:$libdir:'"$aix_libpath"
+ 
+-          _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
++          _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $deplibs $wl'$no_entry_flag' $compiler_flags `if test -n "$allow_undefined_flag"; then func_echo_all "$wl$allow_undefined_flag"; else :; fi` $wl'$exp_sym_flag:\$export_symbols' '$shared_flag
+         else
+-          if test "$host_cpu" = ia64; then
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R $libdir:/usr/lib:/lib'
++          if test ia64 = "$host_cpu"; then
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-R $libdir:/usr/lib:/lib'
+ 	    _LT_TAGVAR(allow_undefined_flag, $1)="-z nodefs"
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\$wl$no_entry_flag"' $compiler_flags $wl$allow_undefined_flag '"\$wl$exp_sym_flag:\$export_symbols"
+           else
+ 	    # Determine the default libpath from the value encoded in an
+ 	    # empty executable.
+ 	    _LT_SYS_MODULE_PATH_AIX([$1])
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-blibpath:$libdir:'"$aix_libpath"
+ 	    # Warning - without using the other run time loading flags,
+ 	    # -berok will link without error, but may produce a broken library.
+-	    _LT_TAGVAR(no_undefined_flag, $1)=' ${wl}-bernotok'
+-	    _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-berok'
+-	    if test "$with_gnu_ld" = yes; then
++	    _LT_TAGVAR(no_undefined_flag, $1)=' $wl-bernotok'
++	    _LT_TAGVAR(allow_undefined_flag, $1)=' $wl-berok'
++	    if test yes = "$with_gnu_ld"; then
+ 	      # We only use this code for GNU lds that support --whole-archive.
+-	      _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	      _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	    else
+ 	      # Exported symbols can be pulled into shared objects from archives
+ 	      _LT_TAGVAR(whole_archive_flag_spec, $1)='$convenience'
+ 	    fi
+ 	    _LT_TAGVAR(archive_cmds_need_lc, $1)=yes
+-	    # This is similar to how AIX traditionally builds its shared
+-	    # libraries.
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$RM -r $output_objdir/$realname.d~$MKDIR $output_objdir/$realname.d'
++	    # -brtl affects multiple linker settings, -berok does not and is overridden later
++	    compiler_flags_filtered='`func_echo_all "$compiler_flags " | $SED -e "s%-brtl\\([[, ]]\\)%-berok\\1%g"`'
++	    if test svr4 != "$with_aix_soname"; then
++	      # This is similar to how AIX traditionally builds its shared
++	      # libraries. Need -bnortl late, we may have -brtl in LDFLAGS.
++	      _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$CC '$shared_flag_aix' -o $output_objdir/$realname.d/$soname $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$realname.d/$soname'
++	    fi
++	    if test aix != "$with_aix_soname"; then
++	      _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$CC '$shared_flag_svr4' -o $output_objdir/$realname.d/$shared_archive_member_spec.o $libobjs $deplibs $wl-bnoentry '$compiler_flags_filtered'$wl-bE:$export_symbols$allow_undefined_flag~$STRIP -e $output_objdir/$realname.d/$shared_archive_member_spec.o~( func_echo_all "#! $soname($shared_archive_member_spec.o)"; if test shr_64 = "$shared_archive_member_spec"; then func_echo_all "# 64"; else func_echo_all "# 32"; fi; cat $export_symbols ) > $output_objdir/$realname.d/$shared_archive_member_spec.imp~$AR $AR_FLAGS $output_objdir/$soname $output_objdir/$realname.d/$shared_archive_member_spec.o $output_objdir/$realname.d/$shared_archive_member_spec.imp'
++	    else
++	      # used by -dlpreopen to get the symbols
++	      _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$MV  $output_objdir/$realname.d/$soname $output_objdir'
++	    fi
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="$_LT_TAGVAR(archive_expsym_cmds, $1)"'~$RM -r $output_objdir/$realname.d'
+           fi
+         fi
+         ;;
+@@ -6103,7 +6638,7 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	  _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
+ 	  # Joseph Beckenbach <jrb3@best.com> says some releases of gcc
+ 	  # support --undefined.  This deserves some investigation.  FIXME
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -nostart $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+ 	else
+ 	  _LT_TAGVAR(ld_shlibs, $1)=no
+ 	fi
+@@ -6131,57 +6666,58 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	  # Tell ltmain to make .lib files, not .a files.
+ 	  libext=lib
+ 	  # Tell ltmain to make .dll files, not .so files.
+-	  shrext_cmds=".dll"
++	  shrext_cmds=.dll
+ 	  # FIXME: Setting linknames here is a bad hack.
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
+-	  _LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	      $SED -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
+-	    else
+-	      $SED -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
+-	    fi~
+-	    $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
+-	    linknames='
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~linknames='
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='if _LT_DLL_DEF_P([$export_symbols]); then
++              cp "$export_symbols" "$output_objdir/$soname.def";
++              echo "$tool_output_objdir$soname.def" > "$output_objdir/$soname.exp";
++            else
++              $SED -e '\''s/^/-link -EXPORT:/'\'' < $export_symbols > $output_objdir/$soname.exp;
++            fi~
++            $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
++            linknames='
+ 	  # The linker will not automatically build a static lib if we build a DLL.
+ 	  # _LT_TAGVAR(old_archive_from_new_cmds, $1)='true'
+ 	  _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
+ 	  # Don't use ranlib
+ 	  _LT_TAGVAR(old_postinstall_cmds, $1)='chmod 644 $oldlib'
+ 	  _LT_TAGVAR(postlink_cmds, $1)='lt_outputfile="@OUTPUT@"~
+-	    lt_tool_outputfile="@TOOL_OUTPUT@"~
+-	    case $lt_outputfile in
+-	      *.exe|*.EXE) ;;
+-	      *)
+-		lt_outputfile="$lt_outputfile.exe"
+-		lt_tool_outputfile="$lt_tool_outputfile.exe"
+-		;;
+-	    esac~
+-	    func_to_tool_file "$lt_outputfile"~
+-	    if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
+-	      $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
+-	      $RM "$lt_outputfile.manifest";
+-	    fi'
++            lt_tool_outputfile="@TOOL_OUTPUT@"~
++            case $lt_outputfile in
++              *.exe|*.EXE) ;;
++              *)
++                lt_outputfile=$lt_outputfile.exe
++                lt_tool_outputfile=$lt_tool_outputfile.exe
++                ;;
++            esac~
++            func_to_tool_file "$lt_outputfile"~
++            if test : != "$MANIFEST_TOOL" && test -f "$lt_outputfile.manifest"; then
++              $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
++              $RM "$lt_outputfile.manifest";
++            fi'
+ 	  ;;
+ 	*)
+ 	  # g++
+ 	  # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
+ 	  # as there is no search path for DLLs.
+ 	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
+-	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-all-symbols'
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-all-symbols'
+ 	  _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
+ 	  _LT_TAGVAR(always_export_symbols, $1)=no
+ 	  _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
+ 
+ 	  if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-	    # If the export-symbols file already is a .def file (1st line
+-	    # is EXPORTS), use it as is; otherwise, prepend...
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	      cp $export_symbols $output_objdir/$soname.def;
+-	    else
+-	      echo EXPORTS > $output_objdir/$soname.def;
+-	      cat $export_symbols >> $output_objdir/$soname.def;
+-	    fi~
+-	    $CC -shared -nostdlib $output_objdir/$soname.def $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	    # If the export-symbols file already is a .def file, use it as
++	    # is; otherwise, prepend EXPORTS...
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='if _LT_DLL_DEF_P([$export_symbols]); then
++              cp $export_symbols $output_objdir/$soname.def;
++            else
++              echo EXPORTS > $output_objdir/$soname.def;
++              cat $export_symbols >> $output_objdir/$soname.def;
++            fi~
++            $CC -shared -nostdlib $output_objdir/$soname.def $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname $wl--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+ 	  else
+ 	    _LT_TAGVAR(ld_shlibs, $1)=no
+ 	  fi
+@@ -6192,6 +6728,35 @@ if test "$_lt_caught_CXX_error" != yes; then
+         _LT_DARWIN_LINKER_FEATURES($1)
+ 	;;
+ 
++      os2*)
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++	_LT_TAGVAR(hardcode_minus_L, $1)=yes
++	_LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	shrext_cmds=.dll
++	_LT_TAGVAR(archive_cmds, $1)='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	  $ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	  $ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	  $ECHO EXPORTS >> $output_objdir/$libname.def~
++	  emxexp $libobjs | $SED /"_DLL_InitTerm"/d >> $output_objdir/$libname.def~
++	  $CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	  emximp -o $lib $output_objdir/$libname.def'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$ECHO "LIBRARY ${soname%$shared_ext} INITINSTANCE TERMINSTANCE" > $output_objdir/$libname.def~
++	  $ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~
++	  $ECHO "DATA MULTIPLE NONSHARED" >> $output_objdir/$libname.def~
++	  $ECHO EXPORTS >> $output_objdir/$libname.def~
++	  prefix_cmds="$SED"~
++	  if test EXPORTS = "`$SED 1q $export_symbols`"; then
++	    prefix_cmds="$prefix_cmds -e 1d";
++	  fi~
++	  prefix_cmds="$prefix_cmds -e \"s/^\(.*\)$/_\1/g\""~
++	  cat $export_symbols | $prefix_cmds >> $output_objdir/$libname.def~
++	  $CC -Zdll -Zcrtdll -o $output_objdir/$soname $libobjs $deplibs $compiler_flags $output_objdir/$libname.def~
++	  emximp -o $lib $output_objdir/$libname.def'
++	_LT_TAGVAR(old_archive_From_new_cmds, $1)='emximp -o $output_objdir/${libname}_dll.a $output_objdir/$libname.def'
++	_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++	_LT_TAGVAR(file_list_spec, $1)='@'
++	;;
++
+       dgux*)
+         case $cc_basename in
+           ec++*)
+@@ -6226,18 +6791,15 @@ if test "$_lt_caught_CXX_error" != yes; then
+         _LT_TAGVAR(ld_shlibs, $1)=yes
+         ;;
+ 
+-      gnu*)
+-        ;;
+-
+       haiku*)
+-        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
+         _LT_TAGVAR(link_all_deplibs, $1)=yes
+         ;;
+ 
+       hpux9*)
+-        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl+b $wl$libdir'
+         _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+-        _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++        _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+         _LT_TAGVAR(hardcode_direct, $1)=yes
+         _LT_TAGVAR(hardcode_minus_L, $1)=yes # Not in the search PATH,
+ 				             # but as the default
+@@ -6249,7 +6811,7 @@ if test "$_lt_caught_CXX_error" != yes; then
+             _LT_TAGVAR(ld_shlibs, $1)=no
+             ;;
+           aCC*)
+-            _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -b ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++            _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -b $wl+b $wl$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+             # Commands to make compiler produce verbose output that lists
+             # what "hidden" libraries, object files and flags are used when
+             # linking a shared library.
+@@ -6258,11 +6820,11 @@ if test "$_lt_caught_CXX_error" != yes; then
+             # explicitly linking system object files so we need to strip them
+             # from the output so that they don't get included in the library
+             # dependencies.
+-            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP "\-L"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP "\-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+             ;;
+           *)
+-            if test "$GXX" = yes; then
+-              _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -shared -nostdlib $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++            if test yes = "$GXX"; then
++              _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -shared -nostdlib $pic_flag $wl+b $wl$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test "x$output_objdir/$soname" = "x$lib" || mv $output_objdir/$soname $lib'
+             else
+               # FIXME: insert proper C++ library support
+               _LT_TAGVAR(ld_shlibs, $1)=no
+@@ -6272,15 +6834,15 @@ if test "$_lt_caught_CXX_error" != yes; then
+         ;;
+ 
+       hpux10*|hpux11*)
+-        if test $with_gnu_ld = no; then
+-	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++        if test no = "$with_gnu_ld"; then
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl+b $wl$libdir'
+ 	  _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+ 
+           case $host_cpu in
+             hppa*64*|ia64*)
+               ;;
+             *)
+-	      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	      _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+               ;;
+           esac
+         fi
+@@ -6306,13 +6868,13 @@ if test "$_lt_caught_CXX_error" != yes; then
+           aCC*)
+ 	    case $host_cpu in
+ 	      hppa*64*)
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	        ;;
+ 	      ia64*)
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname $wl+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	        ;;
+ 	      *)
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -b $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	        ;;
+ 	    esac
+ 	    # Commands to make compiler produce verbose output that lists
+@@ -6323,20 +6885,20 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP "\-L"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP "\-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+ 	    ;;
+           *)
+-	    if test "$GXX" = yes; then
+-	      if test $with_gnu_ld = no; then
++	    if test yes = "$GXX"; then
++	      if test no = "$with_gnu_ld"; then
+ 	        case $host_cpu in
+ 	          hppa*64*)
+-	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib -fPIC ${wl}+h ${wl}$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib -fPIC $wl+h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	            ;;
+ 	          ia64*)
+-	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $pic_flag $wl+h $wl$soname $wl+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	            ;;
+ 	          *)
+-	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $pic_flag $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	            ;;
+ 	        esac
+ 	      fi
+@@ -6351,22 +6913,22 @@ if test "$_lt_caught_CXX_error" != yes; then
+       interix[[3-9]]*)
+ 	_LT_TAGVAR(hardcode_direct, $1)=no
+ 	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+-	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
+ 	# Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
+ 	# Instead, shared libraries are loaded at an image base (0x10000000 by
+ 	# default) and relocated if they conflict, which is a slow very memory
+ 	# consuming and fragmenting process.  To avoid this, we pick a random,
+ 	# 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
+ 	# time.  Moving up from 0x10000000 also allows more sbrk(2) space.
+-	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+-	_LT_TAGVAR(archive_expsym_cmds, $1)='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='sed "s|^|_|" $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-h,$soname $wl--retain-symbols-file,$output_objdir/$soname.expsym $wl--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+ 	;;
+       irix5* | irix6*)
+         case $cc_basename in
+           CC*)
+ 	    # SGI C++
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -all -multigot $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -all -multigot $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+ 
+ 	    # Archives containing C++ object files must be created using
+ 	    # "CC -ar", where "CC" is the IRIX C++ compiler.  This is
+@@ -6375,22 +6937,22 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    _LT_TAGVAR(old_archive_cmds, $1)='$CC -ar -WR,-u -o $oldlib $oldobjs'
+ 	    ;;
+           *)
+-	    if test "$GXX" = yes; then
+-	      if test "$with_gnu_ld" = no; then
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	    if test yes = "$GXX"; then
++	      if test no = "$with_gnu_ld"; then
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 	      else
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` -o $lib'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` -o $lib'
+ 	      fi
+ 	    fi
+ 	    _LT_TAGVAR(link_all_deplibs, $1)=yes
+ 	    ;;
+         esac
+-        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+         _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+         _LT_TAGVAR(inherit_rpath, $1)=yes
+         ;;
+ 
+-      linux* | k*bsd*-gnu | kopensolaris*-gnu)
++      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
+         case $cc_basename in
+           KCC*)
+ 	    # Kuck and Associates, Inc. (KAI) C++ Compiler
+@@ -6398,8 +6960,8 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # KCC will only create a shared library if the output file
+ 	    # ends with ".so" (or ".sl" for HP-UX), so rename the library
+ 	    # to its proper name (with version) after linking.
+-	    _LT_TAGVAR(archive_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib ${wl}-retain-symbols-file,$export_symbols; mv \$templib $lib'
++	    _LT_TAGVAR(archive_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\$tempext\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\$tempext\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib $wl-retain-symbols-file,$export_symbols; mv \$templib $lib'
+ 	    # Commands to make compiler produce verbose output that lists
+ 	    # what "hidden" libraries, object files and flags are used when
+ 	    # linking a shared library.
+@@ -6408,10 +6970,10 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`$CC $CFLAGS -v conftest.$objext -o libconftest$shared_ext 2>&1 | $GREP "ld"`; rm -f libconftest$shared_ext; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    output_verbose_link_cmd='templist=`$CC $CFLAGS -v conftest.$objext -o libconftest$shared_ext 2>&1 | $GREP "ld"`; rm -f libconftest$shared_ext; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+ 
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
+ 
+ 	    # Archives containing C++ object files must be created using
+ 	    # "CC -Bstatic", where "CC" is the KAI C++ compiler.
+@@ -6425,59 +6987,59 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # earlier do not add the objects themselves.
+ 	    case `$CC -V 2>&1` in
+ 	      *"Version 7."*)
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-		_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++		_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 		;;
+ 	      *)  # Version 8.0 or newer
+ 	        tmp_idyn=
+ 	        case $host_cpu in
+ 		  ia64*) tmp_idyn=' -i_dynamic';;
+ 		esac
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-		_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++		_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 		;;
+ 	    esac
+ 	    _LT_TAGVAR(archive_cmds_need_lc, $1)=no
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
+-	    _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive$convenience $wl--no-whole-archive'
+ 	    ;;
+           pgCC* | pgcpp*)
+             # Portland Group C++ compiler
+ 	    case `$CC -V` in
+ 	    *pgCC\ [[1-5]].* | *pgcpp\ [[1-5]].*)
+ 	      _LT_TAGVAR(prelink_cmds, $1)='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
+-		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
++               rm -rf $tpldir~
++               $CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
++               compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
+ 	      _LT_TAGVAR(old_archive_cmds, $1)='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
+-		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
+-		$RANLIB $oldlib'
++                rm -rf $tpldir~
++                $CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
++                $AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
++                $RANLIB $oldlib'
+ 	      _LT_TAGVAR(archive_cmds, $1)='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++                rm -rf $tpldir~
++                $CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
++                $CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
+ 	      _LT_TAGVAR(archive_expsym_cmds, $1)='tpldir=Template.dir~
+-		rm -rf $tpldir~
+-		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
+-		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++                rm -rf $tpldir~
++                $CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
++                $CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	      ;;
+ 	    *) # Version 6 and above use weak symbols
+-	      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
+-	      _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++	      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++	      _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname $wl-retain-symbols-file $wl$export_symbols -o $lib'
+ 	      ;;
+ 	    esac
+ 
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}--rpath ${wl}$libdir'
+-	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
+-	    _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl--rpath $wl$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+             ;;
+ 	  cxx*)
+ 	    # Compaq C++
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname  -o $lib ${wl}-retain-symbols-file $wl$export_symbols'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname -o $lib'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname  -o $lib $wl-retain-symbols-file $wl$export_symbols'
+ 
+ 	    runpath_var=LD_RUN_PATH
+ 	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-rpath $libdir'
+@@ -6491,18 +7053,18 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld .*$\)/\1/"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "X$list" | $Xsed'
++	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld .*$\)/\1/"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "X$list" | $Xsed'
+ 	    ;;
+ 	  xl* | mpixl* | bgxl*)
+ 	    # IBM XL 8.0 on PPC, with GNU ld
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
+-	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -qmkshrobj $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    if test "x$supports_anon_versioning" = xyes; then
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl--export-dynamic'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -qmkshrobj $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++	    if test yes = "$supports_anon_versioning"; then
+ 	      _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
+-		cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-		echo "local: *; };" >> $output_objdir/$libname.ver~
+-		$CC -qmkshrobj $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
++                cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++                echo "local: *; };" >> $output_objdir/$libname.ver~
++                $CC -qmkshrobj $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-version-script $wl$output_objdir/$libname.ver -o $lib'
+ 	    fi
+ 	    ;;
+ 	  *)
+@@ -6510,10 +7072,10 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    *Sun\ C*)
+ 	      # Sun C++ 5.9
+ 	      _LT_TAGVAR(no_undefined_flag, $1)=' -zdefs'
+-	      _LT_TAGVAR(archive_cmds, $1)='$CC -G${allow_undefined_flag} -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+-	      _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G${allow_undefined_flag} -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-retain-symbols-file ${wl}$export_symbols'
++	      _LT_TAGVAR(archive_cmds, $1)='$CC -G$allow_undefined_flag -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	      _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G$allow_undefined_flag -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-retain-symbols-file $wl$export_symbols'
+ 	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
+-	      _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	      _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	      _LT_TAGVAR(compiler_needs_object, $1)=yes
+ 
+ 	      # Not sure whether something based on
+@@ -6571,22 +7133,17 @@ if test "$_lt_caught_CXX_error" != yes; then
+         _LT_TAGVAR(ld_shlibs, $1)=yes
+ 	;;
+ 
+-      openbsd2*)
+-        # C++ shared libraries are fairly broken
+-	_LT_TAGVAR(ld_shlibs, $1)=no
+-	;;
+-
+-      openbsd*)
++      openbsd* | bitrig*)
+ 	if test -f /usr/libexec/ld.so; then
+ 	  _LT_TAGVAR(hardcode_direct, $1)=yes
+ 	  _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+ 	  _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
+ 	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $lib'
+-	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
+-	  if test -z "`echo __ELF__ | $CC -E - | grep __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-retain-symbols-file,$export_symbols -o $lib'
+-	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
+-	    _LT_TAGVAR(whole_archive_flag_spec, $1)="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
++	  if test -z "`echo __ELF__ | $CC -E - | grep __ELF__`"; then
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-retain-symbols-file,$export_symbols -o $lib'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-E'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)=$wlarc'--whole-archive$convenience '$wlarc'--no-whole-archive'
+ 	  fi
+ 	  output_verbose_link_cmd=func_echo_all
+ 	else
+@@ -6602,9 +7159,9 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # KCC will only create a shared library if the output file
+ 	    # ends with ".so" (or ".sl" for HP-UX), so rename the library
+ 	    # to its proper name (with version) after linking.
+-	    _LT_TAGVAR(archive_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo "$lib" | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
++	    _LT_TAGVAR(archive_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo "$lib" | $SED -e "s/\$tempext\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
+ 
+-	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath,$libdir'
+ 	    _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+ 
+ 	    # Archives containing C++ object files must be created using
+@@ -6622,17 +7179,17 @@ if test "$_lt_caught_CXX_error" != yes; then
+           cxx*)
+ 	    case $host in
+ 	      osf3*)
+-	        _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $soname `test -n "$verstring" && func_echo_all "${wl}-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-	        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	        _LT_TAGVAR(allow_undefined_flag, $1)=' $wl-expect_unresolved $wl\*'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $soname `test -n "$verstring" && func_echo_all "$wl-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
++	        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+ 		;;
+ 	      *)
+ 	        _LT_TAGVAR(allow_undefined_flag, $1)=' -expect_unresolved \*'
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
+ 	        _LT_TAGVAR(archive_expsym_cmds, $1)='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done~
+-	          echo "-hidden">> $lib.exp~
+-	          $CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname ${wl}-input ${wl}$lib.exp  `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~
+-	          $RM $lib.exp'
++                  echo "-hidden">> $lib.exp~
++                  $CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname $wl-input $wl$lib.exp  `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib~
++                  $RM $lib.exp'
+ 	        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-rpath $libdir'
+ 		;;
+ 	    esac
+@@ -6647,21 +7204,21 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # explicitly linking system object files so we need to strip them
+ 	    # from the output so that they don't get included in the library
+ 	    # dependencies.
+-	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld" | $GREP -v "ld:"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld.*$\)/\1/"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld" | $GREP -v "ld:"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld.*$\)/\1/"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+ 	    ;;
+ 	  *)
+-	    if test "$GXX" = yes && test "$with_gnu_ld" = no; then
+-	      _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
++	    if test yes,no = "$GXX,$with_gnu_ld"; then
++	      _LT_TAGVAR(allow_undefined_flag, $1)=' $wl-expect_unresolved $wl\*'
+ 	      case $host in
+ 	        osf3*)
+-	          _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib ${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	          _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 		  ;;
+ 	        *)
+-	          _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib ${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	          _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-msym $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations -o $lib'
+ 		  ;;
+ 	      esac
+ 
+-	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+ 	      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
+ 
+ 	      # Commands to make compiler produce verbose output that lists
+@@ -6707,9 +7264,9 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    # Sun C++ 4.2, 5.x and Centerline C++
+             _LT_TAGVAR(archive_cmds_need_lc,$1)=yes
+ 	    _LT_TAGVAR(no_undefined_flag, $1)=' -zdefs'
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -G${allow_undefined_flag}  -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -G$allow_undefined_flag -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
+ 	    _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	      $CC -G${allow_undefined_flag} ${wl}-M ${wl}$lib.exp -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++              $CC -G$allow_undefined_flag $wl-M $wl$lib.exp -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
+ 
+ 	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
+ 	    _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+@@ -6717,7 +7274,7 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	      solaris2.[[0-5]] | solaris2.[[0-5]].*) ;;
+ 	      *)
+ 		# The compiler driver will combine and reorder linker options,
+-		# but understands `-z linker_flag'.
++		# but understands '-z linker_flag'.
+ 	        # Supported since Solaris 2.6 (maybe 2.5.1?)
+ 		_LT_TAGVAR(whole_archive_flag_spec, $1)='-z allextract$convenience -z defaultextract'
+ 	        ;;
+@@ -6734,30 +7291,30 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	    ;;
+           gcx*)
+ 	    # Green Hills C++ Compiler
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-h $wl$soname -o $lib'
+ 
+ 	    # The C++ compiler must be used to create the archive.
+ 	    _LT_TAGVAR(old_archive_cmds, $1)='$CC $LDFLAGS -archive -o $oldlib $oldobjs'
+ 	    ;;
+           *)
+ 	    # GNU C++ compiler with Solaris linker
+-	    if test "$GXX" = yes && test "$with_gnu_ld" = no; then
+-	      _LT_TAGVAR(no_undefined_flag, $1)=' ${wl}-z ${wl}defs'
++	    if test yes,no = "$GXX,$with_gnu_ld"; then
++	      _LT_TAGVAR(no_undefined_flag, $1)=' $wl-z ${wl}defs'
+ 	      if $CC --version | $GREP -v '^2\.7' > /dev/null; then
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $LDFLAGS $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-h $wl$soname -o $lib'
+ 	        _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-		  $CC -shared $pic_flag -nostdlib ${wl}-M $wl$lib.exp -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++                  $CC -shared $pic_flag -nostdlib $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
+ 
+ 	        # Commands to make compiler produce verbose output that lists
+ 	        # what "hidden" libraries, object files and flags are used when
+ 	        # linking a shared library.
+ 	        output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+ 	      else
+-	        # g++ 2.7 appears to require `-G' NOT `-shared' on this
++	        # g++ 2.7 appears to require '-G' NOT '-shared' on this
+ 	        # platform.
+-	        _LT_TAGVAR(archive_cmds, $1)='$CC -G -nostdlib $LDFLAGS $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -G -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags $wl-h $wl$soname -o $lib'
+ 	        _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-		  $CC -G -nostdlib ${wl}-M $wl$lib.exp -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++                  $CC -G -nostdlib $wl-M $wl$lib.exp $wl-h $wl$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
+ 
+ 	        # Commands to make compiler produce verbose output that lists
+ 	        # what "hidden" libraries, object files and flags are used when
+@@ -6765,11 +7322,11 @@ if test "$_lt_caught_CXX_error" != yes; then
+ 	        output_verbose_link_cmd='$CC -G $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+ 	      fi
+ 
+-	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R $wl$libdir'
++	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-R $wl$libdir'
+ 	      case $host_os in
+ 		solaris2.[[0-5]] | solaris2.[[0-5]].*) ;;
+ 		*)
+-		  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
++		  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl-z ${wl}allextract$convenience $wl-z ${wl}defaultextract'
+ 		  ;;
+ 	      esac
+ 	    fi
+@@ -6778,52 +7335,52 @@ if test "$_lt_caught_CXX_error" != yes; then
+         ;;
+ 
+     sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[[01]].[[10]]* | unixware7* | sco3.2v5.0.[[024]]*)
+-      _LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
++      _LT_TAGVAR(no_undefined_flag, $1)='$wl-z,text'
+       _LT_TAGVAR(archive_cmds_need_lc, $1)=no
+       _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+       runpath_var='LD_RUN_PATH'
+ 
+       case $cc_basename in
+         CC*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+ 	*)
+-	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	  ;;
+       esac
+       ;;
+ 
+       sysv5* | sco3.2v5* | sco5v6*)
+-	# Note: We can NOT use -z defs as we might desire, because we do not
++	# Note: We CANNOT use -z defs as we might desire, because we do not
+ 	# link with -lc, and that would cause any symbols used from libc to
+ 	# always be unresolved, which means just about no library would
+ 	# ever link correctly.  If we're not using GNU ld we use -z text
+ 	# though, which does catch some bad symbols but isn't as heavy-handed
+ 	# as -z defs.
+-	_LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
+-	_LT_TAGVAR(allow_undefined_flag, $1)='${wl}-z,nodefs'
++	_LT_TAGVAR(no_undefined_flag, $1)='$wl-z,text'
++	_LT_TAGVAR(allow_undefined_flag, $1)='$wl-z,nodefs'
+ 	_LT_TAGVAR(archive_cmds_need_lc, $1)=no
+ 	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
+-	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R,$libdir'
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-R,$libdir'
+ 	_LT_TAGVAR(hardcode_libdir_separator, $1)=':'
+ 	_LT_TAGVAR(link_all_deplibs, $1)=yes
+-	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-Bexport'
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='$wl-Bexport'
+ 	runpath_var='LD_RUN_PATH'
+ 
+ 	case $cc_basename in
+           CC*)
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -G $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	    _LT_TAGVAR(old_archive_cmds, $1)='$CC -Tprelink_objects $oldobjs~
+-	      '"$_LT_TAGVAR(old_archive_cmds, $1)"
++              '"$_LT_TAGVAR(old_archive_cmds, $1)"
+ 	    _LT_TAGVAR(reload_cmds, $1)='$CC -Tprelink_objects $reload_objs~
+-	      '"$_LT_TAGVAR(reload_cmds, $1)"
++              '"$_LT_TAGVAR(reload_cmds, $1)"
+ 	    ;;
+ 	  *)
+-	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $wl-Bexport:$export_symbols $wl-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+ 	    ;;
+ 	esac
+       ;;
+@@ -6854,10 +7411,10 @@ if test "$_lt_caught_CXX_error" != yes; then
+     esac
+ 
+     AC_MSG_RESULT([$_LT_TAGVAR(ld_shlibs, $1)])
+-    test "$_LT_TAGVAR(ld_shlibs, $1)" = no && can_build_shared=no
++    test no = "$_LT_TAGVAR(ld_shlibs, $1)" && can_build_shared=no
+ 
+-    _LT_TAGVAR(GCC, $1)="$GXX"
+-    _LT_TAGVAR(LD, $1)="$LD"
++    _LT_TAGVAR(GCC, $1)=$GXX
++    _LT_TAGVAR(LD, $1)=$LD
+ 
+     ## CAVEAT EMPTOR:
+     ## There is no encapsulation within the following macros, do not change
+@@ -6884,7 +7441,7 @@ if test "$_lt_caught_CXX_error" != yes; then
+   lt_cv_path_LD=$lt_save_path_LD
+   lt_cv_prog_gnu_ldcxx=$lt_cv_prog_gnu_ld
+   lt_cv_prog_gnu_ld=$lt_save_with_gnu_ld
+-fi # test "$_lt_caught_CXX_error" != yes
++fi # test yes != "$_lt_caught_CXX_error"
+ 
+ AC_LANG_POP
+ ])# _LT_LANG_CXX_CONFIG
+@@ -6906,13 +7463,14 @@ AC_REQUIRE([_LT_DECL_SED])
+ AC_REQUIRE([_LT_PROG_ECHO_BACKSLASH])
+ func_stripname_cnf ()
+ {
+-  case ${2} in
+-  .*) func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%\\\\${2}\$%%"`;;
+-  *)  func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%${2}\$%%"`;;
++  case @S|@2 in
++  .*) func_stripname_result=`$ECHO "@S|@3" | $SED "s%^@S|@1%%; s%\\\\@S|@2\$%%"`;;
++  *)  func_stripname_result=`$ECHO "@S|@3" | $SED "s%^@S|@1%%; s%@S|@2\$%%"`;;
+   esac
+ } # func_stripname_cnf
+ ])# _LT_FUNC_STRIPNAME_CNF
+ 
++
+ # _LT_SYS_HIDDEN_LIBDEPS([TAGNAME])
+ # ---------------------------------
+ # Figure out "hidden" library dependencies from verbose
+@@ -6996,13 +7554,13 @@ if AC_TRY_EVAL(ac_compile); then
+   pre_test_object_deps_done=no
+ 
+   for p in `eval "$output_verbose_link_cmd"`; do
+-    case ${prev}${p} in
++    case $prev$p in
+ 
+     -L* | -R* | -l*)
+        # Some compilers place space between "-{L,R}" and the path.
+        # Remove the space.
+-       if test $p = "-L" ||
+-          test $p = "-R"; then
++       if test x-L = "$p" ||
++          test x-R = "$p"; then
+ 	 prev=$p
+ 	 continue
+        fi
+@@ -7018,16 +7576,16 @@ if AC_TRY_EVAL(ac_compile); then
+        case $p in
+        =*) func_stripname_cnf '=' '' "$p"; p=$lt_sysroot$func_stripname_result ;;
+        esac
+-       if test "$pre_test_object_deps_done" = no; then
+-	 case ${prev} in
++       if test no = "$pre_test_object_deps_done"; then
++	 case $prev in
+ 	 -L | -R)
+ 	   # Internal compiler library paths should come after those
+ 	   # provided the user.  The postdeps already come after the
+ 	   # user supplied libs so there is no need to process them.
+ 	   if test -z "$_LT_TAGVAR(compiler_lib_search_path, $1)"; then
+-	     _LT_TAGVAR(compiler_lib_search_path, $1)="${prev}${p}"
++	     _LT_TAGVAR(compiler_lib_search_path, $1)=$prev$p
+ 	   else
+-	     _LT_TAGVAR(compiler_lib_search_path, $1)="${_LT_TAGVAR(compiler_lib_search_path, $1)} ${prev}${p}"
++	     _LT_TAGVAR(compiler_lib_search_path, $1)="${_LT_TAGVAR(compiler_lib_search_path, $1)} $prev$p"
+ 	   fi
+ 	   ;;
+ 	 # The "-l" case would never come before the object being
+@@ -7035,9 +7593,9 @@ if AC_TRY_EVAL(ac_compile); then
+ 	 esac
+        else
+ 	 if test -z "$_LT_TAGVAR(postdeps, $1)"; then
+-	   _LT_TAGVAR(postdeps, $1)="${prev}${p}"
++	   _LT_TAGVAR(postdeps, $1)=$prev$p
+ 	 else
+-	   _LT_TAGVAR(postdeps, $1)="${_LT_TAGVAR(postdeps, $1)} ${prev}${p}"
++	   _LT_TAGVAR(postdeps, $1)="${_LT_TAGVAR(postdeps, $1)} $prev$p"
+ 	 fi
+        fi
+        prev=
+@@ -7052,15 +7610,15 @@ if AC_TRY_EVAL(ac_compile); then
+ 	 continue
+        fi
+ 
+-       if test "$pre_test_object_deps_done" = no; then
++       if test no = "$pre_test_object_deps_done"; then
+ 	 if test -z "$_LT_TAGVAR(predep_objects, $1)"; then
+-	   _LT_TAGVAR(predep_objects, $1)="$p"
++	   _LT_TAGVAR(predep_objects, $1)=$p
+ 	 else
+ 	   _LT_TAGVAR(predep_objects, $1)="$_LT_TAGVAR(predep_objects, $1) $p"
+ 	 fi
+        else
+ 	 if test -z "$_LT_TAGVAR(postdep_objects, $1)"; then
+-	   _LT_TAGVAR(postdep_objects, $1)="$p"
++	   _LT_TAGVAR(postdep_objects, $1)=$p
+ 	 else
+ 	   _LT_TAGVAR(postdep_objects, $1)="$_LT_TAGVAR(postdep_objects, $1) $p"
+ 	 fi
+@@ -7091,51 +7649,6 @@ interix[[3-9]]*)
+   _LT_TAGVAR(postdep_objects,$1)=
+   _LT_TAGVAR(postdeps,$1)=
+   ;;
+-
+-linux*)
+-  case `$CC -V 2>&1 | sed 5q` in
+-  *Sun\ C*)
+-    # Sun C++ 5.9
+-
+-    # The more standards-conforming stlport4 library is
+-    # incompatible with the Cstd library. Avoid specifying
+-    # it if it's in CXXFLAGS. Ignore libCrun as
+-    # -library=stlport4 depends on it.
+-    case " $CXX $CXXFLAGS " in
+-    *" -library=stlport4 "*)
+-      solaris_use_stlport4=yes
+-      ;;
+-    esac
+-
+-    if test "$solaris_use_stlport4" != yes; then
+-      _LT_TAGVAR(postdeps,$1)='-library=Cstd -library=Crun'
+-    fi
+-    ;;
+-  esac
+-  ;;
+-
+-solaris*)
+-  case $cc_basename in
+-  CC* | sunCC*)
+-    # The more standards-conforming stlport4 library is
+-    # incompatible with the Cstd library. Avoid specifying
+-    # it if it's in CXXFLAGS. Ignore libCrun as
+-    # -library=stlport4 depends on it.
+-    case " $CXX $CXXFLAGS " in
+-    *" -library=stlport4 "*)
+-      solaris_use_stlport4=yes
+-      ;;
+-    esac
+-
+-    # Adding this requires a known-good setup of shared libraries for
+-    # Sun compiler versions before 5.6, else PIC objects from an old
+-    # archive will be linked into the output, leading to subtle bugs.
+-    if test "$solaris_use_stlport4" != yes; then
+-      _LT_TAGVAR(postdeps,$1)='-library=Cstd -library=Crun'
+-    fi
+-    ;;
+-  esac
+-  ;;
+ esac
+ ])
+ 
+@@ -7144,7 +7657,7 @@ case " $_LT_TAGVAR(postdeps, $1) " in
+ esac
+  _LT_TAGVAR(compiler_lib_search_dirs, $1)=
+ if test -n "${_LT_TAGVAR(compiler_lib_search_path, $1)}"; then
+- _LT_TAGVAR(compiler_lib_search_dirs, $1)=`echo " ${_LT_TAGVAR(compiler_lib_search_path, $1)}" | ${SED} -e 's! -L! !g' -e 's!^ !!'`
++ _LT_TAGVAR(compiler_lib_search_dirs, $1)=`echo " ${_LT_TAGVAR(compiler_lib_search_path, $1)}" | $SED -e 's! -L! !g' -e 's!^ !!'`
+ fi
+ _LT_TAGDECL([], [compiler_lib_search_dirs], [1],
+     [The directories searched by this compiler when creating a shared library])
+@@ -7164,10 +7677,10 @@ _LT_TAGDECL([], [compiler_lib_search_path], [1],
+ # --------------------------
+ # Ensure that the configuration variables for a Fortran 77 compiler are
+ # suitably defined.  These variables are subsequently used by _LT_CONFIG
+-# to write the compiler configuration to `libtool'.
++# to write the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_F77_CONFIG],
+ [AC_LANG_PUSH(Fortran 77)
+-if test -z "$F77" || test "X$F77" = "Xno"; then
++if test -z "$F77" || test no = "$F77"; then
+   _lt_disable_F77=yes
+ fi
+ 
+@@ -7204,7 +7717,7 @@ _LT_TAGVAR(objext, $1)=$objext
+ # the F77 compiler isn't working.  Some variables (like enable_shared)
+ # are currently assumed to apply to all compilers on this platform,
+ # and will be corrupted by setting them based on a non-working compiler.
+-if test "$_lt_disable_F77" != yes; then
++if test yes != "$_lt_disable_F77"; then
+   # Code to be used in simple compile tests
+   lt_simple_compile_test_code="\
+       subroutine t
+@@ -7226,7 +7739,7 @@ if test "$_lt_disable_F77" != yes; then
+   _LT_LINKER_BOILERPLATE
+ 
+   # Allow CC to be a program name with arguments.
+-  lt_save_CC="$CC"
++  lt_save_CC=$CC
+   lt_save_GCC=$GCC
+   lt_save_CFLAGS=$CFLAGS
+   CC=${F77-"f77"}
+@@ -7240,21 +7753,25 @@ if test "$_lt_disable_F77" != yes; then
+     AC_MSG_RESULT([$can_build_shared])
+ 
+     AC_MSG_CHECKING([whether to build shared libraries])
+-    test "$can_build_shared" = "no" && enable_shared=no
++    test no = "$can_build_shared" && enable_shared=no
+ 
+     # On AIX, shared libraries and static libraries use the same namespace, and
+     # are all built from PIC.
+     case $host_os in
+       aix3*)
+-        test "$enable_shared" = yes && enable_static=no
++        test yes = "$enable_shared" && enable_static=no
+         if test -n "$RANLIB"; then
+           archive_cmds="$archive_cmds~\$RANLIB \$lib"
+           postinstall_cmds='$RANLIB $lib'
+         fi
+         ;;
+       aix[[4-9]]*)
+-	if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
+-	  test "$enable_shared" = yes && enable_static=no
++	if test ia64 != "$host_cpu"; then
++	  case $enable_shared,$with_aix_soname,$aix_use_runtimelinking in
++	  yes,aix,yes) ;;		# shared object as lib.so file only
++	  yes,svr4,*) ;;		# shared object as lib.so archive member only
++	  yes,*) enable_static=no ;;	# shared object in lib.a archive as well
++	  esac
+ 	fi
+         ;;
+     esac
+@@ -7262,11 +7779,11 @@ if test "$_lt_disable_F77" != yes; then
+ 
+     AC_MSG_CHECKING([whether to build static libraries])
+     # Make sure either enable_shared or enable_static is yes.
+-    test "$enable_shared" = yes || enable_static=yes
++    test yes = "$enable_shared" || enable_static=yes
+     AC_MSG_RESULT([$enable_static])
+ 
+-    _LT_TAGVAR(GCC, $1)="$G77"
+-    _LT_TAGVAR(LD, $1)="$LD"
++    _LT_TAGVAR(GCC, $1)=$G77
++    _LT_TAGVAR(LD, $1)=$LD
+ 
+     ## CAVEAT EMPTOR:
+     ## There is no encapsulation within the following macros, do not change
+@@ -7283,9 +7800,9 @@ if test "$_lt_disable_F77" != yes; then
+   fi # test -n "$compiler"
+ 
+   GCC=$lt_save_GCC
+-  CC="$lt_save_CC"
+-  CFLAGS="$lt_save_CFLAGS"
+-fi # test "$_lt_disable_F77" != yes
++  CC=$lt_save_CC
++  CFLAGS=$lt_save_CFLAGS
++fi # test yes != "$_lt_disable_F77"
+ 
+ AC_LANG_POP
+ ])# _LT_LANG_F77_CONFIG
+@@ -7295,11 +7812,11 @@ AC_LANG_POP
+ # -------------------------
+ # Ensure that the configuration variables for a Fortran compiler are
+ # suitably defined.  These variables are subsequently used by _LT_CONFIG
+-# to write the compiler configuration to `libtool'.
++# to write the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_FC_CONFIG],
+ [AC_LANG_PUSH(Fortran)
+ 
+-if test -z "$FC" || test "X$FC" = "Xno"; then
++if test -z "$FC" || test no = "$FC"; then
+   _lt_disable_FC=yes
+ fi
+ 
+@@ -7336,7 +7853,7 @@ _LT_TAGVAR(objext, $1)=$objext
+ # the FC compiler isn't working.  Some variables (like enable_shared)
+ # are currently assumed to apply to all compilers on this platform,
+ # and will be corrupted by setting them based on a non-working compiler.
+-if test "$_lt_disable_FC" != yes; then
++if test yes != "$_lt_disable_FC"; then
+   # Code to be used in simple compile tests
+   lt_simple_compile_test_code="\
+       subroutine t
+@@ -7358,7 +7875,7 @@ if test "$_lt_disable_FC" != yes; then
+   _LT_LINKER_BOILERPLATE
+ 
+   # Allow CC to be a program name with arguments.
+-  lt_save_CC="$CC"
++  lt_save_CC=$CC
+   lt_save_GCC=$GCC
+   lt_save_CFLAGS=$CFLAGS
+   CC=${FC-"f95"}
+@@ -7374,21 +7891,25 @@ if test "$_lt_disable_FC" != yes; then
+     AC_MSG_RESULT([$can_build_shared])
+ 
+     AC_MSG_CHECKING([whether to build shared libraries])
+-    test "$can_build_shared" = "no" && enable_shared=no
++    test no = "$can_build_shared" && enable_shared=no
+ 
+     # On AIX, shared libraries and static libraries use the same namespace, and
+     # are all built from PIC.
+     case $host_os in
+       aix3*)
+-        test "$enable_shared" = yes && enable_static=no
++        test yes = "$enable_shared" && enable_static=no
+         if test -n "$RANLIB"; then
+           archive_cmds="$archive_cmds~\$RANLIB \$lib"
+           postinstall_cmds='$RANLIB $lib'
+         fi
+         ;;
+       aix[[4-9]]*)
+-	if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
+-	  test "$enable_shared" = yes && enable_static=no
++	if test ia64 != "$host_cpu"; then
++	  case $enable_shared,$with_aix_soname,$aix_use_runtimelinking in
++	  yes,aix,yes) ;;		# shared object as lib.so file only
++	  yes,svr4,*) ;;		# shared object as lib.so archive member only
++	  yes,*) enable_static=no ;;	# shared object in lib.a archive as well
++	  esac
+ 	fi
+         ;;
+     esac
+@@ -7396,11 +7917,11 @@ if test "$_lt_disable_FC" != yes; then
+ 
+     AC_MSG_CHECKING([whether to build static libraries])
+     # Make sure either enable_shared or enable_static is yes.
+-    test "$enable_shared" = yes || enable_static=yes
++    test yes = "$enable_shared" || enable_static=yes
+     AC_MSG_RESULT([$enable_static])
+ 
+-    _LT_TAGVAR(GCC, $1)="$ac_cv_fc_compiler_gnu"
+-    _LT_TAGVAR(LD, $1)="$LD"
++    _LT_TAGVAR(GCC, $1)=$ac_cv_fc_compiler_gnu
++    _LT_TAGVAR(LD, $1)=$LD
+ 
+     ## CAVEAT EMPTOR:
+     ## There is no encapsulation within the following macros, do not change
+@@ -7420,7 +7941,7 @@ if test "$_lt_disable_FC" != yes; then
+   GCC=$lt_save_GCC
+   CC=$lt_save_CC
+   CFLAGS=$lt_save_CFLAGS
+-fi # test "$_lt_disable_FC" != yes
++fi # test yes != "$_lt_disable_FC"
+ 
+ AC_LANG_POP
+ ])# _LT_LANG_FC_CONFIG
+@@ -7430,7 +7951,7 @@ AC_LANG_POP
+ # --------------------------
+ # Ensure that the configuration variables for the GNU Java Compiler compiler
+ # are suitably defined.  These variables are subsequently used by _LT_CONFIG
+-# to write the compiler configuration to `libtool'.
++# to write the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_GCJ_CONFIG],
+ [AC_REQUIRE([LT_PROG_GCJ])dnl
+ AC_LANG_SAVE
+@@ -7464,7 +7985,7 @@ CC=${GCJ-"gcj"}
+ CFLAGS=$GCJFLAGS
+ compiler=$CC
+ _LT_TAGVAR(compiler, $1)=$CC
+-_LT_TAGVAR(LD, $1)="$LD"
++_LT_TAGVAR(LD, $1)=$LD
+ _LT_CC_BASENAME([$compiler])
+ 
+ # GCJ did not exist at the time GCC didn't implicitly link libc in.
+@@ -7501,7 +8022,7 @@ CFLAGS=$lt_save_CFLAGS
+ # --------------------------
+ # Ensure that the configuration variables for the GNU Go compiler
+ # are suitably defined.  These variables are subsequently used by _LT_CONFIG
+-# to write the compiler configuration to `libtool'.
++# to write the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_GO_CONFIG],
+ [AC_REQUIRE([LT_PROG_GO])dnl
+ AC_LANG_SAVE
+@@ -7535,7 +8056,7 @@ CC=${GOC-"gccgo"}
+ CFLAGS=$GOFLAGS
+ compiler=$CC
+ _LT_TAGVAR(compiler, $1)=$CC
+-_LT_TAGVAR(LD, $1)="$LD"
++_LT_TAGVAR(LD, $1)=$LD
+ _LT_CC_BASENAME([$compiler])
+ 
+ # Go did not exist at the time GCC didn't implicitly link libc in.
+@@ -7572,7 +8093,7 @@ CFLAGS=$lt_save_CFLAGS
+ # -------------------------
+ # Ensure that the configuration variables for the Windows resource compiler
+ # are suitably defined.  These variables are subsequently used by _LT_CONFIG
+-# to write the compiler configuration to `libtool'.
++# to write the compiler configuration to 'libtool'.
+ m4_defun([_LT_LANG_RC_CONFIG],
+ [AC_REQUIRE([LT_PROG_RC])dnl
+ AC_LANG_SAVE
+@@ -7588,7 +8109,7 @@ _LT_TAGVAR(objext, $1)=$objext
+ lt_simple_compile_test_code='sample MENU { MENUITEM "&Soup", 100, CHECKED }'
+ 
+ # Code to be used in simple link tests
+-lt_simple_link_test_code="$lt_simple_compile_test_code"
++lt_simple_link_test_code=$lt_simple_compile_test_code
+ 
+ # ltmain only uses $CC for tagged configurations so make sure $CC is set.
+ _LT_TAG_COMPILER
+@@ -7598,7 +8119,7 @@ _LT_COMPILER_BOILERPLATE
+ _LT_LINKER_BOILERPLATE
+ 
+ # Allow CC to be a program name with arguments.
+-lt_save_CC="$CC"
++lt_save_CC=$CC
+ lt_save_CFLAGS=$CFLAGS
+ lt_save_GCC=$GCC
+ GCC=
+@@ -7627,7 +8148,7 @@ AC_DEFUN([LT_PROG_GCJ],
+ [m4_ifdef([AC_PROG_GCJ], [AC_PROG_GCJ],
+   [m4_ifdef([A][M_PROG_GCJ], [A][M_PROG_GCJ],
+     [AC_CHECK_TOOL(GCJ, gcj,)
+-      test "x${GCJFLAGS+set}" = xset || GCJFLAGS="-g -O2"
++      test set = "${GCJFLAGS+set}" || GCJFLAGS="-g -O2"
+       AC_SUBST(GCJFLAGS)])])[]dnl
+ ])
+ 
+@@ -7738,7 +8259,7 @@ lt_ac_count=0
+ # Add /usr/xpg4/bin/sed as it is typically found on Solaris
+ # along with /bin/sed that truncates output.
+ for lt_ac_sed in $lt_ac_sed_list /usr/xpg4/bin/sed; do
+-  test ! -f $lt_ac_sed && continue
++  test ! -f "$lt_ac_sed" && continue
+   cat /dev/null > conftest.in
+   lt_ac_count=0
+   echo $ECHO_N "0123456789$ECHO_C" >conftest.in
+@@ -7755,9 +8276,9 @@ for lt_ac_sed in $lt_ac_sed_list /usr/xpg4/bin/sed; do
+     $lt_ac_sed -e 's/a$//' < conftest.nl >conftest.out || break
+     cmp -s conftest.out conftest.nl || break
+     # 10000 chars as input seems more than enough
+-    test $lt_ac_count -gt 10 && break
++    test 10 -lt "$lt_ac_count" && break
+     lt_ac_count=`expr $lt_ac_count + 1`
+-    if test $lt_ac_count -gt $lt_ac_max; then
++    if test "$lt_ac_count" -gt "$lt_ac_max"; then
+       lt_ac_max=$lt_ac_count
+       lt_cv_path_SED=$lt_ac_sed
+     fi
+@@ -7781,27 +8302,7 @@ dnl AC_DEFUN([LT_AC_PROG_SED], [])
+ # Find out whether the shell is Bourne or XSI compatible,
+ # or has some other useful features.
+ m4_defun([_LT_CHECK_SHELL_FEATURES],
+-[AC_MSG_CHECKING([whether the shell understands some XSI constructs])
+-# Try some XSI features
+-xsi_shell=no
+-( _lt_dummy="a/b/c"
+-  test "${_lt_dummy##*/},${_lt_dummy%/*},${_lt_dummy#??}"${_lt_dummy%"$_lt_dummy"}, \
+-      = c,a/b,b/c, \
+-    && eval 'test $(( 1 + 1 )) -eq 2 \
+-    && test "${#_lt_dummy}" -eq 5' ) >/dev/null 2>&1 \
+-  && xsi_shell=yes
+-AC_MSG_RESULT([$xsi_shell])
+-_LT_CONFIG_LIBTOOL_INIT([xsi_shell='$xsi_shell'])
+-
+-AC_MSG_CHECKING([whether the shell understands "+="])
+-lt_shell_append=no
+-( foo=bar; set foo baz; eval "$[1]+=\$[2]" && test "$foo" = barbaz ) \
+-    >/dev/null 2>&1 \
+-  && lt_shell_append=yes
+-AC_MSG_RESULT([$lt_shell_append])
+-_LT_CONFIG_LIBTOOL_INIT([lt_shell_append='$lt_shell_append'])
+-
+-if ( (MAIL=60; unset MAIL) || exit) >/dev/null 2>&1; then
++[if ( (MAIL=60; unset MAIL) || exit) >/dev/null 2>&1; then
+   lt_unset=unset
+ else
+   lt_unset=false
+@@ -7825,102 +8326,9 @@ _LT_DECL([NL2SP], [lt_NL2SP], [1], [turn newlines into spaces])dnl
+ ])# _LT_CHECK_SHELL_FEATURES
+ 
+ 
+-# _LT_PROG_FUNCTION_REPLACE (FUNCNAME, REPLACEMENT-BODY)
+-# ------------------------------------------------------
+-# In `$cfgfile', look for function FUNCNAME delimited by `^FUNCNAME ()$' and
+-# '^} FUNCNAME ', and replace its body with REPLACEMENT-BODY.
+-m4_defun([_LT_PROG_FUNCTION_REPLACE],
+-[dnl {
+-sed -e '/^$1 ()$/,/^} # $1 /c\
+-$1 ()\
+-{\
+-m4_bpatsubsts([$2], [$], [\\], [^\([	 ]\)], [\\\1])
+-} # Extended-shell $1 implementation' "$cfgfile" > $cfgfile.tmp \
+-  && mv -f "$cfgfile.tmp" "$cfgfile" \
+-    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-test 0 -eq $? || _lt_function_replace_fail=:
+-])
+-
+-
+-# _LT_PROG_REPLACE_SHELLFNS
+-# -------------------------
+-# Replace existing portable implementations of several shell functions with
+-# equivalent extended shell implementations where those features are available..
+-m4_defun([_LT_PROG_REPLACE_SHELLFNS],
+-[if test x"$xsi_shell" = xyes; then
+-  _LT_PROG_FUNCTION_REPLACE([func_dirname], [dnl
+-    case ${1} in
+-      */*) func_dirname_result="${1%/*}${2}" ;;
+-      *  ) func_dirname_result="${3}" ;;
+-    esac])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_basename], [dnl
+-    func_basename_result="${1##*/}"])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_dirname_and_basename], [dnl
+-    case ${1} in
+-      */*) func_dirname_result="${1%/*}${2}" ;;
+-      *  ) func_dirname_result="${3}" ;;
+-    esac
+-    func_basename_result="${1##*/}"])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_stripname], [dnl
+-    # pdksh 5.2.14 does not do ${X%$Y} correctly if both X and Y are
+-    # positional parameters, so assign one to ordinary parameter first.
+-    func_stripname_result=${3}
+-    func_stripname_result=${func_stripname_result#"${1}"}
+-    func_stripname_result=${func_stripname_result%"${2}"}])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_split_long_opt], [dnl
+-    func_split_long_opt_name=${1%%=*}
+-    func_split_long_opt_arg=${1#*=}])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_split_short_opt], [dnl
+-    func_split_short_opt_arg=${1#??}
+-    func_split_short_opt_name=${1%"$func_split_short_opt_arg"}])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_lo2o], [dnl
+-    case ${1} in
+-      *.lo) func_lo2o_result=${1%.lo}.${objext} ;;
+-      *)    func_lo2o_result=${1} ;;
+-    esac])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_xform], [    func_xform_result=${1%.*}.lo])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_arith], [    func_arith_result=$(( $[*] ))])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_len], [    func_len_result=${#1}])
+-fi
+-
+-if test x"$lt_shell_append" = xyes; then
+-  _LT_PROG_FUNCTION_REPLACE([func_append], [    eval "${1}+=\\${2}"])
+-
+-  _LT_PROG_FUNCTION_REPLACE([func_append_quoted], [dnl
+-    func_quote_for_eval "${2}"
+-dnl m4 expansion turns \\\\ into \\, and then the shell eval turns that into \
+-    eval "${1}+=\\\\ \\$func_quote_for_eval_result"])
+-
+-  # Save a `func_append' function call where possible by direct use of '+='
+-  sed -e 's%func_append \([[a-zA-Z_]]\{1,\}\) "%\1+="%g' $cfgfile > $cfgfile.tmp \
+-    && mv -f "$cfgfile.tmp" "$cfgfile" \
+-      || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-  test 0 -eq $? || _lt_function_replace_fail=:
+-else
+-  # Save a `func_append' function call even when '+=' is not available
+-  sed -e 's%func_append \([[a-zA-Z_]]\{1,\}\) "%\1="$\1%g' $cfgfile > $cfgfile.tmp \
+-    && mv -f "$cfgfile.tmp" "$cfgfile" \
+-      || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
+-  test 0 -eq $? || _lt_function_replace_fail=:
+-fi
+-
+-if test x"$_lt_function_replace_fail" = x":"; then
+-  AC_MSG_WARN([Unable to substitute extended shell functions in $ofile])
+-fi
+-])
+-
+ # _LT_PATH_CONVERSION_FUNCTIONS
+ # -----------------------------
+-# Determine which file name conversion functions should be used by
++# Determine what file name conversion functions should be used by
+ # func_to_host_file (and, implicitly, by func_to_host_path).  These are needed
+ # for certain cross-compile configurations and native mingw.
+ m4_defun([_LT_PATH_CONVERSION_FUNCTIONS],
+diff --git a/m4/ltoptions.m4 b/m4/ltoptions.m4
+index 5d9acd8..b34dd2f 100644
+--- a/m4/ltoptions.m4
++++ b/m4/ltoptions.m4
+@@ -1,14 +1,14 @@
+ # Helper functions for option handling.                    -*- Autoconf -*-
+ #
+-#   Copyright (C) 2004, 2005, 2007, 2008, 2009 Free Software Foundation,
+-#   Inc.
++#   Copyright (C) 2004-2005, 2007-2009, 2011-2016 Free Software
++#   Foundation, Inc.
+ #   Written by Gary V. Vaughan, 2004
+ #
+ # This file is free software; the Free Software Foundation gives
+ # unlimited permission to copy and/or distribute it, with or without
+ # modifications, as long as this notice is preserved.
+ 
+-# serial 7 ltoptions.m4
++# serial 8 ltoptions.m4
+ 
+ # This is to help aclocal find these macros, as it can't see m4_define.
+ AC_DEFUN([LTOPTIONS_VERSION], [m4_if([1])])
+@@ -29,7 +29,7 @@ m4_define([_LT_SET_OPTION],
+ [m4_define(_LT_MANGLE_OPTION([$1], [$2]))dnl
+ m4_ifdef(_LT_MANGLE_DEFUN([$1], [$2]),
+         _LT_MANGLE_DEFUN([$1], [$2]),
+-    [m4_warning([Unknown $1 option `$2'])])[]dnl
++    [m4_warning([Unknown $1 option '$2'])])[]dnl
+ ])
+ 
+ 
+@@ -75,13 +75,15 @@ m4_if([$1],[LT_INIT],[
+   dnl
+   dnl If no reference was made to various pairs of opposing options, then
+   dnl we run the default mode handler for the pair.  For example, if neither
+-  dnl `shared' nor `disable-shared' was passed, we enable building of shared
++  dnl 'shared' nor 'disable-shared' was passed, we enable building of shared
+   dnl archives by default:
+   _LT_UNLESS_OPTIONS([LT_INIT], [shared disable-shared], [_LT_ENABLE_SHARED])
+   _LT_UNLESS_OPTIONS([LT_INIT], [static disable-static], [_LT_ENABLE_STATIC])
+   _LT_UNLESS_OPTIONS([LT_INIT], [pic-only no-pic], [_LT_WITH_PIC])
+   _LT_UNLESS_OPTIONS([LT_INIT], [fast-install disable-fast-install],
+-  		   [_LT_ENABLE_FAST_INSTALL])
++		   [_LT_ENABLE_FAST_INSTALL])
++  _LT_UNLESS_OPTIONS([LT_INIT], [aix-soname=aix aix-soname=both aix-soname=svr4],
++		   [_LT_WITH_AIX_SONAME([aix])])
+   ])
+ ])# _LT_SET_OPTIONS
+ 
+@@ -112,7 +114,7 @@ AU_DEFUN([AC_LIBTOOL_DLOPEN],
+ [_LT_SET_OPTION([LT_INIT], [dlopen])
+ AC_DIAGNOSE([obsolete],
+ [$0: Remove this warning and the call to _LT_SET_OPTION when you
+-put the `dlopen' option into LT_INIT's first parameter.])
++put the 'dlopen' option into LT_INIT's first parameter.])
+ ])
+ 
+ dnl aclocal-1.4 backwards compatibility:
+@@ -148,7 +150,7 @@ AU_DEFUN([AC_LIBTOOL_WIN32_DLL],
+ _LT_SET_OPTION([LT_INIT], [win32-dll])
+ AC_DIAGNOSE([obsolete],
+ [$0: Remove this warning and the call to _LT_SET_OPTION when you
+-put the `win32-dll' option into LT_INIT's first parameter.])
++put the 'win32-dll' option into LT_INIT's first parameter.])
+ ])
+ 
+ dnl aclocal-1.4 backwards compatibility:
+@@ -157,9 +159,9 @@ dnl AC_DEFUN([AC_LIBTOOL_WIN32_DLL], [])
+ 
+ # _LT_ENABLE_SHARED([DEFAULT])
+ # ----------------------------
+-# implement the --enable-shared flag, and supports the `shared' and
+-# `disable-shared' LT_INIT options.
+-# DEFAULT is either `yes' or `no'.  If omitted, it defaults to `yes'.
++# implement the --enable-shared flag, and supports the 'shared' and
++# 'disable-shared' LT_INIT options.
++# DEFAULT is either 'yes' or 'no'.  If omitted, it defaults to 'yes'.
+ m4_define([_LT_ENABLE_SHARED],
+ [m4_define([_LT_ENABLE_SHARED_DEFAULT], [m4_if($1, no, no, yes)])dnl
+ AC_ARG_ENABLE([shared],
+@@ -172,14 +174,14 @@ AC_ARG_ENABLE([shared],
+     *)
+       enable_shared=no
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for pkg in $enableval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$pkg" = "X$p"; then
+ 	  enable_shared=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac],
+     [enable_shared=]_LT_ENABLE_SHARED_DEFAULT)
+@@ -211,9 +213,9 @@ dnl AC_DEFUN([AM_DISABLE_SHARED], [])
+ 
+ # _LT_ENABLE_STATIC([DEFAULT])
+ # ----------------------------
+-# implement the --enable-static flag, and support the `static' and
+-# `disable-static' LT_INIT options.
+-# DEFAULT is either `yes' or `no'.  If omitted, it defaults to `yes'.
++# implement the --enable-static flag, and support the 'static' and
++# 'disable-static' LT_INIT options.
++# DEFAULT is either 'yes' or 'no'.  If omitted, it defaults to 'yes'.
+ m4_define([_LT_ENABLE_STATIC],
+ [m4_define([_LT_ENABLE_STATIC_DEFAULT], [m4_if($1, no, no, yes)])dnl
+ AC_ARG_ENABLE([static],
+@@ -226,14 +228,14 @@ AC_ARG_ENABLE([static],
+     *)
+      enable_static=no
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for pkg in $enableval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$pkg" = "X$p"; then
+ 	  enable_static=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac],
+     [enable_static=]_LT_ENABLE_STATIC_DEFAULT)
+@@ -265,9 +267,9 @@ dnl AC_DEFUN([AM_DISABLE_STATIC], [])
+ 
+ # _LT_ENABLE_FAST_INSTALL([DEFAULT])
+ # ----------------------------------
+-# implement the --enable-fast-install flag, and support the `fast-install'
+-# and `disable-fast-install' LT_INIT options.
+-# DEFAULT is either `yes' or `no'.  If omitted, it defaults to `yes'.
++# implement the --enable-fast-install flag, and support the 'fast-install'
++# and 'disable-fast-install' LT_INIT options.
++# DEFAULT is either 'yes' or 'no'.  If omitted, it defaults to 'yes'.
+ m4_define([_LT_ENABLE_FAST_INSTALL],
+ [m4_define([_LT_ENABLE_FAST_INSTALL_DEFAULT], [m4_if($1, no, no, yes)])dnl
+ AC_ARG_ENABLE([fast-install],
+@@ -280,14 +282,14 @@ AC_ARG_ENABLE([fast-install],
+     *)
+       enable_fast_install=no
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for pkg in $enableval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$pkg" = "X$p"; then
+ 	  enable_fast_install=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac],
+     [enable_fast_install=]_LT_ENABLE_FAST_INSTALL_DEFAULT)
+@@ -304,14 +306,14 @@ AU_DEFUN([AC_ENABLE_FAST_INSTALL],
+ [_LT_SET_OPTION([LT_INIT], m4_if([$1], [no], [disable-])[fast-install])
+ AC_DIAGNOSE([obsolete],
+ [$0: Remove this warning and the call to _LT_SET_OPTION when you put
+-the `fast-install' option into LT_INIT's first parameter.])
++the 'fast-install' option into LT_INIT's first parameter.])
+ ])
+ 
+ AU_DEFUN([AC_DISABLE_FAST_INSTALL],
+ [_LT_SET_OPTION([LT_INIT], [disable-fast-install])
+ AC_DIAGNOSE([obsolete],
+ [$0: Remove this warning and the call to _LT_SET_OPTION when you put
+-the `disable-fast-install' option into LT_INIT's first parameter.])
++the 'disable-fast-install' option into LT_INIT's first parameter.])
+ ])
+ 
+ dnl aclocal-1.4 backwards compatibility:
+@@ -319,11 +321,64 @@ dnl AC_DEFUN([AC_ENABLE_FAST_INSTALL], [])
+ dnl AC_DEFUN([AM_DISABLE_FAST_INSTALL], [])
+ 
+ 
++# _LT_WITH_AIX_SONAME([DEFAULT])
++# ----------------------------------
++# implement the --with-aix-soname flag, and support the `aix-soname=aix'
++# and `aix-soname=both' and `aix-soname=svr4' LT_INIT options. DEFAULT
++# is either `aix', `both' or `svr4'.  If omitted, it defaults to `aix'.
++m4_define([_LT_WITH_AIX_SONAME],
++[m4_define([_LT_WITH_AIX_SONAME_DEFAULT], [m4_if($1, svr4, svr4, m4_if($1, both, both, aix))])dnl
++shared_archive_member_spec=
++case $host,$enable_shared in
++power*-*-aix[[5-9]]*,yes)
++  AC_MSG_CHECKING([which variant of shared library versioning to provide])
++  AC_ARG_WITH([aix-soname],
++    [AS_HELP_STRING([--with-aix-soname=aix|svr4|both],
++      [shared library versioning (aka "SONAME") variant to provide on AIX, @<:@default=]_LT_WITH_AIX_SONAME_DEFAULT[@:>@.])],
++    [case $withval in
++    aix|svr4|both)
++      ;;
++    *)
++      AC_MSG_ERROR([Unknown argument to --with-aix-soname])
++      ;;
++    esac
++    lt_cv_with_aix_soname=$with_aix_soname],
++    [AC_CACHE_VAL([lt_cv_with_aix_soname],
++      [lt_cv_with_aix_soname=]_LT_WITH_AIX_SONAME_DEFAULT)
++    with_aix_soname=$lt_cv_with_aix_soname])
++  AC_MSG_RESULT([$with_aix_soname])
++  if test aix != "$with_aix_soname"; then
++    # For the AIX way of multilib, we name the shared archive member
++    # based on the bitwidth used, traditionally 'shr.o' or 'shr_64.o',
++    # and 'shr.imp' or 'shr_64.imp', respectively, for the Import File.
++    # Even when GNU compilers ignore OBJECT_MODE but need '-maix64' flag,
++    # the AIX toolchain works better with OBJECT_MODE set (default 32).
++    if test 64 = "${OBJECT_MODE-32}"; then
++      shared_archive_member_spec=shr_64
++    else
++      shared_archive_member_spec=shr
++    fi
++  fi
++  ;;
++*)
++  with_aix_soname=aix
++  ;;
++esac
++
++_LT_DECL([], [shared_archive_member_spec], [0],
++    [Shared archive member basename, for filename based shared library versioning on AIX])dnl
++])# _LT_WITH_AIX_SONAME
++
++LT_OPTION_DEFINE([LT_INIT], [aix-soname=aix], [_LT_WITH_AIX_SONAME([aix])])
++LT_OPTION_DEFINE([LT_INIT], [aix-soname=both], [_LT_WITH_AIX_SONAME([both])])
++LT_OPTION_DEFINE([LT_INIT], [aix-soname=svr4], [_LT_WITH_AIX_SONAME([svr4])])
++
++
+ # _LT_WITH_PIC([MODE])
+ # --------------------
+-# implement the --with-pic flag, and support the `pic-only' and `no-pic'
++# implement the --with-pic flag, and support the 'pic-only' and 'no-pic'
+ # LT_INIT options.
+-# MODE is either `yes' or `no'.  If omitted, it defaults to `both'.
++# MODE is either 'yes' or 'no'.  If omitted, it defaults to 'both'.
+ m4_define([_LT_WITH_PIC],
+ [AC_ARG_WITH([pic],
+     [AS_HELP_STRING([--with-pic@<:@=PKGS@:>@],
+@@ -334,19 +389,17 @@ m4_define([_LT_WITH_PIC],
+     *)
+       pic_mode=default
+       # Look at the argument we got.  We use all the common list separators.
+-      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      lt_save_ifs=$IFS; IFS=$IFS$PATH_SEPARATOR,
+       for lt_pkg in $withval; do
+-	IFS="$lt_save_ifs"
++	IFS=$lt_save_ifs
+ 	if test "X$lt_pkg" = "X$lt_p"; then
+ 	  pic_mode=yes
+ 	fi
+       done
+-      IFS="$lt_save_ifs"
++      IFS=$lt_save_ifs
+       ;;
+     esac],
+-    [pic_mode=default])
+-
+-test -z "$pic_mode" && pic_mode=m4_default([$1], [default])
++    [pic_mode=m4_default([$1], [default])])
+ 
+ _LT_DECL([], [pic_mode], [0], [What type of objects to build])dnl
+ ])# _LT_WITH_PIC
+@@ -359,7 +412,7 @@ AU_DEFUN([AC_LIBTOOL_PICMODE],
+ [_LT_SET_OPTION([LT_INIT], [pic-only])
+ AC_DIAGNOSE([obsolete],
+ [$0: Remove this warning and the call to _LT_SET_OPTION when you
+-put the `pic-only' option into LT_INIT's first parameter.])
++put the 'pic-only' option into LT_INIT's first parameter.])
+ ])
+ 
+ dnl aclocal-1.4 backwards compatibility:
+diff --git a/m4/ltsugar.m4 b/m4/ltsugar.m4
+index 9000a05..bbd6faf 100644
+--- a/m4/ltsugar.m4
++++ b/m4/ltsugar.m4
+@@ -1,6 +1,7 @@
+ # ltsugar.m4 -- libtool m4 base layer.                         -*-Autoconf-*-
+ #
+-# Copyright (C) 2004, 2005, 2007, 2008 Free Software Foundation, Inc.
++# Copyright (C) 2004-2005, 2007-2008, 2011-2016 Free Software
++# Foundation, Inc.
+ # Written by Gary V. Vaughan, 2004
+ #
+ # This file is free software; the Free Software Foundation gives
+@@ -33,7 +34,7 @@ m4_define([_lt_join],
+ # ------------
+ # Manipulate m4 lists.
+ # These macros are necessary as long as will still need to support
+-# Autoconf-2.59 which quotes differently.
++# Autoconf-2.59, which quotes differently.
+ m4_define([lt_car], [[$1]])
+ m4_define([lt_cdr],
+ [m4_if([$#], 0, [m4_fatal([$0: cannot be called without arguments])],
+@@ -44,7 +45,7 @@ m4_define([lt_unquote], $1)
+ 
+ # lt_append(MACRO-NAME, STRING, [SEPARATOR])
+ # ------------------------------------------
+-# Redefine MACRO-NAME to hold its former content plus `SEPARATOR'`STRING'.
++# Redefine MACRO-NAME to hold its former content plus 'SEPARATOR''STRING'.
+ # Note that neither SEPARATOR nor STRING are expanded; they are appended
+ # to MACRO-NAME as is (leaving the expansion for when MACRO-NAME is invoked).
+ # No SEPARATOR is output if MACRO-NAME was previously undefined (different
+diff --git a/m4/ltversion.m4 b/m4/ltversion.m4
+index 07a8602..2cad8ec 100644
+--- a/m4/ltversion.m4
++++ b/m4/ltversion.m4
+@@ -1,6 +1,6 @@
+ # ltversion.m4 -- version numbers			-*- Autoconf -*-
+ #
+-#   Copyright (C) 2004 Free Software Foundation, Inc.
++#   Copyright (C) 2004, 2011-2016 Free Software Foundation, Inc.
+ #   Written by Scott James Remnant, 2004
+ #
+ # This file is free software; the Free Software Foundation gives
+@@ -9,15 +9,15 @@
+ 
+ # @configure_input@
+ 
+-# serial 3337 ltversion.m4
++# serial 4213 ltversion.m4
+ # This file is part of GNU Libtool
+ 
+-m4_define([LT_PACKAGE_VERSION], [2.4.2])
+-m4_define([LT_PACKAGE_REVISION], [1.3337])
++m4_define([LT_PACKAGE_VERSION], [2.4.6.34-08c5])
++m4_define([LT_PACKAGE_REVISION], [2.4.6.34])
+ 
+ AC_DEFUN([LTVERSION_VERSION],
+-[macro_version='2.4.2'
+-macro_revision='1.3337'
++[macro_version='2.4.6.34-08c5'
++macro_revision='2.4.6.34'
+ _LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
+ _LT_DECL(, macro_revision, 0)
+ ])
+diff --git a/m4/lt~obsolete.m4 b/m4/lt~obsolete.m4
+index c573da9..6eb9dbc 100644
+--- a/m4/lt~obsolete.m4
++++ b/m4/lt~obsolete.m4
+@@ -1,6 +1,7 @@
+ # lt~obsolete.m4 -- aclocal satisfying obsolete definitions.    -*-Autoconf-*-
+ #
+-#   Copyright (C) 2004, 2005, 2007, 2009 Free Software Foundation, Inc.
++#   Copyright (C) 2004-2005, 2007, 2009, 2011-2016 Free Software
++#   Foundation, Inc.
+ #   Written by Scott James Remnant, 2004.
+ #
+ # This file is free software; the Free Software Foundation gives
+@@ -11,7 +12,7 @@
+ 
+ # These exist entirely to fool aclocal when bootstrapping libtool.
+ #
+-# In the past libtool.m4 has provided macros via AC_DEFUN (or AU_DEFUN)
++# In the past libtool.m4 has provided macros via AC_DEFUN (or AU_DEFUN),
+ # which have later been changed to m4_define as they aren't part of the
+ # exported API, or moved to Autoconf or Automake where they belong.
+ #
+@@ -25,7 +26,7 @@
+ # included after everything else.  This provides aclocal with the
+ # AC_DEFUNs it wants, but when m4 processes it, it doesn't do anything
+ # because those macros already exist, or will be overwritten later.
+-# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6. 
++# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6.
+ #
+ # Anytime we withdraw an AC_DEFUN or AU_DEFUN, remember to add it here.
+ # Yes, that means every name once taken will need to remain here until
+diff --git a/man/Makefile.in b/man/Makefile.in
+index d92af74..c2195d0 100644
+--- a/man/Makefile.in
++++ b/man/Makefile.in
+@@ -205,6 +205,7 @@ LIBTOOL = @LIBTOOL@
+ LIPO = @LIPO@
+ LN_S = @LN_S@
+ LTLIBOBJS = @LTLIBOBJS@
++LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
+ MAINT = @MAINT@
+ MAKEINFO = @MAKEINFO@
+ MANIFEST_TOOL = @MANIFEST_TOOL@
+diff --git a/testsuite/Makefile.in b/testsuite/Makefile.in
+index 99e226c..253b3be 100644
+--- a/testsuite/Makefile.in
++++ b/testsuite/Makefile.in
+@@ -178,6 +178,7 @@ LIBTOOL = @LIBTOOL@
+ LIPO = @LIPO@
+ LN_S = @LN_S@
+ LTLIBOBJS = @LTLIBOBJS@
++LT_SYS_LIBRARY_PATH = @LT_SYS_LIBRARY_PATH@
+ MAINT = @MAINT@
+ MAKEINFO = @MAKEINFO@
+ MANIFEST_TOOL = @MANIFEST_TOOL@
+-- 
+2.8.2
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,9 @@
+copy "%RECIPE_DIR%\build.sh" .
+set PREFIX=%PREFIX:\=/%
+set SRC_DIR=%SRC_DIR:\=/%
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
+bash -lc "./build.sh"
+if errorlevel 1 exit 1
+exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,11 +5,20 @@ if [[ $(uname) == "Linux" ]]; then
   sed -i 's:@toolexeclibdir@:$(libdir):g' Makefile.in */Makefile.in
   sed -i 's:@toolexeclibdir@:${libdir}:g' libffi.pc.in
 fi
-
-./configure --disable-debug --disable-dependency-tracking \
-            --prefix="${PREFIX}" --includedir="${PREFIX}/include" \
-  || { cat config.log; exit 1;}
-
+if [[ $(uname -o) == "Msys" ]]; then
+  ./configure --prefix="${PREFIX}" --includedir="${PREFIX}/include" \
+              --disable-debug --disable-dependency-tracking \
+              CC="${PWD}/msvcc.sh -m${ARCH}" \
+              CXX="${PWD}/msvcc.sh -m${ARCH}" \
+              LD=link \
+              CXXCPP="cl -nologo -EP" \
+              CPP="cl -nologo -EP" \
+              --build=x86_64-w64-mingw32 \
+              --enable-static --disable-shared
+else
+  ./configure --disable-debug --disable-dependency-tracking \
+              --prefix="${PREFIX}" --includedir="${PREFIX}/include" \
+fi
 make
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set name = "libffi" %}
 {% set version = "3.2.1" %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
 
 package:
   name: {{ name|lower }}
@@ -11,16 +13,22 @@ source:
   sha1: 280c265b789e041c02e5c97815793dfc283fb1e6
   patches:
     - configure_includedir_option.patch
+    - 0002-Don-t-define-FFI_COMPLEX_TYPEDEF-ifndef-FFI_TARGET_H.patch  # [win]
+    - 0003-Win64-remove-two-SHORT-annotations.patch                    # [win]
+    - 0004-Update-to-libtool-2.4.6.34.patch                            # [win]
+#    - 9999-Hack-verbose-libtool.patch                                 # [win]
 
 build:
   number: 3
-  skip: True  # [win]
 
 requirements:
   build:
-    - autoconf
-    - automake
-    - libtool
+    - posix                     # [win]
+    - {{posix}}automake-wrapper # [win]
+    - {{native}}toolchain       # [win]
+    - {{posix}}automake         # [not win]
+    - {{posix}}autoconf
+    - {{posix}}libtool
 
 test:
   commands:

--- a/recipe/notes.md
+++ b/recipe/notes.md
@@ -1,0 +1,32 @@
+# To regenerate 0004-Update-to-libtool-2.4.6.34.patch
+# .. first fix libtool so that static libraries have
+#    a lib prefix, then run:
+[[ -d /tmp/0004-regen ]] && rm -rf /tmp/0004-regen
+mkdir /tmp/0004-regen
+pushd /tmp/0004-regen
+  git clone /f/upstreams/libtool
+  pushd libtool
+    AUTOMAKE=/usr/bin/automake-1.13 ACLOCAL=/usr/bin/aclocal-1.13 ./bootstrap
+    ./configure --prefix=/tmp/test/libtool-install
+    make && make install
+  popd
+  wget -c ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz
+  tar -xf libffi-3.2.1.tar.gz
+  git clone -b v3.2.1 --single-branch /f/upstreams/libffi
+  cp -f libffi-3.2.1/{aclocal.m4,compile,config.guess,config.sub,configure,depcomp,fficonfig.h.in,install-sh,ltmain.sh,Makefile.in,mdate-sh,missing} libffi/
+  cp -f libffi-3.2.1/m4/{libtool.m4,lt~obsolete.m4,ltoptions.m4,ltsugar.m4,ltversion.m4} libffi/m4/
+  cp -f libffi-3.2.1/include/Makefile.in libffi/include/
+  cp -f libffi-3.2.1/man/Makefile.in libffi/man/
+  cp -f libffi-3.2.1/testsuite/Makefile.in libffi/testsuite/
+  pushd libffi
+    git add --force -A
+    git commit -a -m "Libtool 2.4.2 files from libffi-3.2.1.tar.gz"
+    AUTOMAKE=/usr/bin/automake-1.13 ACLOCAL=/usr/bin/aclocal-1.13 PATH=/tmp/test/libtool-install/bin:$PATH ./autogen.sh
+    rm -rf autom4te.cache fficonfig.h.in~
+    git add --force -A
+    git commit -a -m "Update to libtool 2.4.6.34"
+    git format-patch -4
+    mv 0004-Update-to-libtool-2.4.6.34.patch ~/conda-forge/libffi-feedstock/recipe
+  popd
+popd
+


### PR DESCRIPTION
It is not currently possible to build shared MSVC libraries
using libtool (either the one bundled with libffi 2.4.1 or
the latest from git).

The reason for this is because libtool aliases the name of
import libraries and the name of static libraries for that
toolchain (in this case, both are libffi.lib).

Instead, we need to patch libtool to use defacto standard
on Windows/MSVC of prefixing the static libraries with an
extra 'lib'. This is what Microsoft and also Boost does.

I will work on that when I can. notes.md is a shell script
that regenerates the patch to perform the libtool update
and should be re-run once the libtool work is finished.

For now, we pass --enable-static --disable-shared because
some libraries are better than none, right?
