### PR TITLE
Windows: add ffi.lib

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,3 @@
 call %BUILD_PREFIX%\Library\bin\run_autotools_clang_conda_build.bat
 if %ERRORLEVEL% neq 0 exit 1
+copy %LIBRARY_LIB%\libffi.lib %LIBRARY_LIB%\ffi.lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0002-Don-t-define-FFI_COMPLEX_TYPEDEF-ifndef-FFI_TARGET_H.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # good history: https://abi-laboratory.pro/tracker/timeline/libffi/
     - {{ pin_subpackage('libffi', "x.x") }}
@@ -46,6 +46,7 @@ test:
     - test -e $PREFIX/include/ffitarget.h                          # [not win]
     - if not exist %LIBRARY_PREFIX%/bin/ffi-7.dll exit /b 1        # [win]
     - if not exist %LIBRARY_PREFIX%/lib/libffi.lib exit /b 1       # [win]
+    - if not exist %LIBRARY_PREFIX%/lib/ffi.lib exit /b 1       # [win]
     - if not exist %LIBRARY_PREFIX%/include/ffi.h exit /b 1        # [win]
     - if not exist %LIBRARY_PREFIX%/include/ffitarget.h exit /b 1  # [win]
     - llvm-nm %LIBRARY_PREFIX%/lib/libffi.lib | grep "__imp_ffi_type_void"        # [win]


### PR DESCRIPTION
gobject-introspection expects import libraries without the 'lib' prefix.