### PR TITLE
Workaround for libffi 3.4 + gobject-introspection

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -86,7 +86,7 @@ jobs:
 
     - script: |
         call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,7 @@ configure_args=(
     --disable-dependency-tracking
     --prefix="${PREFIX}"
     --includedir="${PREFIX}/include"
+    --disable-exec-static-tramp
 )
 
 if [[ "$target_platform" != win-* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0002-Don-t-define-FFI_COMPLEX_TYPEDEF-ifndef-FFI_TARGET_H.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # good history: https://abi-laboratory.pro/tracker/timeline/libffi/
     - {{ pin_subpackage('libffi', "x.x") }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

A new feature was introduced in libffi 3.4 and is known to break
some downstream packages, notably ghc and gobject-introspection.
Upstream also added a configure-time option in this release to
disable the feature until all downstream users can be fixed to be
compatible with it, at which point it can be safely re-enabled.

Note that while the symptoms of this issue appear similar to issues seen
with libffi 3.3 on osx-arm64, this specific issue is at least seen on libffi 3.4
on both linux-64 and linux-aarch64.

Fixes: https://github.com/conda-forge/gnuradio-feedstock/issues/84
See also: https://github.com/libffi/libffi/pull/647
See also: https://gitlab.gnome.org/GNOME/pygobject/-/issues/455
See also: https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
