### PR TITLE
Fix includes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,8 +5,11 @@ if [[ $(uname) == "Linux" ]]; then
   sed -i 's:@toolexeclibdir@:$(libdir):g' Makefile.in */Makefile.in
   sed -i 's:@toolexeclibdir@:${libdir}:g' libffi.pc.in
 fi
-./configure --disable-debug --disable-dependency-tracking --prefix="${PREFIX}" \
+
+./configure --disable-debug --disable-dependency-tracking \
+            --prefix="${PREFIX}" --includedir="${PREFIX}/include" \
   || { cat config.log; exit 1;}
+
 make
 make check
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,5 +10,3 @@ fi
 make
 make check
 make install
-
-mv ${PREFIX}/lib/*/include/* ${PREFIX}/include

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,3 +10,5 @@ fi
 make
 make check
 make install
+
+mv ${PREFIX}/lib/*/include/* ${PREFIX}/include

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,8 @@ if [[ $(uname) == "Linux" ]]; then
   sed -i 's:@toolexeclibdir@:$(libdir):g' Makefile.in */Makefile.in
   sed -i 's:@toolexeclibdir@:${libdir}:g' libffi.pc.in
 fi
-./configure --disable-debug --disable-dependency-tracking --prefix="${PREFIX}" \
+./configure --disable-debug --disable-dependency-tracking \
+  --prefix="${PREFIX}" --includedir="${PREFIX}/include" \
   || { cat config.log; exit 1;}
 make
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,8 +5,7 @@ if [[ $(uname) == "Linux" ]]; then
   sed -i 's:@toolexeclibdir@:$(libdir):g' Makefile.in */Makefile.in
   sed -i 's:@toolexeclibdir@:${libdir}:g' libffi.pc.in
 fi
-./configure --disable-debug --disable-dependency-tracking \
-  --prefix="${PREFIX}" --includedir="${PREFIX}/include" \
+./configure --disable-debug --disable-dependency-tracking --prefix="${PREFIX}" \
   || { cat config.log; exit 1;}
 make
 make check

--- a/recipe/configure_includedir_option.patch
+++ b/recipe/configure_includedir_option.patch
@@ -1,0 +1,37 @@
+diff --git a/include/Makefile.am b/include/Makefile.am
+index fd28024..15301d6 100644
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -5,5 +5,5 @@ AUTOMAKE_OPTIONS=foreign
+ DISTCLEANFILES=ffitarget.h
+ EXTRA_DIST=ffi.h.in ffi_common.h
+ 
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+diff --git a/include/Makefile.in b/include/Makefile.in
+index 9d747e8..f8f4af0 100644
+--- a/include/Makefile.in
++++ b/include/Makefile.in
+@@ -314,7 +314,7 @@ top_srcdir = @top_srcdir@
+ AUTOMAKE_OPTIONS = foreign
+ DISTCLEANFILES = ffitarget.h
+ EXTRA_DIST = ffi.h.in ffi_common.h
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+ all: all-am
+ 
+diff --git a/libffi.pc.in b/libffi.pc.in
+index edf6fde..e3a0312 100644
+--- a/libffi.pc.in
++++ b/libffi.pc.in
+@@ -2,7 +2,7 @@ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ toolexeclibdir=@toolexeclibdir@
+-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includedir=${libdir}/include
+ 
+ Name: @PACKAGE_NAME@
+ Description: Library supporting Foreign Function Interfaces

--- a/recipe/configure_includedir_option.patch
+++ b/recipe/configure_includedir_option.patch
@@ -23,7 +23,7 @@ index 9d747e8..f8f4af0 100644
  all: all-am
  
 diff --git a/libffi.pc.in b/libffi.pc.in
-index edf6fde..e3a0312 100644
+index edf6fde..0b58ac2 100644
 --- a/libffi.pc.in
 +++ b/libffi.pc.in
 @@ -2,7 +2,7 @@ prefix=@prefix@
@@ -31,7 +31,7 @@ index edf6fde..e3a0312 100644
  libdir=@libdir@
  toolexeclibdir=@toolexeclibdir@
 -includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
-+includedir=${libdir}/include
++includedir=@exec_prefix@/include
  
  Name: @PACKAGE_NAME@
  Description: Library supporting Foreign Function Interfaces

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - configure_includedir_option.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ test:
     - test -e $PREFIX/lib/libffi.so  # [linux]
     - test -e $PREFIX/lib/libffi.a  # [osx]
     - test -e $PREFIX/lib/libffi.dylib  # [osx]
+    - test -e $PREFIX/include/ffi.h
+    - test -e $PREFIX/include/ffitarget.h
 
 about:
   home: https://sourceware.org/libffi/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
+{% set name = "libffi" %}
 {% set version = "3.2.1" %}
 
 package:
-  name: libffi
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: libffi-3.2.1.tar.gz
-  url: ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: ftp://sourceware.org/pub/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha1: 280c265b789e041c02e5c97815793dfc283fb1e6
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 test:
   commands:
     - test -e $PREFIX/lib/libffi.so  # [linux]
-    - test -e $PREFIX/lib/libffi.a  # [osx]
+    - test -e $PREFIX/lib/libffi.a  # [unix]
     - test -e $PREFIX/lib/libffi.dylib  # [osx]
     - test -e $PREFIX/include/ffi.h
     - test -e $PREFIX/include/ffitarget.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: ftp://sourceware.org/pub/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha1: 280c265b789e041c02e5c97815793dfc283fb1e6
+  patches:
+    - configure_includedir_option.patch
 
 build:
   number: 2


### PR DESCRIPTION
Include files are being installed one level below of where conda expects them, `<PREFIX>/lib/libffi-<version>/include`. This PR, first, attempts to fix the correct path by passing --includedir option to configure, which doesn't seem to work, and then by manually moving contents of `include` directory into `<PREFIX>/lib/include`.