### PR TITLE
Fix the Windows package: provide a static library, not a DLL.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,17 +23,37 @@ configure_args=(
 # Windows fun
 
 if [[ $(uname -o) == "Msys" ]] ; then
-    am_version=1.15 # keep sync'ed with meta.yaml
+    # Many many many autotools bits hardcode Windows checks that fail when the
+    # OS is our default, "msys2", rather than something starting with cygwin
+    # or mingw.
+    export BUILD=x86_64-pc-mingw64
+    export HOST=x86_64-pc-mingw64
+
+    # Needed for autoreconf to work - keep version sync'ed with meta.yaml.
+    am_version=1.15
     export ACLOCAL=aclocal-$am_version
     export AUTOMAKE=automake-$am_version
 
+    # Special compiler wrappers. Modern autotools do OK when working with "cl"
+    # directly, but we need to preprocess an assembly (.S) file, which libffis
+    # msvcc.sh wrapper takes care of.
     export CC="$(pwd)/msvcc.sh -m64"
     export CXX="$(pwd)/msvcc.sh -m64"
     export LD="link"
     export CPP="cl -nologo -EP"
     export CXXCPP="cl -nologo -EP"
-    export BUILD=x86_64-unknown-cygwin
-    export HOST=x86_64-unknown-cygwin
+
+    # Buuut the funky wrapper breaks shared library compilation for us, I
+    # think. At least, other autotools-based builds *can* get shared libraries
+    # working, but I can't pull it off here.
+    configure_args+=(--disable-shared)
+
+    # Remove the "/GL flag, which causes two problems. First, it messes up
+    # Libtool's identification of how the linker works; it parses dumpbin
+    # output and: https://stackoverflow.com/a/11850034/3760486 . Second, it
+    # seems to break static library creation via "ar cru".
+    export CFLAGS=$(echo " $CFLAGS " |sed -e "s, [-/]GL ,,")
+    export CXXFLAGS=$(echo " $CXXFLAGS " |sed -e "s, [-/]GL ,,")
 fi
 
 configure_args+=(--build=$BUILD --host=$HOST)
@@ -48,24 +68,11 @@ fi
 
 ./configure "${configure_args[@]}" || { cat config.log; exit 1;}
 
-if [[ $(uname -o) == "Msys" ]] ; then
-    # Currently, libtool has trouble building on Windows I think because the
-    # "import library" that goes with the DLL has the same filename as the
-    # static library that libtool would want to generate -- libffi.lib. For
-    # some reason, configuring with --disable-static doesn't avoid the error,
-    # but this hack does.
-    sed -i 's|test.*func_append staticlibs.*|true|' $HOST/libtool
-fi
-
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install
 
-if [[ $(uname -o) == "Msys" ]] ; then
-    mkdir -p $PREFIX/bin
-    mv $PREFIX/lib/libffi-*.dll $PREFIX/bin
-    find $PREFIX/. -name '*.la' -delete
-fi
+find $PREFIX/. -name '*.la' -delete
 
 # This overlaps with libgcc-ng:
 rm -rf ${PREFIX}/share/info/dir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,10 @@ source:
     - 0002-Don-t-define-FFI_COMPLEX_TYPEDEF-ifndef-FFI_TARGET_H.patch  # [win]
     - 0003-Win64-Remove-two-SHORT-annotations.patch                    # [win]
     - 0004-Remove-C99-constructs.patch                                 # [win]
+    - windows-static.patch                                             # [win]
 
 build:
-  number: 4
+  number: 5
   run_exports:
     # good history: https://abi-laboratory.pro/tracker/timeline/libffi/
     - {{ pin_subpackage('libffi') }}
@@ -45,7 +46,6 @@ test:
     - test -e $PREFIX/lib/libffi.a                                 # [not win]
     - test -e $PREFIX/include/ffi.h                                # [not win]
     - test -e $PREFIX/include/ffitarget.h                          # [not win]
-    - if not exist %LIBRARY_PREFIX%/bin/libffi-*.dll exit /b 1     # [win]
     - if not exist %LIBRARY_PREFIX%/lib/libffi.lib exit /b 1       # [win]
     - if not exist %LIBRARY_PREFIX%/include/ffi.h exit /b 1        # [win]
     - if not exist %LIBRARY_PREFIX%/include/ffitarget.h exit /b 1  # [win]

--- a/recipe/windows-static.patch
+++ b/recipe/windows-static.patch
@@ -1,0 +1,13 @@
+diff --git a/include/ffi.h.in b/include/ffi.h.in
+index f403ae0..f56ff31 100644
+--- a/include/ffi.h.in
++++ b/include/ffi.h.in
+@@ -175,7 +175,7 @@ typedef struct _ffi_type
+ /* as a workaround, they can define FFI_BUILDING if they  */
+ /* *know* they are going to link with the static library. */
+ #if defined _MSC_VER && !defined FFI_BUILDING
+-#define FFI_EXTERN extern __declspec(dllimport)
++#define FFI_EXTERN extern /*__declspec(dllimport) conda-forge: static library only*/
+ #else
+ #define FFI_EXTERN extern
+ #endif


### PR DESCRIPTION
Well, it turns out that the attempt to build a libffi DLL didn't work. The libffi source code isn't annotated with __declspec(dllexport) markers, so exporting the correct symbols would be a pain. (The recent libffi 3.3 release candidate should fix this, fortunately.) And the `.lib` file installed by Libtool in the package turned out to be exactly the same file as the DLL, not an import library at all. I attempted to use `LIB /DEF` to generate an import library but it errored on the DLL executable format (message like this: https://stackoverflow.com/q/9657040/3760486), so it seemed wisest just to give up.

The static library wasn't trouble-free. It was necessary to remove the "-GL" flag from the environment, however. The "global link optimization" mode that it enables seems to break the creation of static libraries via "ar cru" -- if you run `nm` on the resulting file, you get "unknown file format" for the object files compiled with that option active. It was also necessary to hack the header to remove __declspec(dllimport) tags that would be adopted by users -- otherwise they would look for symbols named like `__imp_ffi_foo`. Note that this hack is essentially what's recommended in the header itself.

I also switched the build script to remove `.la` files for all platforms, since we're making a point of ditching them.